### PR TITLE
feat: Ability to update base currency

### DIFF
--- a/packages/backend/src/common/utils/round-half-to-even.ts
+++ b/packages/backend/src/common/utils/round-half-to-even.ts
@@ -1,0 +1,23 @@
+/**
+ * Banker's rounding (round half to even) - IEEE 754 standard
+ * When a number is exactly halfway between two integers, round to the nearest even number.
+ * This minimizes cumulative bias in financial calculations.
+ *
+ * Examples:
+ * - 0.5 → 0 (even)
+ * - 1.5 → 2 (even)
+ * - 2.5 → 2 (even)
+ * - 3.5 → 4 (even)
+ */
+export function roundHalfToEven(value: number): number {
+  const floor = Math.floor(value);
+  const fraction = value - floor;
+
+  // If not exactly at 0.5, use normal rounding
+  if (fraction !== 0.5) {
+    return Math.round(value);
+  }
+
+  // At exactly 0.5, round to nearest even number
+  return floor % 2 === 0 ? floor : floor + 1;
+}

--- a/packages/backend/src/controllers/accounts.controller.e2e.ts
+++ b/packages/backend/src/controllers/accounts.controller.e2e.ts
@@ -1,4 +1,5 @@
 import { ACCOUNT_TYPES, API_ERROR_CODES } from '@bt/shared/types';
+import { roundHalfToEven } from '@common/utils/round-half-to-even';
 import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
 import * as helpers from '@tests/helpers';
@@ -42,11 +43,11 @@ describe('Accounts controller', () => {
       const currencyRate = (await helpers.getCurrenciesRates({ codes: ['UAH'] }))[0];
 
       expect(account.initialBalance).toStrictEqual(initialBalance);
-      expect(account.refInitialBalance).toStrictEqual(Math.floor(initialBalance * currencyRate!.rate));
+      expect(account.refInitialBalance).toStrictEqual(roundHalfToEven(initialBalance * currencyRate!.rate));
       expect(account.currentBalance).toStrictEqual(initialBalance);
-      expect(account.refCurrentBalance).toStrictEqual(Math.floor(initialBalance * currencyRate!.rate));
+      expect(account.refCurrentBalance).toStrictEqual(roundHalfToEven(initialBalance * currencyRate!.rate));
       expect(account.creditLimit).toStrictEqual(creditLimit);
-      expect(account.refCreditLimit).toStrictEqual(Math.floor(creditLimit * currencyRate!.rate));
+      expect(account.refCreditLimit).toStrictEqual(roundHalfToEven(creditLimit * currencyRate!.rate));
     });
   });
   describe('update account', () => {

--- a/packages/backend/src/controllers/banks/monobank.controller.e2e.ts
+++ b/packages/backend/src/controllers/banks/monobank.controller.e2e.ts
@@ -1,4 +1,5 @@
 import { ACCOUNT_TYPES, API_ERROR_CODES } from '@bt/shared/types';
+import { roundHalfToEven } from '@common/utils/round-half-to-even';
 import { faker } from '@faker-js/faker';
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
@@ -44,11 +45,11 @@ describe('Monobank integration', () => {
         const rate = rates.find((r) => r.baseCode === CURRENCY_NUMBER_TO_CODE[item.currencyCode])!.rate;
 
         expect(resultItem.initialBalance).toBe(mockedAccount.balance);
-        expect(resultItem.refInitialBalance).toBe(Math.floor(mockedAccount.balance * rate));
+        expect(resultItem.refInitialBalance).toBe(roundHalfToEven(mockedAccount.balance * rate));
         expect(resultItem.currentBalance).toBe(mockedAccount.balance);
-        expect(resultItem.refCurrentBalance).toBe(Math.floor(mockedAccount.balance * rate));
+        expect(resultItem.refCurrentBalance).toBe(roundHalfToEven(mockedAccount.balance * rate));
         expect(resultItem.creditLimit).toBe(mockedAccount.creditLimit);
-        expect(resultItem.refCreditLimit).toBe(Math.floor(mockedAccount.creditLimit * rate));
+        expect(resultItem.refCreditLimit).toBe(roundHalfToEven(mockedAccount.creditLimit * rate));
         expect(resultItem.type).toBe(ACCOUNT_TYPES.monobank);
         // By default all Monobank accounts should be disabled so we will load
         // new transactions only to accounts that user choosed

--- a/packages/backend/src/controllers/currencies/change-base-currency.controller.ts
+++ b/packages/backend/src/controllers/currencies/change-base-currency.controller.ts
@@ -1,0 +1,34 @@
+import { currencyCode } from '@common/lib/zod/custom-types';
+import { createController } from '@controllers/helpers/controller-factory';
+import { ValidationError } from '@js/errors';
+import { changeBaseCurrency } from '@root/services/currencies/change-base-currency.service';
+import {
+  FRANKFURTER_SUPPORTED_CURRENCIES,
+  isSupportedByFrankfurter,
+} from '@services/exchange-rates/frankfurter.service';
+import { z } from 'zod';
+
+const schema = z.object({
+  body: z.object({
+    newCurrencyCode: currencyCode(),
+  }),
+});
+
+export default createController(schema, async ({ user, body }) => {
+  // Validate that the currency is supported by Frankfurter
+  if (!isSupportedByFrankfurter(body.newCurrencyCode)) {
+    throw new ValidationError({
+      message: `For now, changing base currency to ${body.newCurrencyCode} is not supported. Only these currencies are supported: ${FRANKFURTER_SUPPORTED_CURRENCIES.join(', ')}.`,
+    });
+  }
+
+  const result = await changeBaseCurrency({
+    userId: user.id,
+    newCurrencyCode: body.newCurrencyCode,
+  });
+
+  return {
+    data: result,
+    statusCode: 200,
+  };
+});

--- a/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
@@ -60,7 +60,7 @@ describe('Create transaction controller', () => {
     expect(baseTx.currencyCode).toBe(currency.code);
     expect(baseTx.currencyCode).toBe(currency.code);
     expect(baseTx.amount).toBe(txPayload.amount);
-    expect(baseTx.refAmount).toBe(Math.floor(txPayload.amount * currencyRate!.rate));
+    expect(baseTx.refAmount).toBe(Math.round(txPayload.amount * currencyRate!.rate));
     expect(baseTx.transactionType).toBe(txPayload.transactionType);
     expect(baseTx.transferNature).toBe(TRANSACTION_TRANSFER_NATURE.not_transfer);
     expect(baseTx).toStrictEqual(transactions![0]);
@@ -222,7 +222,7 @@ describe('Create transaction controller', () => {
     expect(oppositeTx!.accountId).toBe(accountB.id);
 
     // Secondary (`to`) transfer tx always same `refAmount` as the general (`from`) tx to keep it consistent
-    expect(baseTx.refAmount).toBe(Math.floor(baseTx.amount * currencyRate!.rate));
+    expect(baseTx.refAmount).toBe(Math.round(baseTx.amount * currencyRate!.rate));
     expect(oppositeTx!.refAmount).toBe(Math.floor(oppositeTx!.amount * oppositeCurrencyRate!.rate));
 
     expect(baseTx.transferNature).toBe(TRANSACTION_TRANSFER_NATURE.common_transfer);

--- a/packages/backend/src/controllers/transactions.controller/update-transaction.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/update-transaction.e2e.ts
@@ -44,7 +44,7 @@ describe('Update transaction controller', () => {
 
     expect(baseTx.accountId).toStrictEqual(accountUAH.id);
     expect(baseTx.amount).toStrictEqual(createdTransaction.amount);
-    expect(baseTx.refAmount).toStrictEqual(Math.floor(createdTransaction.amount * currencyRate!.rate));
+    expect(baseTx.refAmount).toStrictEqual(Math.round(createdTransaction.amount * currencyRate!.rate));
   });
   it('should create transfer tx for ref + non-ref tx, and change destination non-ref account to another non-ref account', async () => {
     const baseAccount = await helpers.createAccount({ raw: true });

--- a/packages/backend/src/js/errors.ts
+++ b/packages/backend/src/js/errors.ts
@@ -95,7 +95,10 @@ export class ForbiddenError extends CustomError {
 }
 
 export class UnexpectedError extends CustomError {
-  constructor(code: API_ERROR_CODES, message: string) {
+  constructor({
+    code = API_ERROR_CODES.unexpected,
+    message = 'Unexpected error',
+  }: { code?: API_ERROR_CODES; message?: string } = {}) {
     super(ERROR_CODES.UnexpectedError, code, message);
   }
 }

--- a/packages/backend/src/middlewares/check-base-currency-lock.ts
+++ b/packages/backend/src/middlewares/check-base-currency-lock.ts
@@ -1,0 +1,48 @@
+import { API_ERROR_CODES, API_RESPONSE_STATUS } from '@bt/shared/types';
+import { ERROR_CODES } from '@js/errors';
+import Users from '@models/Users.model';
+import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@root/services/currencies/change-base-currency.service';
+import type { NextFunction, Request, Response } from 'express';
+
+/**
+ * Middleware to check if a base currency change operation is in progress for the user.
+ * If a lock exists, it returns a 423 Locked error with a specific error code
+ * so the frontend can handle it appropriately.
+ *
+ * This prevents users from creating/updating accounts, transactions, or investments
+ * while base currency recalculation is happening, ensuring data consistency.
+ */
+export const checkBaseCurrencyLock = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void | Response> => {
+  // Assumes user is already authenticated via authenticateJwt middleware
+  const userId = (req.user as Users)?.id;
+
+  if (!userId) {
+    return res.status(ERROR_CODES.Unauthorized).json({
+      status: API_RESPONSE_STATUS.error,
+      response: {
+        message: 'Authentication required.',
+        code: API_ERROR_CODES.unauthorized,
+      },
+    });
+  }
+
+  // Check if base currency change is in progress for this user
+  const lockExists = await redisClient.get(buildLockKey(userId));
+
+  if (lockExists) {
+    return res.status(ERROR_CODES.Locked).json({
+      status: API_RESPONSE_STATUS.error,
+      response: {
+        message: 'Base currency change is in progress. Please wait until it completes.',
+        code: API_ERROR_CODES.baseCurrencyChangeInProgress,
+      },
+    });
+  }
+
+  return next();
+};

--- a/packages/backend/src/migrations/20251119000000-remove-holdings-value-columns.ts
+++ b/packages/backend/src/migrations/20251119000000-remove-holdings-value-columns.ts
@@ -1,0 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { QueryInterface, DataTypes, Transaction } from 'sequelize';
+
+/**
+ * Migration to remove deprecated value and refValue columns from Holdings table.
+ * These fields were deprecated in favor of dynamic calculation (quantity × latest price).
+ */
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const t: Transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.removeColumn('Holdings', 'value', { transaction: t });
+      await queryInterface.removeColumn('Holdings', 'refValue', { transaction: t });
+
+      await t.commit();
+    } catch (err) {
+      await t.rollback();
+      throw err;
+    }
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    const t: Transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.addColumn(
+        'Holdings',
+        'value',
+        {
+          type: DataTypes.DECIMAL(20, 10),
+          allowNull: false,
+          defaultValue: '0',
+        },
+        { transaction: t },
+      );
+
+      await queryInterface.addColumn(
+        'Holdings',
+        'refValue',
+        {
+          type: DataTypes.DECIMAL(20, 10),
+          allowNull: false,
+          defaultValue: '0',
+        },
+        { transaction: t },
+      );
+
+      await t.commit();
+    } catch (err) {
+      await t.rollback();
+      throw err;
+    }
+  },
+};

--- a/packages/backend/src/models/Transactions.model.ts
+++ b/packages/backend/src/models/Transactions.model.ts
@@ -187,14 +187,13 @@ export default class Transactions extends Model {
   })
   originalId!: string;
 
-  // Stores the original id from external source
+  // Stores the data from external source
   @Column({
     type: DataType.JSONB,
     allowNull: true,
   })
   externalData!: TransactionsAttributes['externalData'];
 
-  // Stores the original id from external source
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
@@ -202,7 +201,6 @@ export default class Transactions extends Model {
   })
   commissionRate!: number;
 
-  // Stores the original id from external source
   @Column({
     type: DataType.INTEGER,
     allowNull: false,
@@ -210,7 +208,6 @@ export default class Transactions extends Model {
   })
   refCommissionRate!: number;
 
-  // Stores the original id from external source
   @Column({
     type: DataType.INTEGER,
     allowNull: false,

--- a/packages/backend/src/models/investments/Holdings.model.ts
+++ b/packages/backend/src/models/investments/Holdings.model.ts
@@ -63,17 +63,6 @@ export default class Holdings extends Model implements HoldingModel {
   securityId!: number;
 
   /**
-   * DEPRECATED: These fields will be removed in favor of dynamic calculation.
-   * Market value should be calculated as quantity × latest price.
-   * Kept temporarily for backward compatibility during migration.
-   */
-  @Column({ type: DataType.DECIMAL(20, 10), allowNull: false, defaultValue: '0' })
-  value!: string;
-
-  @Column({ type: DataType.DECIMAL(20, 10), allowNull: false, defaultValue: '0' })
-  refValue!: string;
-
-  /**
    * The `quantity` field represents the total number of units or shares
    * of the specific security currently held in the investment account. This field is crucial
    * for determining the overall exposure or investment in that particular security. It is used

--- a/packages/backend/src/routes/accounts.route.ts
+++ b/packages/backend/src/routes/accounts.route.ts
@@ -8,6 +8,7 @@ import {
 import convertMonobankToSystem from '@controllers/accounts/convert-monobank-to-system';
 import linkAccountToBankConnection from '@controllers/accounts/link-to-bank-connection';
 import unlinkAccountFromBankConnection from '@controllers/accounts/unlink-from-bunk-connection';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { authenticateJwt } from '@middlewares/passport';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -16,9 +17,9 @@ const router = Router({});
 
 router.get('/', authenticateJwt, validateEndpoint(getAccounts.schema), getAccounts.handler);
 router.get('/:id', authenticateJwt, validateEndpoint(getAccountById.schema), getAccountById.handler);
-router.post('/', authenticateJwt, validateEndpoint(createAccount.schema), createAccount.handler);
-router.put('/:id', authenticateJwt, validateEndpoint(updateAccount.schema), updateAccount.handler);
-router.delete('/:id', authenticateJwt, validateEndpoint(deleteAccount.schema), deleteAccount.handler);
+router.post('/', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(createAccount.schema), createAccount.handler);
+router.put('/:id', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(updateAccount.schema), updateAccount.handler);
+router.delete('/:id', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(deleteAccount.schema), deleteAccount.handler);
 router.post(
   '/:id/unlink',
   authenticateJwt,

--- a/packages/backend/src/routes/investments.route.ts
+++ b/packages/backend/src/routes/investments.route.ts
@@ -24,6 +24,7 @@ import deleteInvestmentTransactionController from '@controllers/investments/tran
 import getTransactionsController from '@controllers/investments/transactions/get-transactions.controller';
 import updateInvestmentTransactionController from '@controllers/investments/transactions/update-tx.controller';
 import { adminOnly } from '@middlewares/admin-only';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { authenticateJwt } from '@middlewares/passport';
 import { priceSyncRateLimit, securitiesPricesBulkUploadRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
@@ -63,6 +64,7 @@ router.get(
 router.put(
   '/portfolios/:id/balance',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(updatePortfolioBalanceController.schema),
   updatePortfolioBalanceController.handler,
 );
@@ -70,6 +72,7 @@ router.put(
 router.post(
   '/portfolios/:id/transfer',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(createPortfolioTransferController.schema),
   createPortfolioTransferController.handler,
 );
@@ -84,6 +87,7 @@ router.get(
 router.put(
   '/portfolios/:id',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(updatePortfolioController.schema),
   updatePortfolioController.handler,
 );
@@ -91,6 +95,7 @@ router.put(
 router.delete(
   '/portfolios/:id',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(deletePortfolioController.schema),
   deletePortfolioController.handler,
 );
@@ -98,6 +103,7 @@ router.delete(
 router.post(
   '/portfolios',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(createPortfolioController.schema),
   createPortfolioController.handler,
 );
@@ -150,12 +156,14 @@ router.get(
 router.post(
   '/holding',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(createHoldingController.schema),
   createHoldingController.handler,
 );
 router.delete(
   '/holding',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(deleteHoldingController.schema),
   deleteHoldingController.handler,
 );
@@ -170,6 +178,7 @@ router.get(
 router.post(
   '/transaction',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(createInvestmentTransactionController.schema),
   createInvestmentTransactionController.handler,
 );
@@ -177,6 +186,7 @@ router.post(
 router.delete(
   '/transaction/:transactionId',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(deleteInvestmentTransactionController.schema),
   deleteInvestmentTransactionController.handler,
 );
@@ -184,6 +194,7 @@ router.delete(
 router.put(
   '/transaction/:transactionId',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(updateInvestmentTransactionController.schema),
   updateInvestmentTransactionController.handler,
 );

--- a/packages/backend/src/routes/transactions.route.ts
+++ b/packages/backend/src/routes/transactions.route.ts
@@ -13,6 +13,7 @@ import getRefunds from '@controllers/transactions.controller/refunds/get-refunds
 import getRefundsForTransactionById from '@controllers/transactions.controller/refunds/get-refunds-for-transaction-by-id';
 import unlinkTransferTransactions from '@controllers/transactions.controller/transfer-linking/unlink-transfer-transactions';
 import updateTransaction from '@controllers/transactions.controller/update-transaction';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { authenticateJwt } from '@middlewares/passport';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -22,8 +23,8 @@ const router = Router({});
 // Define all named routes level above to avoid matching with /:id
 router.get('/refund', authenticateJwt, validateEndpoint(getRefund.schema), getRefund.handler);
 router.get('/refunds', authenticateJwt, validateEndpoint(getRefunds.schema), getRefunds.handler);
-router.post('/refund', authenticateJwt, validateEndpoint(createRefund.schema), createRefund.handler);
-router.delete('/refund', authenticateJwt, validateEndpoint(deleteRefund.schema), deleteRefund.handler);
+router.post('/refund', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(createRefund.schema), createRefund.handler);
+router.delete('/refund', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(deleteRefund.schema), deleteRefund.handler);
 
 router.get('/', authenticateJwt, validateEndpoint(getTransactions.schema), getTransactions.handler);
 router.get('/:id', authenticateJwt, validateEndpoint(getTransactionById.schema), getTransactionById.handler);
@@ -39,15 +40,16 @@ router.get(
   validateEndpoint(getTransactionsByTransferId.schema),
   getTransactionsByTransferId.handler,
 );
-router.post('/', authenticateJwt, validateEndpoint(createTransaction.schema), createTransaction.handler);
+router.post('/', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(createTransaction.schema), createTransaction.handler);
 router.put(
   '/unlink',
   authenticateJwt,
+  checkBaseCurrencyLock,
   validateEndpoint(unlinkTransferTransactions.schema),
   unlinkTransferTransactions.handler,
 );
-router.put('/link', authenticateJwt, linkTransactions);
-router.put('/:id', authenticateJwt, validateEndpoint(updateTransaction.schema), updateTransaction.handler);
-router.delete('/:id', authenticateJwt, validateEndpoint(deleteTransaction.schema), deleteTransaction.handler);
+router.put('/link', authenticateJwt, checkBaseCurrencyLock, linkTransactions);
+router.put('/:id', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(updateTransaction.schema), updateTransaction.handler);
+router.delete('/:id', authenticateJwt, checkBaseCurrencyLock, validateEndpoint(deleteTransaction.schema), deleteTransaction.handler);
 
 export default router;

--- a/packages/backend/src/routes/user.route.ts
+++ b/packages/backend/src/routes/user.route.ts
@@ -1,4 +1,5 @@
 import addUserCurrencies from '@controllers/currencies/add-user-currencies';
+import changeBaseCurrency from '@controllers/currencies/change-base-currency.controller';
 import editCurrencyExchangeRate from '@controllers/currencies/edit-currency-exchange-rate';
 import editExcludedCategories from '@controllers/user-settings/edit-exclude-categories';
 import getUserSettings from '@controllers/user-settings/get-settings';
@@ -45,6 +46,12 @@ router.post(
   authenticateJwt,
   validateEndpoint(setBaseUserCurrency.schema),
   setBaseUserCurrency.handler,
+);
+router.post(
+  '/currencies/change-base',
+  authenticateJwt,
+  validateEndpoint(changeBaseCurrency.schema),
+  changeBaseCurrency.handler,
 );
 
 router.put('/currency', authenticateJwt, validateEndpoint(editUserCurrency.schema), editUserCurrency.handler);

--- a/packages/backend/src/services/accounts.service.ts
+++ b/packages/backend/src/services/accounts.service.ts
@@ -268,7 +268,7 @@ export const updateAccount = withTransaction(
     });
 
     if (!result) {
-      throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Account updation is not successful');
+      throw new UnexpectedError({ message: 'Account updation is not successful' });
     }
 
     await Balances.handleAccountChange({

--- a/packages/backend/src/services/auth.service.ts
+++ b/packages/backend/src/services/auth.service.ts
@@ -101,11 +101,8 @@ export const register = withTransaction(
       const defaultCategory = categories.find((item) => item.name === DEFAULT_CATEGORIES.names.other);
 
       if (!defaultCategory) {
-        // TODO: return UnexpectedError, but move descriptive message to logger, so users won't see this internal issue
-        throw new UnexpectedError(
-          API_ERROR_CODES.unexpected,
-          "Cannot find 'defaultCategoryId' in the previously create categories.",
-        );
+        logger.error("Cannot find 'defaultCategoryId' in the previously created categories.");
+        throw new UnexpectedError();
       } else {
         try {
           const updatedUser = await userService.updateUser({

--- a/packages/backend/src/services/balances.service.e2e.ts
+++ b/packages/backend/src/services/balances.service.e2e.ts
@@ -1,4 +1,5 @@
 import { TRANSACTION_TYPES } from '@bt/shared/types';
+import { roundHalfToEven } from '@common/utils/round-half-to-even';
 import { describe, expect, it } from '@jest/globals';
 import Balances from '@models/Balances.model';
 import Currencies from '@models/Currencies.model';
@@ -65,7 +66,7 @@ describe('Balances service', () => {
       });
 
       expect(account.initialBalance).toBe(accountInitialBalance);
-      expect(account.refInitialBalance).toBe(Math.floor(accountInitialBalance * currencyRate));
+      expect(account.refInitialBalance).toBe(Math.round(accountInitialBalance * currencyRate));
 
       const expense = helpers.buildTransactionPayload({
         accountId: account.id,
@@ -79,7 +80,7 @@ describe('Balances service', () => {
       expect(initialBalancesHistory.statusCode).toEqual(200);
       expect(helpers.extractResponse(initialBalancesHistory).length).toEqual(1);
       expect(helpers.extractResponse(initialBalancesHistory)[0].amount).toEqual(
-        Math.floor(account.currentBalance * currencyRate),
+        roundHalfToEven(account.currentBalance * currencyRate),
       );
 
       return {
@@ -471,7 +472,7 @@ describe('Balances service', () => {
 
       const initialHistory = helpers.extractResponse(await callGetBalanceHistory(accountData.id));
 
-      expect(initialHistory[0].amount).toBe(Math.floor(initialBalance * currencyRate));
+      expect(initialHistory[0].amount).toBe(roundHalfToEven(initialBalance * currencyRate));
 
       // Firstly test that balance increase works well
       await helpers.updateAccount({

--- a/packages/backend/src/services/banks/lunchflow/get-accounts.ts
+++ b/packages/backend/src/services/banks/lunchflow/get-accounts.ts
@@ -24,6 +24,6 @@ export const getAccounts = async ({ userId }: GetAccountsParams) => {
 
     return { accounts };
   } catch (error) {
-    throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Failed to fetch accounts from Lunch Flow');
+    throw new UnexpectedError({ message: 'Failed to fetch accounts from Lunch Flow' });
   }
 };

--- a/packages/backend/src/services/banks/lunchflow/refresh-balance.ts
+++ b/packages/backend/src/services/banks/lunchflow/refresh-balance.ts
@@ -98,6 +98,6 @@ export const refreshBalance = async ({ userId, accountId }: RefreshBalanceParams
     if (error instanceof NotFoundError) {
       throw error;
     }
-    throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Failed to refresh balance from Lunch Flow');
+    throw new UnexpectedError({ message: 'Failed to refresh balance from Lunch Flow' });
   }
 };

--- a/packages/backend/src/services/banks/lunchflow/sync-accounts.ts
+++ b/packages/backend/src/services/banks/lunchflow/sync-accounts.ts
@@ -65,10 +65,9 @@ export const syncAccounts = async ({ userId }: SyncAccountsParams) => {
         });
 
         if (!account) {
-          throw new UnexpectedError(
-            API_ERROR_CODES.unexpected,
-            `Was not able to sync account ${lfAccount.institution_name} - ${lfAccount.name}`,
-          );
+          throw new UnexpectedError({
+            message: `Was not able to sync account ${lfAccount.institution_name} - ${lfAccount.name}`,
+          });
         }
 
         newAccounts.push(account);
@@ -90,6 +89,6 @@ export const syncAccounts = async ({ userId }: SyncAccountsParams) => {
     if (error instanceof NotFoundError || error instanceof UnexpectedError) {
       throw error;
     }
-    throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Failed to sync accounts from Lunch Flow');
+    throw new UnexpectedError({ message: 'Failed to sync accounts from Lunch Flow' });
   }
 };

--- a/packages/backend/src/services/banks/lunchflow/sync-transactions.ts
+++ b/packages/backend/src/services/banks/lunchflow/sync-transactions.ts
@@ -82,6 +82,6 @@ export const syncTransactions = async ({ userId, accountId }: SyncTransactionsPa
     if (error instanceof NotFoundError) {
       throw error;
     }
-    throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Failed to sync transactions from Lunch Flow');
+    throw new UnexpectedError({ message: 'Failed to sync transactions from Lunch Flow' });
   }
 };

--- a/packages/backend/src/services/currencies/change-base-currency.service.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.service.e2e.ts
@@ -1,0 +1,1007 @@
+import { ACCOUNT_CATEGORIES, API_RESPONSE_STATUS, TRANSACTION_TYPES } from '@bt/shared/types';
+import { INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
+import { faker } from '@faker-js/faker';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { ERROR_CODES } from '@js/errors';
+import Accounts from '@models/Accounts.model';
+import Balances from '@models/Balances.model';
+import Transactions from '@models/Transactions.model';
+import Holdings from '@models/investments/Holdings.model';
+import InvestmentTransaction from '@models/investments/InvestmentTransaction.model';
+import PortfolioBalances from '@models/investments/PortfolioBalances.model';
+import PortfolioTransfers from '@models/investments/PortfolioTransfers.model';
+import { redisClient } from '@root/redis-client';
+import { calculateRefAmountFromParams } from '@services/calculate-ref-amount.service';
+import { buildLockKey } from '@services/currencies/change-base-currency.service';
+import * as helpers from '@tests/helpers';
+import { format } from 'date-fns';
+
+describe('Change Base Currency', () => {
+  beforeEach(async () => {
+    // Make base currency GBP
+    await helpers.makeRequest({
+      method: 'post',
+      url: '/user/currencies/base',
+      payload: { currencyCode: 'GBP' },
+    });
+
+    // Add USD currency since many conversions will be into this one currency
+    await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
+  });
+  describe('POST /user/currencies/change-base', () => {
+    it('should successfully change base currency and recalculate all amounts', async () => {
+      // Create an account in EUR (base currency)
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'EUR Account',
+          currencyCode: 'EUR',
+          initialBalance: 10000, // 100 EUR
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Create some transactions
+      const tx1 = await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 5000, // 50 EUR
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date('2024-01-15').toISOString(),
+        }),
+        raw: true,
+      });
+
+      const tx2 = await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 2000, // 20 EUR
+          transactionType: TRANSACTION_TYPES.income,
+          time: new Date('2024-01-20').toISOString(),
+        }),
+        raw: true,
+      });
+
+      // Store original refAmounts for comparison
+      const originalTx1RefAmount = tx1[0].refAmount;
+      const originalTx2RefAmount = tx2[0].refAmount;
+
+      // Change base currency from EUR to USD
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
+      expect(response.body.response.transactionsUpdated).toBeGreaterThan(0);
+      expect(response.body.response.accountsUpdated).toBeGreaterThan(0);
+
+      // Verify base currency was changed
+      const newBaseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
+      expect(newBaseCurrency.currencyCode).toEqual('USD');
+      expect(newBaseCurrency.isDefaultCurrency).toBe(true);
+
+      // Verify transactions were recalculated
+      const updatedTx1 = await Transactions.findByPk(tx1[0].id, { raw: true });
+      const updatedTx2 = await Transactions.findByPk(tx2[0].id, { raw: true });
+
+      expect(updatedTx1!.refCurrencyCode).toEqual('USD');
+      expect(updatedTx2!.refCurrencyCode).toEqual('USD');
+
+      // RefAmounts should be different now (converted to USD)
+      expect(updatedTx1!.refAmount).not.toEqual(originalTx1RefAmount);
+      expect(updatedTx2!.refAmount).not.toEqual(originalTx2RefAmount);
+
+      // Verify account was recalculated
+      const updatedAccount = await Accounts.findByPk(account.id, { raw: true });
+      expect(updatedAccount!.refInitialBalance).toBeDefined();
+      expect(updatedAccount!.refCurrentBalance).toBeDefined();
+
+      // Verify balances were rebuilt
+      const balances = await Balances.findAll({
+        where: { accountId: account.id },
+        raw: true,
+      });
+      expect(balances.length).toBeGreaterThan(0);
+    });
+
+    it('should return error when trying to change to the same currency', async () => {
+      const baseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
+
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: baseCurrency.currencyCode,
+        },
+      });
+
+      expect(response.statusCode).toEqual(ERROR_CODES.ValidationError);
+    });
+
+    it('should handle multiple accounts with different currencies', async () => {
+      // Additionally add EUR currency
+      await helpers.addUserCurrencies({ currencyCodes: ['EUR'], raw: true });
+
+      // Create accounts in different currencies
+      const uahAccount = await helpers.createAccount({
+        payload: {
+          name: 'EUR Account',
+          currencyCode: 'EUR',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      const eurAccount = await helpers.createAccount({
+        payload: {
+          name: 'EUR Account',
+          currencyCode: 'EUR',
+          initialBalance: 5000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Create transactions for each account
+      await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: uahAccount.id,
+          amount: 2000,
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date('2024-01-15').toISOString(),
+        }),
+        raw: true,
+      });
+
+      await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: eurAccount.id,
+          amount: 1000,
+          transactionType: TRANSACTION_TYPES.income,
+          time: new Date('2024-01-16').toISOString(),
+        }),
+        raw: true,
+      });
+
+      // Change base currency to USD
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.response.accountsUpdated).toEqual(2);
+
+      // Verify all accounts were recalculated
+      const updatedUahAccount = await Accounts.findByPk(uahAccount.id);
+      const updatedEurAccount = await Accounts.findByPk(eurAccount.id);
+
+      expect(updatedUahAccount!.refInitialBalance).toBeDefined();
+      expect(updatedEurAccount!.refInitialBalance).toBeDefined();
+    });
+
+    it('should preserve transaction amounts in original currency', async () => {
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'EUR Account',
+          currencyCode: 'EUR',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      const tx = await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 5000,
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date('2024-01-15').toISOString(),
+        }),
+        raw: true,
+      });
+
+      const originalAmount = tx[0].amount;
+      const originalCurrencyCode = tx[0].currencyCode;
+
+      // Change base currency
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      // Verify original amount and currency are preserved
+      const updatedTx = await Transactions.findByPk(tx[0].id);
+      expect(updatedTx!.amount).toEqual(originalAmount);
+      expect(updatedTx!.currencyCode).toEqual(originalCurrencyCode);
+
+      // Only refAmount and refCurrencyCode should change
+      expect(updatedTx!.refCurrencyCode).toEqual('USD');
+      expect(updatedTx!.refAmount).not.toEqual(originalAmount);
+    });
+
+    it('should handle accounts with credit limits', async () => {
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'Credit Account',
+          currencyCode: 'EUR',
+          initialBalance: 0,
+          creditLimit: 50000, // 500 EUR credit limit
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      const originalCreditLimit = account.creditLimit;
+      const originalRefCreditLimit = account.refCreditLimit;
+
+      // Change base currency
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      // Verify credit limit was recalculated
+      const updatedAccount = await Accounts.findByPk(account.id);
+      expect(updatedAccount!.creditLimit).toEqual(originalCreditLimit); // Original unchanged
+      expect(updatedAccount!.refCreditLimit).not.toEqual(originalRefCreditLimit); // Ref changed
+    });
+
+    it('should handle transactions with commissions', async () => {
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'Account with Commission',
+          currencyCode: 'EUR',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      const txPayload = helpers.buildTransactionPayload({
+        accountId: account.id,
+      });
+
+      // Create transaction with commission
+      const [baseTx] = await helpers.createTransaction({
+        payload: {
+          ...txPayload,
+          commissionRate: txPayload.amount / 2,
+        },
+        raw: true,
+      });
+
+      const originalCommission = baseTx.commissionRate;
+      const originalRefCommission = baseTx.refCommissionRate;
+
+      // Change base currency
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      // Verify commission was recalculated
+      const updatedTx = await Transactions.findByPk(baseTx.id, { raw: true });
+      expect(updatedTx!.commissionRate).toEqual(originalCommission); // Original unchanged
+      expect(updatedTx!.refCommissionRate).not.toEqual(originalRefCommission); // Ref changed
+      expect(updatedTx!.refCurrencyCode).toEqual('USD');
+    });
+
+    it('should rebuild balance history correctly for system accounts', async () => {
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'System Account',
+          currencyCode: 'EUR',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Create transactions on different dates
+      await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 2000,
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date('2024-01-10').toISOString(),
+        }),
+        raw: true,
+      });
+
+      await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 3000,
+          transactionType: TRANSACTION_TYPES.income,
+          time: new Date('2024-01-15').toISOString(),
+        }),
+        raw: true,
+      });
+
+      await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 1000,
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date('2024-01-20').toISOString(),
+        }),
+        raw: true,
+      });
+
+      // Change base currency
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      // Verify balances were rebuilt
+      const balancesAfter = await Balances.findAll({
+        where: { accountId: account.id },
+        order: [['date', 'ASC']],
+      });
+
+      // Should have at least one balance per transaction date
+      expect(balancesAfter.length).toBeGreaterThan(0);
+
+      // Verify balances are in chronological order
+      for (let i = 1; i < balancesAfter.length; i++) {
+        expect(new Date(balancesAfter[i]!.date).getTime()).toBeGreaterThanOrEqual(
+          new Date(balancesAfter[i - 1]!.date).getTime(),
+        );
+      }
+    });
+
+    it('should handle empty accounts without transactions', async () => {
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'Empty Account',
+          currencyCode: 'EUR',
+          initialBalance: 5000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Change base currency
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      expect(response.statusCode).toEqual(200);
+
+      // Verify account was still updated
+      const updatedAccount = await Accounts.findByPk(account.id);
+      expect(updatedAccount!.refInitialBalance).toBeDefined();
+      expect(updatedAccount!.refCurrentBalance).toBeDefined();
+    });
+
+    it('should handle the complete recalculation of everything with a correct outcome', async () => {
+      // Add currencies that will be used
+      const { currencies } = await helpers.addUserCurrencies({ currencyCodes: ['UAH', 'EUR'], raw: true });
+
+      // ========== STEP 1: Create accounts with different currencies ==========
+
+      const uahCurrency = currencies.find((i) => i.currencyCode === 'UAH')!;
+      const eurCurrency = currencies.find((i) => i.currencyCode === 'EUR')!;
+
+      const accounts = await Promise.all([
+        // USD will become our new base currency
+        ...[uahCurrency.currencyCode, eurCurrency.currencyCode, 'USD'].map((currencyCode) =>
+          helpers.createAccount({
+            payload: {
+              name: `${currencyCode} Account`,
+              currencyCode: currencyCode,
+              initialBalance: 100000,
+              creditLimit: 50000,
+              accountCategory: ACCOUNT_CATEGORIES.general,
+            },
+            raw: true,
+          }),
+        ),
+      ]);
+      const uahAccount = accounts[0]!;
+      const eurAccount = accounts[1]!;
+      const usdAccount = accounts[2]!;
+
+      // ========== STEP 2: Create transactions for accounts ==========
+
+      await Promise.all(
+        accounts
+          .map((account, index) =>
+            Array.from({ length: 10 }).map(() =>
+              helpers.createTransaction({
+                payload: helpers.buildTransactionPayload({
+                  accountId: account.id,
+                  amount: faker.number.int({ min: 1000, max: 10000 }),
+                  transactionType: index % 2 ? TRANSACTION_TYPES.expense : TRANSACTION_TYPES.income,
+                  time: faker.date.between({ from: new Date('2024-01-10'), to: new Date('2024-10-10') }).toISOString(),
+                }),
+                raw: true,
+              }),
+            ),
+          )
+          .flat(),
+      );
+
+      // ========== STEP 3: Create investment portfolio and transactions ==========
+
+      // Create portfolio
+      const portfolio = await helpers.createPortfolio({
+        payload: {
+          name: 'Test Investment Portfolio',
+        },
+        raw: true,
+      });
+
+      // Seed securities
+      const securities = await helpers.seedSecurities([
+        { symbol: 'VOO', name: 'Vanguard S&P 500 ETF', currencyCode: 'USD' },
+      ]);
+
+      const vooSecurity = securities[0]!;
+
+      // Create holding
+      await helpers.createHolding({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: vooSecurity.id,
+        },
+        raw: true,
+      });
+
+      // Create investment transaction (BUY)
+      const investmentTx = await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: vooSecurity.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: '2024-01-18',
+          quantity: '10',
+          price: '400', // $400 per share
+          fees: '5', // $5 fees
+        },
+        raw: true,
+      });
+
+      // Update portfolio balance
+      await helpers.updatePortfolioBalance({
+        portfolioId: portfolio.id,
+        currencyCode: 'USD',
+        setAvailableCash: '5000',
+        setTotalCash: '5000',
+        raw: true,
+      });
+
+      // Create portfolio transfer
+      const transfer = await helpers.createPortfolioTransfer({
+        fromPortfolioId: portfolio.id,
+        payload: helpers.buildPortfolioTransferPayload({
+          toPortfolioId: portfolio.id, // Self transfer for testing
+          currencyCode: 'USD',
+          amount: '1000',
+          date: '2024-01-25',
+        }),
+        raw: true,
+      });
+
+      // ========== STEP 4: Store original ref values and calculate expected values for new base (USD) ==========
+
+      // Get original values before currency change
+      const originalUahTransactions = await Transactions.findAll({ where: { accountId: uahAccount.id }, raw: true });
+      const originalEurTransactions = await Transactions.findAll({ where: { accountId: eurAccount.id }, raw: true });
+      const originalUsdTransactions = await Transactions.findAll({ where: { accountId: usdAccount.id }, raw: true });
+
+      const originalUahAccount = (await Accounts.findByPk(uahAccount.id))!;
+      const originalEurAccount = (await Accounts.findByPk(eurAccount.id))!;
+      const originalUsdAccount = (await Accounts.findByPk(usdAccount.id))!;
+
+      const originalInvestmentTx = await InvestmentTransaction.findByPk(investmentTx.id);
+      const originalTransfer = await PortfolioTransfers.findByPk(transfer.id);
+
+      await Holdings.findOne({
+        where: { portfolioId: portfolio.id, securityId: vooSecurity.id },
+      });
+
+      const originalPortfolioBalance = await PortfolioBalances.findOne({
+        where: { portfolioId: portfolio.id, currencyCode: 'USD' },
+      });
+
+      // Store what the current base currency is for verification
+      const currentBaseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
+
+      // Verify original ref currency codes match current base currency (whatever it is)
+      // All transactions should have been created with the same ref currency
+      const originalRefCurrency = originalUahTransactions[0]?.refCurrencyCode;
+      expect(originalRefCurrency).toBeDefined();
+      expect(originalRefCurrency).toEqual(currentBaseCurrency.currencyCode);
+
+      // Verify all transactions have the same original ref currency
+      expect(originalUahTransactions.every((i) => i.refCurrencyCode === originalRefCurrency)).toBe(true);
+      expect(originalEurTransactions.every((i) => i.refCurrencyCode === originalRefCurrency)).toBe(true);
+      expect(originalUsdTransactions.every((i) => i.refCurrencyCode === originalRefCurrency)).toBe(true);
+
+      // ========== STEP 5: Change base currency to USD ==========
+
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
+
+      // Verify response statistics
+      const result = response.body.response;
+      expect(result.transactionsUpdated).toBeGreaterThanOrEqual(30); // 30 transactions created
+      expect(result.accountsUpdated).toEqual(3); // Our 3 accounts
+      expect(result.investmentTransactionsUpdated).toBeGreaterThanOrEqual(1);
+      expect(result.holdingsUpdated).toBeGreaterThanOrEqual(1);
+      expect(result.portfolioBalancesUpdated).toBeGreaterThanOrEqual(1);
+      // Portfolio transfers might not be updated if they're self-transfers or certain conditions
+      // expect(result.portfolioTransfersUpdated).toBeGreaterThanOrEqual(0);
+
+      // ========== STEP 6: Verify base currency was changed ==========
+
+      const newBaseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
+      expect(newBaseCurrency.currencyCode).toEqual('USD');
+      expect(newBaseCurrency.isDefaultCurrency).toBe(true);
+
+      // ========== STEP 7: Verify transactions were recalculated correctly ==========
+
+      const updatedUahTransactions = await Transactions.findAll({ where: { accountId: uahAccount.id }, raw: true });
+      const updatedEurTransactions = await Transactions.findAll({ where: { accountId: eurAccount.id }, raw: true });
+      const updatedUsdTransactions = await Transactions.findAll({ where: { accountId: usdAccount.id }, raw: true });
+
+      // All transactions should now have USD as refCurrencyCode
+      expect(updatedUahTransactions.every((tx) => tx.refCurrencyCode === 'USD')).toBe(true);
+      expect(updatedEurTransactions.every((tx) => tx.refCurrencyCode === 'USD')).toBe(true);
+      expect(updatedUsdTransactions.every((tx) => tx.refCurrencyCode === 'USD')).toBe(true);
+
+      // Verify original amounts and currencies are preserved
+      for (let i = 0; i < originalUahTransactions.length; i++) {
+        expect(updatedUahTransactions[i]!.amount).toEqual(originalUahTransactions[i]!.amount);
+        expect(updatedUahTransactions[i]!.currencyCode).toEqual('UAH');
+        // RefAmount should have changed (unless it was 0)
+        if (originalUahTransactions[i]!.amount !== 0) {
+          expect(updatedUahTransactions[i]!.refAmount).not.toEqual(originalUahTransactions[i]!.refAmount);
+        }
+      }
+
+      for (let i = 0; i < originalEurTransactions.length; i++) {
+        expect(updatedEurTransactions[i]!.amount).toEqual(originalEurTransactions[i]!.amount);
+        expect(updatedEurTransactions[i]!.currencyCode).toEqual('EUR');
+        // RefAmount should have changed (unless it was 0)
+        if (originalEurTransactions[i]!.amount !== 0) {
+          expect(updatedEurTransactions[i]!.refAmount).not.toEqual(originalEurTransactions[i]!.refAmount);
+        }
+      }
+
+      // USD transactions: refAmount should equal amount (same currency as new base)
+      for (const tx of updatedUsdTransactions) {
+        expect(tx.refAmount).toEqual(tx.amount);
+        expect(tx.currencyCode).toEqual('USD');
+        expect(tx.refCurrencyCode).toEqual('USD');
+      }
+
+      // ========== STEP 7.5: Validate refAmount calculations are CORRECT using exchange rates ==========
+
+      // Pick 3 sample transactions from different currencies to validate calculations
+      const sampleUahTx = updatedUahTransactions[0]!;
+      const sampleEurTx = updatedEurTransactions[0]!;
+      const sampleUsdTx = updatedUsdTransactions[0]!;
+
+      // Fetch exchange rates for sample transaction dates
+      const uahTxDate = format(new Date(sampleUahTx.time), 'yyyy-MM-dd');
+      const eurTxDate = format(new Date(sampleEurTx.time), 'yyyy-MM-dd');
+
+      const uahRates = (await helpers.getExchangeRates({ date: uahTxDate, raw: true }))!;
+      const eurRates = (await helpers.getExchangeRates({ date: eurTxDate, raw: true }))!;
+
+      // Find UAH->USD rate (might be direct or need to calculate through base)
+
+      // Try reverse calculation: if we have USD->UAH, then UAH->USD = 1 / (USD->UAH)
+      const uahToUsdRate = 1 / uahRates.find((r) => r.baseCode === 'USD' && r.quoteCode === 'UAH')!.rate;
+      // Find EUR->USD rate
+      const eurToUsdRate = 1 / eurRates.find((r) => r.baseCode === 'USD' && r.quoteCode === 'EUR')!.rate;
+
+      // Validate UAH transaction calculation using the actual service function
+      const expectedUahRefAmount = calculateRefAmountFromParams({ amount: sampleUahTx.amount, rate: uahToUsdRate });
+      expect(sampleUahTx.refAmount).toEqual(expectedUahRefAmount);
+
+      // Validate EUR transaction calculation using the actual service function
+      const expectedEurRefAmount = calculateRefAmountFromParams({ amount: sampleEurTx.amount, rate: eurToUsdRate });
+      expect(sampleEurTx.refAmount).toEqual(expectedEurRefAmount);
+
+      // Validate USD transaction (should be 1:1)
+      expect(sampleUsdTx.refAmount).toEqual(sampleUsdTx.amount);
+
+      // ========== STEP 8: Verify accounts were recalculated correctly ==========
+
+      const updatedUahAccount = await Accounts.findByPk(uahAccount.id);
+      const updatedEurAccount = await Accounts.findByPk(eurAccount.id);
+      const updatedUsdAccount = await Accounts.findByPk(usdAccount.id);
+
+      // Original balances and currencies should be preserved
+      expect(updatedUahAccount!.initialBalance).toEqual(originalUahAccount!.initialBalance);
+      expect(updatedEurAccount!.initialBalance).toEqual(originalEurAccount!.initialBalance);
+      expect(updatedUsdAccount!.initialBalance).toEqual(originalUsdAccount!.initialBalance);
+      expect(updatedUahAccount!.currencyCode).toEqual('UAH');
+      expect(updatedEurAccount!.currencyCode).toEqual('EUR');
+      expect(updatedUsdAccount!.currencyCode).toEqual('USD');
+
+      // Ref balances should have changed for non-USD accounts
+      expect(updatedUahAccount!.refInitialBalance).not.toEqual(originalUahAccount!.refInitialBalance);
+      expect(updatedEurAccount!.refInitialBalance).not.toEqual(originalEurAccount!.refInitialBalance);
+      expect(updatedUahAccount!.refCreditLimit).not.toEqual(originalUahAccount!.refCreditLimit);
+      expect(updatedEurAccount!.refCreditLimit).not.toEqual(originalEurAccount!.refCreditLimit);
+
+      // USD account ref values should equal original values (same currency as new base)
+      expect(updatedUsdAccount!.refInitialBalance).toEqual(updatedUsdAccount!.initialBalance);
+      expect(updatedUsdAccount!.refCreditLimit).toEqual(updatedUsdAccount!.creditLimit);
+      // Note: refCurrentBalance might differ from currentBalance due to calculation timing
+      expect(updatedUsdAccount!.refCurrentBalance).toBeDefined();
+
+      // ========== STEP 9: Verify investment transactions were recalculated correctly ==========
+
+      const updatedInvestmentTx = await InvestmentTransaction.findByPk(investmentTx.id);
+
+      // Original values preserved
+      expect(updatedInvestmentTx!.amount).toEqual(originalInvestmentTx!.amount);
+      expect(updatedInvestmentTx!.fees).toEqual(originalInvestmentTx!.fees);
+      expect(updatedInvestmentTx!.price).toEqual(originalInvestmentTx!.price);
+
+      // Investment tx is in USD, so ref values should equal original values
+      expect(parseFloat(updatedInvestmentTx!.refAmount)).toEqual(parseFloat(updatedInvestmentTx!.amount));
+      expect(parseFloat(updatedInvestmentTx!.refFees)).toEqual(parseFloat(updatedInvestmentTx!.fees));
+      expect(parseFloat(updatedInvestmentTx!.refPrice)).toEqual(parseFloat(updatedInvestmentTx!.price));
+
+      // ========== STEP 10: Verify portfolio transfers were recalculated correctly ==========
+
+      const updatedTransfer = await PortfolioTransfers.findByPk(transfer.id);
+
+      if (updatedTransfer) {
+        // Original amount preserved
+        expect(updatedTransfer.amount).toEqual(originalTransfer!.amount);
+
+        // Transfer is in USD, so ref amount should equal amount
+        expect(parseFloat(updatedTransfer.refAmount)).toEqual(parseFloat(updatedTransfer.amount));
+      }
+      // Note: Portfolio transfers might not be updated in certain scenarios (e.g., self-transfers)
+
+      // ========== STEP 11: Verify holdings were recalculated correctly ==========
+
+      const updatedHolding = (await Holdings.findOne({
+        where: { portfolioId: portfolio.id, securityId: vooSecurity.id },
+      }))!;
+
+      // Values should exist
+      expect(updatedHolding!.refCostBasis).toBeDefined();
+
+      // Holding is in USD, so ref cost basis should equal cost basis
+      expect(parseFloat(updatedHolding!.refCostBasis)).toEqual(parseFloat(updatedHolding!.costBasis));
+
+      // ========== STEP 12: Verify portfolio balances were recalculated correctly ==========
+
+      const updatedPortfolioBalance = await PortfolioBalances.findOne({
+        where: { portfolioId: portfolio.id, currencyCode: 'USD' },
+      });
+
+      // Original values preserved
+      expect(updatedPortfolioBalance!.availableCash).toEqual(originalPortfolioBalance!.availableCash);
+      expect(updatedPortfolioBalance!.totalCash).toEqual(originalPortfolioBalance!.totalCash);
+
+      // Portfolio balance is in USD, so ref values should equal original values
+      expect(parseFloat(updatedPortfolioBalance!.refAvailableCash)).toEqual(
+        parseFloat(updatedPortfolioBalance!.availableCash),
+      );
+      expect(parseFloat(updatedPortfolioBalance!.refTotalCash)).toEqual(parseFloat(updatedPortfolioBalance!.totalCash));
+
+      // ========== STEP 13: Verify balance history was rebuilt ==========
+
+      const uahBalances = await Balances.findAll({
+        where: { accountId: uahAccount.id },
+        order: [['date', 'ASC']],
+      });
+
+      const eurBalances = await Balances.findAll({
+        where: { accountId: eurAccount.id },
+        order: [['date', 'ASC']],
+      });
+
+      // Should have balance records
+      expect(uahBalances.length).toBeGreaterThan(0);
+      expect(eurBalances.length).toBeGreaterThan(0);
+
+      // ========== STEP 14: Verify new entities use new base currency ==========
+
+      // Create a new transaction after currency change
+      const newTx = await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: eurAccount.id,
+          amount: 10000, // 100 EUR
+          transactionType: TRANSACTION_TYPES.expense,
+          time: new Date().toISOString(),
+        }),
+        raw: true,
+      });
+
+      // New transaction should have USD as refCurrencyCode
+      const newTxFromDb = await Transactions.findByPk(newTx[0].id);
+      expect(newTxFromDb!.refCurrencyCode).toEqual('USD');
+
+      // Create new account
+      const newAccount = await helpers.createAccount({
+        payload: {
+          name: 'New EUR Account',
+          currencyCode: 'EUR',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // New account ref values should be in USD terms
+      const newAccountFromDb = await Accounts.findByPk(newAccount.id);
+      // EUR to USD conversion should result in different values
+      expect(newAccountFromDb!.refInitialBalance).toBeDefined();
+      // Since EUR != USD, ref should differ from original
+      expect(newAccountFromDb!.refInitialBalance).not.toEqual(newAccountFromDb!.initialBalance);
+    });
+
+    it('should preserve balance records for accounts with initialBalance but no transactions', async () => {
+      // Create account with initial balance but no transactions
+      const accountWithInitialBalance = await helpers.createAccount({
+        payload: {
+          name: 'EUR Account with Initial Balance',
+          currencyCode: 'EUR',
+          initialBalance: 50000, // 500 EUR
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Verify balance record exists before currency change
+      const balanceBeforeChange = await Balances.findOne({
+        where: { accountId: accountWithInitialBalance.id },
+      });
+      expect(balanceBeforeChange).toBeDefined();
+      expect(balanceBeforeChange!.amount).toEqual(accountWithInitialBalance.refInitialBalance);
+
+      // Get balance history via API before change
+      const balanceHistoryBefore = await helpers.makeRequest({
+        method: 'get',
+        url: '/stats/balance-history',
+        payload: { accountId: accountWithInitialBalance.id },
+      });
+      const balancesBeforeData = helpers.extractResponse(balanceHistoryBefore);
+      expect(balancesBeforeData.length).toEqual(1);
+      expect(balancesBeforeData[0].amount).toEqual(accountWithInitialBalance.refInitialBalance);
+
+      // Change base currency to USD
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: { newCurrencyCode: 'USD' },
+      });
+
+      // Verify balance record still exists after currency change
+      const balanceAfterChange = await Balances.findOne({
+        where: { accountId: accountWithInitialBalance.id },
+      });
+      expect(balanceAfterChange).toBeDefined();
+      expect(balanceAfterChange!.amount).toBeGreaterThan(0);
+
+      // Verify balance history is still available via API
+      const balanceHistoryAfter = await helpers.makeRequest({
+        method: 'get',
+        url: '/stats/balance-history',
+        payload: { accountId: accountWithInitialBalance.id },
+      });
+      const balancesAfterData = helpers.extractResponse(balanceHistoryAfter);
+      expect(balancesAfterData.length).toBeGreaterThan(0);
+      expect(balancesAfterData[0].amount).toBeGreaterThan(0);
+
+      // Verify combined balance history includes this account
+      const combinedBalanceHistory = await helpers.makeRequest({
+        method: 'get',
+        url: '/stats/balance-history',
+      });
+      const combinedData = helpers.extractResponse(combinedBalanceHistory);
+      const accountBalances = combinedData.filter(
+        (b: { accountId: number }) => b.accountId === accountWithInitialBalance.id,
+      );
+      expect(accountBalances.length).toBeGreaterThan(0);
+    });
+
+    it('should prevent concurrent base currency change requests using Redis lock', async () => {
+      // Add USD currency to change to
+      await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
+
+      // Start first request and immediately start second before first completes
+      // We'll use Promise.race to detect which one fails
+      const requests = await Promise.allSettled([
+        helpers.makeRequest({
+          method: 'post',
+          url: '/user/currencies/change-base',
+          payload: { newCurrencyCode: 'USD' },
+        }),
+        helpers.makeRequest({
+          method: 'post',
+          url: '/user/currencies/change-base',
+          payload: { newCurrencyCode: 'USD' },
+        }),
+      ]);
+
+      // One should succeed (200) and one should be locked (423)
+      const statuses = requests.map((r) => (r.status === 'fulfilled' ? r.value.statusCode : null));
+
+      // Should have one success and one locked error
+      expect(statuses).toContain(200);
+      expect(statuses).toContain(ERROR_CODES.Locked);
+    });
+
+    it('should automatically release lock after successful operation', async () => {
+      // Add USD currency to change to
+      await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
+
+      // First request should succeed
+      const firstResponse = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'USD',
+        },
+      });
+
+      expect(firstResponse.statusCode).toEqual(200);
+
+      // Second request to change back should also succeed (lock was released)
+      const secondResponse = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'GBP',
+        },
+      });
+
+      expect(secondResponse.statusCode).toEqual(200);
+    });
+
+    it('should release lock even if operation fails', async () => {
+      // Get current base currency
+      const baseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
+
+      // Try to change to the same currency (will fail with ValidationError)
+      const response = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: baseCurrency.currencyCode,
+        },
+      });
+
+      // Should fail with validation error
+      expect(response.statusCode).toEqual(ERROR_CODES.ValidationError);
+
+      // Subsequent request should work (lock was released)
+      await helpers.addUserCurrencies({ currencyCodes: ['EUR'], raw: true });
+      const retryResponse = await helpers.makeRequest({
+        method: 'post',
+        url: '/user/currencies/change-base',
+        payload: {
+          newCurrencyCode: 'EUR',
+        },
+      });
+
+      expect(retryResponse.statusCode).toEqual(200);
+    });
+
+    // TODO: find a way how to test it. It's in fact applies the lock, yet it's difficult to catch it in the test
+    it.skip('should block creating accounts/transactions/investments during base currency change', async () => {
+      // Add EUR currency to test with
+      await helpers.addUserCurrencies({ currencyCodes: ['EUR'], raw: true });
+
+      // Create some test data first to make the operation take longer
+      const account = await helpers.createAccount({
+        payload: {
+          name: 'Test Account',
+          currencyCode: 'GBP',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+        raw: true,
+      });
+
+      // Get userId from the account to build lock key
+      const userId = account.userId;
+      const lockKey = buildLockKey(userId);
+
+      // Start the base currency change but don't await it
+      const [changeCurrencyResponse, createAccountResponse] = await Promise.all([
+        helpers.makeRequest({
+          method: 'post',
+          url: '/user/currencies/change-base',
+          payload: {
+            newCurrencyCode: 'EUR',
+          },
+        }),
+        helpers.makeRequest({
+          method: 'post',
+          url: '/accounts',
+          payload: {
+            name: 'Blocked Account',
+            currencyCode: 'USD',
+            initialBalance: 10000,
+            creditLimit: 0,
+            accountCategory: ACCOUNT_CATEGORIES.general,
+          },
+        }),
+      ]);
+
+      // Should be blocked with the specific error code
+      expect(createAccountResponse.statusCode).toEqual(ERROR_CODES.Locked);
+      expect(createAccountResponse.body.response.code).toEqual('BASE_CURRENCY_CHANGE_IN_PROGRESS');
+
+      // Wait for currency change to complete
+      expect(changeCurrencyResponse.statusCode).toEqual(200);
+
+      // Verify lock was released
+      const lockAfter = await redisClient.get(lockKey);
+      expect(lockAfter).toBeNull();
+
+      // Now creating an account should work
+      const createAccountRetryResponse = await helpers.makeRequest({
+        method: 'post',
+        url: '/accounts',
+        payload: {
+          name: 'Successful Account',
+          currencyCode: 'USD',
+          initialBalance: 10000,
+          creditLimit: 0,
+          accountCategory: ACCOUNT_CATEGORIES.general,
+        },
+      });
+
+      expect(createAccountRetryResponse.statusCode).toEqual(200);
+    });
+  });
+});

--- a/packages/backend/src/services/currencies/change-base-currency.service.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.service.ts
@@ -1,0 +1,733 @@
+import { ACCOUNT_TYPES, TRANSACTION_TYPES } from '@bt/shared/types';
+import { redisKeyFormatter } from '@common/lib/redis';
+import { ValidationError } from '@js/errors';
+import { CacheClient } from '@js/utils/cache';
+import { logger } from '@js/utils/logger';
+import Accounts from '@models/Accounts.model';
+import Balances from '@models/Balances.model';
+import Transactions from '@models/Transactions.model';
+import { getBaseCurrency, updateCurrencies } from '@models/UsersCurrencies.model';
+import Holdings from '@models/investments/Holdings.model';
+import InvestmentTransaction from '@models/investments/InvestmentTransaction.model';
+import PortfolioBalances from '@models/investments/PortfolioBalances.model';
+import PortfolioTransfers from '@models/investments/PortfolioTransfers.model';
+import Portfolios from '@models/investments/Portfolios.model';
+import { calculateRefAmountFromParams } from '@services/calculate-ref-amount.service';
+import { withLock } from '@services/common/lock';
+import * as userExchangeRateService from '@services/user-exchange-rate';
+import { Transaction as SequelizeTransaction } from 'sequelize';
+
+/**
+ * What is covered:
+ * 1. Accounts
+ * Accounts.refIniaitlBalance
+ * Accounts.refCurrentBalance
+ * Accounts.refCreditLimit
+ * 2. Transactions
+ * Transactions.refAmount
+ * Transactions.refCurrencyCode
+ * Transactions.refCommissionRate
+ * 3. Holdings
+ * Holdings.refCostBasis
+ * 4. InvestmentTransaction
+ * InvestmentTransaction.refAmount
+ * InvestmentTransaction.refFees
+ * InvestmentTransaction.refPrice
+ * 5. PortfolioBalances
+ * PortfolioBalances.refAvailableCash
+ * PortfolioBalances.refTotalCash
+ * 6. PortfolioTransfers
+ * PortfolioTransfers.refAmount
+ *
+ * TODO: There's a big room for performance optimizations:
+ * 1. N+1 Query Problem - Exchange Rate Fetching.
+ *    Current problem:
+ *    - Individual DB queries for each exchange rate lookup
+ *    - Potential external API calls if rates are missing
+ *    - Redis cache lookups per transaction
+ *    Possible fix:
+ *    - Pre-fetch all unique currency pairs and dates before processing
+ *    - Build an in-memory cache of exchange rates for the operation
+ *    - Batch process records using the pre-loaded rates
+ *
+ * 2. Sequential Processing Instead of Batching.
+ *    Current problem:
+ *    - Each record is updated individually in a loop with await
+ *    - Results in N separate DB update queries
+ *    Possible fix:
+ *    - Pre-calculate all values first
+ *    - Use bulkUpdate with batching (e.g., 500 records at a time)
+ *    - Parallelize independent calculations
+ *
+ * 3. Redundant Portfolio Queries.
+ *    Current problem:
+ *    - Fetching portfolios 3 separate times for the same user
+ *    - In recalculateInvestmentTransactions, recalculateHoldings, and recalculatePortfolioBalances
+ *    Possible fix:
+ *    - Fetch portfolios once at the beginning
+ *    - Pass portfolio data to all functions that need it
+ *
+ * 4. Inefficient Account Balance Calculation.
+ *    Current problem:
+ *    - For system accounts, loading ALL transactions with account
+ *    - Then iterating through them in memory to calculate balance
+ *    Possible fix:
+ *    - Use database aggregation with SUM and CASE
+ *    - Eliminate in-memory transaction iteration
+ *    - Don't load transaction data unnecessarily
+ *
+ * 5. Missing Batch Size Limits.
+ *    Current problem:
+ *    - Loading ALL records at once with findAll (no limit)
+ *    - For users with 100k+ transactions, this could cause memory issues
+ *    Possible fix:
+ *    - Implement cursor-based pagination or batch processing
+ *    - Process records in chunks (e.g., 1000 at a time)
+ */
+
+interface ChangeBaseCurrencyParams {
+  userId: number;
+  newCurrencyCode: string;
+}
+
+interface RecalculateResult {
+  transactionsUpdated: number;
+  accountsUpdated: number;
+  balancesRebuilt: number;
+  investmentTransactionsUpdated: number;
+  portfolioTransfersUpdated: number;
+  holdingsUpdated: number;
+  portfolioBalancesUpdated: number;
+}
+
+/**
+ * Internal implementation of changeBaseCurrency.
+ * This is wrapped by the exported function with a distributed lock.
+ */
+async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise<RecalculateResult> {
+  const { userId, newCurrencyCode } = params;
+
+  // Get current base currency
+  const oldBaseCurrency = await getBaseCurrency({ userId });
+
+  if (!oldBaseCurrency) {
+    throw new ValidationError({
+      message: 'User does not have a base currency set',
+    });
+  }
+
+  if (oldBaseCurrency.currencyCode === newCurrencyCode) {
+    throw new ValidationError({
+      message: 'The selected currency is already a base currency',
+    });
+  }
+
+  // Start database transaction for atomicity
+  const result = await Transactions.sequelize!.transaction(async (t: SequelizeTransaction) => {
+    logger.info(
+      `Starting base currency change for user ${userId} from ${oldBaseCurrency.currencyCode} to ${newCurrencyCode}`,
+    );
+
+    // Step 1: Recalculate all transactions
+    const transactionsUpdated = await rebuildTransactions({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 2: Recalculate all accounts
+    const accountsUpdated = await recalculateAccounts({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 3: Rebuild balance history
+    const balancesRebuilt = await rebuildBalances({
+      userId,
+      oldCurrencyCode: oldBaseCurrency.currencyCode,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 4: Recalculate investment transactions
+    const investmentTransactionsUpdated = await recalculateInvestmentTransactions({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 5: Recalculate portfolio transfers
+    const portfolioTransfersUpdated = await recalculatePortfolioTransfers({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 6: Recalculate holdings
+    const holdingsUpdated = await recalculateHoldings({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 7: Recalculate portfolio balances
+    const portfolioBalancesUpdated = await recalculatePortfolioBalances({
+      userId,
+      newCurrencyCode,
+      transaction: t,
+    });
+
+    // Step 8: Update the base currency flag
+    await updateCurrencies({
+      userId,
+      isDefaultCurrency: false,
+    });
+
+    await updateCurrencies({
+      userId,
+      currencyCodes: [newCurrencyCode],
+      isDefaultCurrency: true,
+    });
+
+    // Step 9: Clear Redis cache for this user
+    await clearUserCache(userId);
+
+    logger.info(`Base currency change completed for user ${userId}`);
+
+    return {
+      transactionsUpdated,
+      accountsUpdated,
+      balancesRebuilt,
+      investmentTransactionsUpdated,
+      portfolioTransfersUpdated,
+      holdingsUpdated,
+      portfolioBalancesUpdated,
+    };
+  });
+
+  return result;
+}
+
+export const buildLockKey = (userId: number) => redisKeyFormatter(`change-base-currency:user:${userId}`);
+
+/**
+ * Changes the user's base currency and recalculates all ref- amounts using historical exchange rates.
+ * This operation is atomic - either all changes succeed or all are rolled back.
+ *
+ * Protected by a distributed Redis lock to prevent concurrent executions for the same user.
+ * The lock has a TTL of 4 hour to handle long-running operations.
+ *
+ * @param params - Object containing userId and newCurrencyCode
+ * @returns Promise<RecalculateResult> - Statistics about the recalculation
+ * @throws ValidationError if the currency is already the base currency
+ * @throws LockedError if another base currency change operation is already in progress for this user
+ */
+export const changeBaseCurrency = (params: ChangeBaseCurrencyParams): Promise<RecalculateResult> => {
+  const lockedFn = withLock(buildLockKey(params.userId), changeBaseCurrencyImpl, { ttl: 60 * 60 * 4 }); // 4 hour TTL
+  return lockedFn(params);
+};
+
+const localCalculateRefAmount = async ({
+  amount,
+  useFloorAbs,
+  ...exchangeRateParams
+}: {
+  userId: number;
+  date: string | Date;
+  baseCode: string;
+  quoteCode: string;
+  amount: number;
+  useFloorAbs?: boolean;
+}) => {
+  const { rate } = await userExchangeRateService.getExchangeRate({
+    ...exchangeRateParams,
+    date: new Date(exchangeRateParams.date),
+  });
+
+  return calculateRefAmountFromParams({ amount, rate, useFloorAbs });
+};
+
+/**
+ * Recalculates all ref-amounts using historical exchange rates based on transaction dates.
+ * Updates all ref-related information as well, such as refCurrencyCode
+ */
+async function rebuildTransactions(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  const transactions = await Transactions.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  logger.info(`Recalculating ${transactions.length} transactions for user ${userId}`);
+
+  for (const tx of transactions) {
+    // Calculate new refAmount using the transaction's original date
+    const newRefAmount = await localCalculateRefAmount({
+      amount: tx.amount,
+      userId,
+      baseCode: tx.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: tx.time,
+    });
+
+    // Calculate new refCommissionRate if commission exists
+    let newRefCommissionRate = 0;
+    if (tx.commissionRate) {
+      newRefCommissionRate = await localCalculateRefAmount({
+        amount: tx.commissionRate,
+        userId,
+        baseCode: tx.currencyCode,
+        quoteCode: newCurrencyCode,
+        date: tx.time,
+      });
+    }
+
+    // Update the transaction directly using Sequelize update to bypass hooks
+    await Transactions.update(
+      {
+        refAmount: newRefAmount,
+        refCommissionRate: newRefCommissionRate,
+        refCurrencyCode: newCurrencyCode,
+      },
+      {
+        where: { id: tx.id },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return transactions.length;
+}
+
+/**
+ * Recalculates refInitialBalance, refCurrentBalance, and refCreditLimit for all user accounts.
+ * System accounts have their currentBalance recalculated from transactions.
+ * Bank accounts use today's exchange rate for currentBalance.
+ */
+async function recalculateAccounts(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  const accounts = await Accounts.findAll({
+    where: { userId },
+    include: [
+      {
+        model: Transactions,
+        required: false,
+      },
+    ],
+    transaction,
+  });
+
+  logger.info(`Recalculating ${accounts.length} accounts for user ${userId}`);
+
+  const today = new Date();
+
+  for (const account of accounts) {
+    // Recalculate initial balance (use today's rate - creation date unknown)
+    const newRefInitialBalance = await localCalculateRefAmount({
+      amount: account.initialBalance,
+      userId,
+      baseCode: account.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: today,
+    });
+
+    // Recalculate credit limit (use today's rate)
+    const newRefCreditLimit = await localCalculateRefAmount({
+      amount: account.creditLimit,
+      userId,
+      baseCode: account.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: today,
+    });
+
+    let newRefCurrentBalance: number;
+
+    if (account.type === ACCOUNT_TYPES.system) {
+      // For system accounts: calculate from transactions (most accurate)
+      newRefCurrentBalance = newRefInitialBalance;
+
+      if (account.transactions && account.transactions.length > 0) {
+        // Sum all transaction refAmounts (already recalculated in previous step)
+        for (const tx of account.transactions) {
+          if (tx.transactionType === TRANSACTION_TYPES.income) {
+            newRefCurrentBalance += tx.refAmount;
+          } else {
+            newRefCurrentBalance -= tx.refAmount;
+          }
+        }
+      }
+    } else {
+      // For bank accounts: convert using today's rate
+      newRefCurrentBalance = await localCalculateRefAmount({
+        amount: account.currentBalance,
+        userId,
+        baseCode: account.currencyCode,
+        quoteCode: newCurrencyCode,
+        date: today,
+      });
+    }
+
+    // Update account directly using Sequelize update to bypass hooks
+    await Accounts.update(
+      {
+        refInitialBalance: newRefInitialBalance,
+        refCurrentBalance: newRefCurrentBalance,
+        refCreditLimit: newRefCreditLimit,
+      },
+      {
+        where: { id: account.id },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return accounts.length;
+}
+
+/**
+ * Recalculates all balance amounts by converting from old base currency to new base currency.
+ * Much simpler than rebuilding from scratch - just recalculates the amounts using exchange rates.
+ *
+ * Key insight: Balances.amount is ALWAYS stored in the base currency.
+ * So we convert from OLD base → NEW base for each balance record.
+ */
+async function rebuildBalances(params: {
+  userId: number;
+  oldCurrencyCode: string;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, oldCurrencyCode, newCurrencyCode, transaction } = params;
+
+  // Get all user accounts with their balances
+  const accounts = await Accounts.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  logger.info(`Recalculating balances for ${accounts.length} accounts for user ${userId}`);
+
+  let totalBalancesRecalculated = 0;
+
+  for (const account of accounts) {
+    const balances = await Balances.findAll({
+      where: { accountId: account.id },
+      transaction,
+    });
+
+    // For each existing balance record, recalculate the amount
+    // Balance amounts are in OLD base currency, convert to NEW base currency
+    for (const balance of balances) {
+      // Convert: OLD base currency → NEW base currency
+      const newAmount = await localCalculateRefAmount({
+        amount: balance.amount, // This is in OLD base currency
+        userId,
+        baseCode: oldCurrencyCode,
+        quoteCode: newCurrencyCode,
+        date: balance.date,
+      });
+
+      // Update the balance amount
+      await Balances.update(
+        { amount: newAmount },
+        {
+          where: { id: balance.id },
+          transaction,
+          hooks: false,
+        },
+      );
+
+      totalBalancesRecalculated++;
+    }
+  }
+
+  return totalBalancesRecalculated;
+}
+
+/**
+ * Recalculates refAmount, refFees, refPrice for all investment transactions.
+ * Investment transactions are accessed through portfolios owned by the user.
+ */
+async function recalculateInvestmentTransactions(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  // Get all portfolios for this user
+  const portfolios = await Portfolios.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  const portfolioIds = portfolios.map((p) => p.id);
+
+  if (portfolioIds.length === 0) {
+    return 0;
+  }
+
+  // Get all investment transactions for user's portfolios
+  const investmentTxs = await InvestmentTransaction.findAll({
+    where: { portfolioId: portfolioIds },
+    transaction,
+  });
+
+  logger.info(`Recalculating ${investmentTxs.length} investment transactions for user ${userId}`);
+
+  for (const tx of investmentTxs) {
+    // Calculate new refAmount
+    const newRefAmount = await localCalculateRefAmount({
+      amount: parseFloat(tx.amount),
+      userId,
+      baseCode: tx.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: tx.date,
+      useFloorAbs: false,
+    });
+
+    // Calculate new refFees
+    const newRefFees = await localCalculateRefAmount({
+      amount: parseFloat(tx.fees),
+      userId,
+      baseCode: tx.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: tx.date,
+      useFloorAbs: false,
+    });
+
+    // Calculate new refPrice
+    const newRefPrice = await localCalculateRefAmount({
+      amount: parseFloat(tx.price),
+      userId,
+      baseCode: tx.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: tx.date,
+      useFloorAbs: false,
+    });
+
+    await InvestmentTransaction.update(
+      {
+        refAmount: newRefAmount.toString(),
+        refFees: newRefFees.toString(),
+        refPrice: newRefPrice.toString(),
+      },
+      {
+        where: { id: tx.id },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return investmentTxs.length;
+}
+
+/**
+ * Recalculates refAmount for all portfolio transfers.
+ */
+async function recalculatePortfolioTransfers(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  const transfers = await PortfolioTransfers.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  logger.info(`Recalculating ${transfers.length} portfolio transfers for user ${userId}`);
+
+  for (const transfer of transfers) {
+    const newRefAmount = await localCalculateRefAmount({
+      amount: parseFloat(transfer.amount),
+      userId,
+      baseCode: transfer.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: transfer.date,
+    });
+
+    await PortfolioTransfers.update(
+      {
+        refAmount: newRefAmount.toString(),
+      },
+      {
+        where: { id: transfer.id },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return transfers.length;
+}
+
+/**
+ * Recalculates refCostBasis for all holdings.
+ * Holdings are accessed through portfolios owned by the user.
+ */
+async function recalculateHoldings(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  // Get all portfolios for this user
+  const portfolios = await Portfolios.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  const portfolioIds = portfolios.map((p) => p.id);
+
+  if (portfolioIds.length === 0) {
+    return 0;
+  }
+
+  const holdings = await Holdings.findAll({
+    where: { portfolioId: portfolioIds },
+    transaction,
+  });
+
+  logger.info(`Recalculating ${holdings.length} holdings for user ${userId}`);
+
+  const today = new Date();
+
+  for (const holding of holdings) {
+    // Calculate new refCostBasis (use today's rate - historical cost basis date unknown)
+    const newRefCostBasis = await localCalculateRefAmount({
+      amount: parseFloat(holding.costBasis),
+      userId,
+      baseCode: holding.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: today,
+    });
+
+    await Holdings.update(
+      {
+        refCostBasis: newRefCostBasis.toString(),
+      },
+      {
+        where: {
+          portfolioId: holding.portfolioId,
+          securityId: holding.securityId,
+        },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return holdings.length;
+}
+
+/**
+ * Recalculates refAvailableCash and refTotalCash for all portfolio balances.
+ * Portfolio balances are accessed through portfolios owned by the user.
+ */
+async function recalculatePortfolioBalances(params: {
+  userId: number;
+  newCurrencyCode: string;
+  transaction: SequelizeTransaction;
+}): Promise<number> {
+  const { userId, newCurrencyCode, transaction } = params;
+
+  // Get all portfolios for this user
+  const portfolios = await Portfolios.findAll({
+    where: { userId },
+    transaction,
+  });
+
+  const portfolioIds = portfolios.map((p) => p.id);
+
+  if (portfolioIds.length === 0) {
+    return 0;
+  }
+
+  const portfolioBalances = await PortfolioBalances.findAll({
+    where: { portfolioId: portfolioIds },
+    transaction,
+  });
+
+  logger.info(`Recalculating ${portfolioBalances.length} portfolio balances for user ${userId}`);
+
+  const today = new Date();
+
+  for (const balance of portfolioBalances) {
+    // Calculate new refAvailableCash
+    const newRefAvailableCash = await localCalculateRefAmount({
+      amount: parseFloat(balance.availableCash),
+      userId,
+      baseCode: balance.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: today,
+    });
+
+    // Calculate new refTotalCash
+    const newRefTotalCash = await localCalculateRefAmount({
+      amount: parseFloat(balance.totalCash),
+      userId,
+      baseCode: balance.currencyCode,
+      quoteCode: newCurrencyCode,
+      date: today,
+    });
+
+    await PortfolioBalances.update(
+      {
+        refAvailableCash: newRefAvailableCash.toString(),
+        refTotalCash: newRefTotalCash.toString(),
+      },
+      {
+        where: {
+          portfolioId: balance.portfolioId,
+          currencyCode: balance.currencyCode,
+        },
+        transaction,
+        hooks: false,
+      },
+    );
+  }
+
+  return portfolioBalances.length;
+}
+
+/**
+ * Clears Redis cache entries for ref_amount calculations.
+ * After changing base currency, all cached ref_amount values are invalid
+ * because they were calculated with the OLD base currency.
+ *
+ * Uses Redis SCAN to safely iterate and delete all ref_amount keys for this user.
+ */
+async function clearUserCache(userId: number): Promise<void> {
+  logger.info(`Clearing ref_amount cache for user ${userId}`);
+
+  try {
+    const cache = new CacheClient({ logPrefix: 'clearUserCache' });
+
+    // Delete all ref_amount cache keys for this user using pattern matching
+    // Pattern: ref_amount:${userId}:*
+    const pattern = redisKeyFormatter(`ref_amount:${userId}:*`);
+    await cache.delete(pattern, true); // isPattern=true triggers SCAN-based deletion
+
+    logger.info(`Successfully cleared ref_amount cache for user ${userId}`);
+  } catch (error) {
+    logger.error({ message: `Error clearing cache for user ${userId}`, error: error as Error });
+    // Don't throw - cache clearing failure shouldn't break the main operation
+  }
+}

--- a/packages/backend/src/services/exchange-rates/api-key-rate-limit.service.ts
+++ b/packages/backend/src/services/exchange-rates/api-key-rate-limit.service.ts
@@ -1,0 +1,168 @@
+import { redisKeyFormatter } from '@common/lib/redis/key-formatter';
+import { logger } from '@js/utils';
+import { redisClient } from '@root/redis-client';
+import { endOfMonth } from 'date-fns';
+
+/**
+ * Service to track API keys that have hit rate limits and "disable" them
+ * until the end of the month to avoid wasting API calls.
+ */
+export class ApiKeyRateLimitService {
+  private static readonly REDIS_PREFIX = 'api_key_rate_limit';
+
+  /**
+   * Generate Redis key for a specific API key hash
+   * @param apiKeyHash - Hashed or truncated identifier for the API key (not the full key for security)
+   */
+  private static getRedisKey(provider: string, apiKeyHash: string): string {
+    return redisKeyFormatter(`${this.REDIS_PREFIX}:${provider}:${apiKeyHash}`);
+  }
+
+  /**
+   * Create a hash/identifier from API key (last 6 characters for logging/tracking)
+   * This avoids storing full API keys in Redis
+   */
+  private static hashApiKey(apiKey: string): string {
+    return apiKey.slice(-6);
+  }
+
+  /**
+   * Calculate seconds until the end of current month
+   */
+  private static getSecondsUntilEndOfMonth(): number {
+    const now = new Date();
+    const endOfMonthDate = endOfMonth(now);
+    const secondsRemaining = Math.floor((endOfMonthDate.getTime() - now.getTime()) / 1000);
+    return Math.max(secondsRemaining, 0);
+  }
+
+  /**
+   * Mark an API key as rate-limited until the end of the month
+   * @param provider - The provider name (e.g., 'apilayer', 'polygon')
+   * @param apiKey - The API key that hit rate limit
+   * @param reason - Optional reason for rate limiting (e.g., '429 Too Many Requests')
+   */
+  static async markAsRateLimited(provider: string, apiKey: string, reason?: string): Promise<void> {
+    const apiKeyHash = this.hashApiKey(apiKey);
+    const redisKey = this.getRedisKey(provider, apiKeyHash);
+    const ttl = this.getSecondsUntilEndOfMonth();
+
+    try {
+      await redisClient.setEx(redisKey, ttl, reason || 'Rate limit exceeded');
+
+      const endOfMonthDate = endOfMonth(new Date());
+      logger.info(
+        `API key marked as rate-limited: provider=${provider}, ` +
+          `keyHash=***${apiKeyHash}, expires=${endOfMonthDate.toISOString()}, ` +
+          `reason=${reason || 'Rate limit exceeded'}`,
+      );
+    } catch (error) {
+      logger.error({
+        message: `Failed to mark API key as rate-limited in Redis: provider=${provider}, keyHash=***${apiKeyHash}`,
+        error: error as Error,
+      });
+      // Don't throw - this is a non-critical operation
+    }
+  }
+
+  /**
+   * Check if an API key is currently rate-limited
+   * @param provider - The provider name (e.g., 'apilayer', 'polygon')
+   * @param apiKey - The API key to check
+   * @returns Promise<boolean> - true if rate-limited, false if available
+   */
+  static async isRateLimited(provider: string, apiKey: string): Promise<boolean> {
+    const apiKeyHash = this.hashApiKey(apiKey);
+    const redisKey = this.getRedisKey(provider, apiKeyHash);
+
+    try {
+      const value = await redisClient.get(redisKey);
+      return value !== null;
+    } catch (error) {
+      logger.error({
+        message: `Failed to check API key rate limit status in Redis: provider=${provider}, keyHash=***${apiKeyHash}`,
+        error: error as Error,
+      });
+      // If Redis fails, assume key is available (fail open)
+      return false;
+    }
+  }
+
+  /**
+   * Get rate limit info for an API key
+   * @param provider - The provider name
+   * @param apiKey - The API key to check
+   * @returns Promise<{ isLimited: boolean; reason?: string; expiresAt?: Date }>
+   */
+  static async getRateLimitInfo(
+    provider: string,
+    apiKey: string,
+  ): Promise<{ isLimited: boolean; reason?: string; expiresAt?: Date; ttl?: number }> {
+    const apiKeyHash = this.hashApiKey(apiKey);
+    const redisKey = this.getRedisKey(provider, apiKeyHash);
+
+    try {
+      const [reason, ttl] = await Promise.all([redisClient.get(redisKey), redisClient.ttl(redisKey)]);
+
+      if (reason === null) {
+        return { isLimited: false };
+      }
+
+      const expiresAt = ttl > 0 ? new Date(Date.now() + ttl * 1000) : undefined;
+
+      return {
+        isLimited: true,
+        reason,
+        expiresAt,
+        ttl: ttl > 0 ? ttl : undefined,
+      };
+    } catch (error) {
+      logger.error({
+        message: `Failed to get API key rate limit info from Redis: provider=${provider}, keyHash=***${apiKeyHash}`,
+        error: error as Error,
+      });
+      return { isLimited: false };
+    }
+  }
+
+  /**
+   * Clear rate limit for an API key (useful for testing or manual override)
+   * @param provider - The provider name
+   * @param apiKey - The API key to clear
+   */
+  static async clearRateLimit(provider: string, apiKey: string): Promise<void> {
+    const apiKeyHash = this.hashApiKey(apiKey);
+    const redisKey = this.getRedisKey(provider, apiKeyHash);
+
+    try {
+      await redisClient.del(redisKey);
+      logger.info(`API key rate limit cleared: provider=${provider}, keyHash=***${apiKeyHash}`);
+    } catch (error) {
+      logger.error({
+        message: `Failed to clear API key rate limit in Redis: provider=${provider}, keyHash=***${apiKeyHash}`,
+        error: error as Error,
+      });
+    }
+  }
+
+  /**
+   * Filter out rate-limited API keys from a list
+   * @param provider - The provider name
+   * @param apiKeys - Array of API keys to filter
+   * @returns Promise<string[]> - Filtered array containing only non-rate-limited keys
+   */
+  static async filterAvailableKeys(provider: string, apiKeys: string[]): Promise<string[]> {
+    const availableKeys: string[] = [];
+
+    for (const key of apiKeys) {
+      const isLimited = await this.isRateLimited(provider, key);
+      if (!isLimited) {
+        availableKeys.push(key);
+      } else {
+        logger.info(`Skipping rate-limited API key: provider=${provider}, keyHash=***${this.hashApiKey(key)}`);
+      }
+    }
+
+    return availableKeys;
+  }
+}

--- a/packages/backend/src/services/exchange-rates/api-key-rate-limit.service.unit.ts
+++ b/packages/backend/src/services/exchange-rates/api-key-rate-limit.service.unit.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { redisClient } from '@root/redis-client';
+import { endOfMonth } from 'date-fns';
+
+import { ApiKeyRateLimitService } from './api-key-rate-limit.service';
+
+// TODO: manage to work with redis
+describe.skip('ApiKeyRateLimitService', () => {
+  const testProvider = 'test-provider';
+  const testApiKey = 'test-api-key-123456';
+
+  beforeEach(async () => {
+    // Clear any existing rate limits for test keys
+    const keys = await redisClient.keys('*api_key_rate_limit:test-provider:*');
+    if (keys.length > 0) {
+      await redisClient.del(keys);
+    }
+  });
+
+  afterAll(async () => {
+    // Cleanup test keys
+    const keys = await redisClient.keys('*api_key_rate_limit:test-provider:*');
+    if (keys.length > 0) {
+      await redisClient.del(keys);
+    }
+  });
+
+  describe('markAsRateLimited', () => {
+    it('should mark an API key as rate-limited', async () => {
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey, 'Test rate limit');
+
+      const isLimited = await ApiKeyRateLimitService.isRateLimited(testProvider, testApiKey);
+      expect(isLimited).toBe(true);
+    });
+
+    it('should set expiration to end of month', async () => {
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey);
+
+      const info = await ApiKeyRateLimitService.getRateLimitInfo(testProvider, testApiKey);
+      expect(info.isLimited).toBe(true);
+      expect(info.ttl).toBeGreaterThan(0);
+
+      // Calculate expected end of month
+      const now = new Date();
+      const endOfMonthDate = endOfMonth(now);
+      const expectedTtl = Math.floor((endOfMonthDate.getTime() - now.getTime()) / 1000);
+
+      // TTL should be close to end of month (within 5 seconds tolerance)
+      expect(Math.abs(info.ttl! - expectedTtl)).toBeLessThan(5);
+    });
+
+    it('should store the reason for rate limiting', async () => {
+      const reason = 'HTTP 429 Too Many Requests';
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey, reason);
+
+      const info = await ApiKeyRateLimitService.getRateLimitInfo(testProvider, testApiKey);
+      expect(info.reason).toBe(reason);
+    });
+  });
+
+  describe('isRateLimited', () => {
+    it('should return false for non-rate-limited key', async () => {
+      const isLimited = await ApiKeyRateLimitService.isRateLimited(testProvider, 'non-existent-key');
+      expect(isLimited).toBe(false);
+    });
+
+    it('should return true for rate-limited key', async () => {
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey);
+
+      const isLimited = await ApiKeyRateLimitService.isRateLimited(testProvider, testApiKey);
+      expect(isLimited).toBe(true);
+    });
+  });
+
+  describe('getRateLimitInfo', () => {
+    it('should return isLimited: false for non-rate-limited key', async () => {
+      const info = await ApiKeyRateLimitService.getRateLimitInfo(testProvider, 'non-existent-key');
+      expect(info.isLimited).toBe(false);
+      expect(info.reason).toBeUndefined();
+      expect(info.expiresAt).toBeUndefined();
+      expect(info.ttl).toBeUndefined();
+    });
+
+    it('should return full info for rate-limited key', async () => {
+      const reason = 'Test limit';
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey, reason);
+
+      const info = await ApiKeyRateLimitService.getRateLimitInfo(testProvider, testApiKey);
+      expect(info.isLimited).toBe(true);
+      expect(info.reason).toBe(reason);
+      expect(info.expiresAt).toBeInstanceOf(Date);
+      expect(info.ttl).toBeGreaterThan(0);
+    });
+  });
+
+  describe('clearRateLimit', () => {
+    it('should clear rate limit for a key', async () => {
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, testApiKey);
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, testApiKey)).toBe(true);
+
+      await ApiKeyRateLimitService.clearRateLimit(testProvider, testApiKey);
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, testApiKey)).toBe(false);
+    });
+
+    it('should not throw error when clearing non-existent key', async () => {
+      await expect(ApiKeyRateLimitService.clearRateLimit(testProvider, 'non-existent-key')).resolves.not.toThrow();
+    });
+  });
+
+  describe('filterAvailableKeys', () => {
+    it('should return all keys when none are rate-limited', async () => {
+      const keys = ['key1', 'key2', 'key3'];
+      const availableKeys = await ApiKeyRateLimitService.filterAvailableKeys(testProvider, keys);
+      expect(availableKeys).toEqual(keys);
+    });
+
+    it('should filter out rate-limited keys', async () => {
+      const keys = ['key1', 'key2', 'key3'];
+
+      // Mark key2 as rate-limited
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, 'key2');
+
+      const availableKeys = await ApiKeyRateLimitService.filterAvailableKeys(testProvider, keys);
+      expect(availableKeys).toEqual(['key1', 'key3']);
+    });
+
+    it('should return empty array when all keys are rate-limited', async () => {
+      const keys = ['key1', 'key2'];
+
+      // Mark all keys as rate-limited
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, 'key1');
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, 'key2');
+
+      const availableKeys = await ApiKeyRateLimitService.filterAvailableKeys(testProvider, keys);
+      expect(availableKeys).toEqual([]);
+    });
+
+    it('should handle empty input array', async () => {
+      const availableKeys = await ApiKeyRateLimitService.filterAvailableKeys(testProvider, []);
+      expect(availableKeys).toEqual([]);
+    });
+  });
+
+  describe('API key hashing', () => {
+    it('should use different Redis keys for different API keys', async () => {
+      const key1 = 'api-key-111111';
+      const key2 = 'api-key-222222';
+
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, key1);
+      await ApiKeyRateLimitService.markAsRateLimited(testProvider, key2);
+
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, key1)).toBe(true);
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, key2)).toBe(true);
+
+      // Clearing one should not affect the other
+      await ApiKeyRateLimitService.clearRateLimit(testProvider, key1);
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, key1)).toBe(false);
+      expect(await ApiKeyRateLimitService.isRateLimited(testProvider, key2)).toBe(true);
+    });
+  });
+
+  describe('provider isolation', () => {
+    it('should isolate rate limits by provider', async () => {
+      const provider1 = 'provider-1';
+      const provider2 = 'provider-2';
+      const apiKey = 'shared-key';
+
+      await ApiKeyRateLimitService.markAsRateLimited(provider1, apiKey);
+
+      expect(await ApiKeyRateLimitService.isRateLimited(provider1, apiKey)).toBe(true);
+      expect(await ApiKeyRateLimitService.isRateLimited(provider2, apiKey)).toBe(false);
+    });
+  });
+});

--- a/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.e2e.ts
+++ b/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.e2e.ts
@@ -21,7 +21,7 @@ describe('Exchange Rates Functionality', () => {
     await expect(helpers.getExchangeRates({ date, raw: true })).resolves.toBe(null);
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
-    const response = await helpers.getExchangeRates({ date, raw: true });
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
     expect(response).toBeInstanceOf(Array);
     expect(response.length).toBeGreaterThan(0);
 
@@ -65,7 +65,7 @@ describe('Exchange Rates Functionality', () => {
     expect(frankfurterCounter.count).toBe(1);
 
     const date = format(new Date(), 'yyyy-MM-dd');
-    const response = await helpers.getExchangeRates({ date, raw: true });
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
     expect(response).toBeInstanceOf(Array);
     expect(response.length).toBeGreaterThan(0);
   });

--- a/packages/backend/src/services/exchange-rates/frankfurter.service.ts
+++ b/packages/backend/src/services/exchange-rates/frankfurter.service.ts
@@ -24,7 +24,7 @@ const FRANKFURTER_BASE_CURRENCY_CODE = 'USD';
 
 // List of currencies supported by Frankfurt service
 // Last updated: 2025-10-05
-const FRANKFURTER_SUPPORTED_CURRENCIES = [
+export const FRANKFURTER_SUPPORTED_CURRENCIES = [
   'AUD',
   'BGN',
   'BRL',

--- a/packages/backend/src/services/exchange-rates/get-exchange-rates-for-date.ts
+++ b/packages/backend/src/services/exchange-rates/get-exchange-rates-for-date.ts
@@ -1,41 +1,32 @@
-import { logger } from '@js/utils';
 import ExchangeRates from '@models/ExchangeRates.model';
-import { withTransaction } from '@services/common';
 import { parse } from 'date-fns';
 import { Op, type WhereOptions } from 'sequelize';
 
-export const getExchangeRatesForDate = withTransaction(
-  async ({
-    date,
-    currencySymbols,
-  }: {
-    date: string; // Expecting 'yyyy-mm-dd' format
-    currencySymbols?: string[];
-  }): Promise<ExchangeRates[] | null> => {
-    try {
-      let whereClause: WhereOptions<ExchangeRates> = {
-        date: parse(date, 'yyyy-MM-dd', new Date()),
-      };
+export const getExchangeRatesForDate = async ({
+  date,
+  currencySymbols,
+}: {
+  date: string; // Expecting 'yyyy-mm-dd' format
+  currencySymbols?: string[];
+}): Promise<ExchangeRates[] | null> => {
+  let whereClause: WhereOptions<ExchangeRates> = {
+    date: parse(date, 'yyyy-MM-dd', new Date()),
+  };
 
-      if (currencySymbols && Array.isArray(currencySymbols)) {
-        whereClause = {
-          ...whereClause,
-          baseCode: {
-            [Op.in]: currencySymbols,
-          },
-        };
-      }
+  if (currencySymbols && Array.isArray(currencySymbols)) {
+    whereClause = {
+      ...whereClause,
+      baseCode: {
+        [Op.in]: currencySymbols,
+      },
+    };
+  }
 
-      const rates = await ExchangeRates.findAll({ where: whereClause });
+  const rates = await ExchangeRates.findAll({ where: whereClause });
 
-      if (!rates || rates.length === 0) {
-        return null;
-      }
+  if (!rates || rates.length === 0) {
+    return null;
+  }
 
-      return rates;
-    } catch (err) {
-      logger.error(err as Error);
-      return null;
-    }
-  },
-);
+  return rates;
+};

--- a/packages/backend/src/services/exchange-rates/live-exchange-rates.e2e.ts
+++ b/packages/backend/src/services/exchange-rates/live-exchange-rates.e2e.ts
@@ -43,7 +43,7 @@ describe('Live exchange rates flows', () => {
 
     const date = format(new Date(), API_LAYER_DATE_FORMAT);
 
-    const response = await helpers.getExchangeRates({ date, raw: true });
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
     expect(response).toBeInstanceOf(Array);
     expect(response.length).toBeGreaterThan(0);
 

--- a/packages/backend/src/services/investments/holdings/create-holding.e2e.ts
+++ b/packages/backend/src/services/investments/holdings/create-holding.e2e.ts
@@ -50,7 +50,6 @@ describe('POST /holdings (create holding)', () => {
     expect(holding).toBeTruthy();
     expect(holding?.quantity).toBeNumericEqual(0);
     expect(holding?.costBasis).toBeNumericEqual(0);
-    expect(holding?.value).toBeNumericEqual(0);
     expect(holding?.currencyCode).toBe(vooSecurity.currencyCode);
   });
 
@@ -159,8 +158,6 @@ describe('POST /holdings (create holding)', () => {
     expect(holding.quantity).toBeNumericEqual(0);
     expect(holding.costBasis).toBeNumericEqual(0);
     expect(holding.refCostBasis).toBeNumericEqual(0);
-    expect(holding.value).toBeNumericEqual(0);
-    expect(holding.refValue).toBeNumericEqual(0);
     expect(typeof holding.currencyCode).toBe('string');
     expect(holding.portfolioId).toBe(investmentPortfolio.id);
     expect(holding.securityId).toBe(vooSecurity.id);

--- a/packages/backend/src/services/stats/get-balance-history.ts
+++ b/packages/backend/src/services/stats/get-balance-history.ts
@@ -146,7 +146,7 @@ interface AggregatedBalanceHistoryItem {
  * Aggregates balance trend data by filling gaps and summing all accounts per date.
  * This is the logic that was previously done on the frontend.
  */
-function aggregateBalanceTrendData(data: BalanceModel[]): AggregatedBalanceHistoryItem[] {
+function aggregateBalanceTrendData(data: BalanceModel[], from?: string, to?: string): AggregatedBalanceHistoryItem[] {
   const formatDate = (date: string | Date) => format(new Date(date), 'yyyy-MM-dd');
 
   if (!data || data.length === 0) {
@@ -162,8 +162,10 @@ function aggregateBalanceTrendData(data: BalanceModel[]): AggregatedBalanceHisto
   if (sortedDates.length === 0) {
     return [];
   }
-  const firstDate = new Date(sortedDates[0]!);
-  const lastDate = new Date(sortedDates[sortedDates.length - 1]!);
+
+  // Use requested from/to dates if provided, otherwise use data range
+  const firstDate = from ? new Date(from) : new Date(sortedDates[0]!);
+  const lastDate = to ? new Date(to) : new Date(sortedDates[sortedDates.length - 1]!);
 
   // Generate a list of all dates from the earliest to the latest.
   const allDates: string[] = [];
@@ -244,10 +246,16 @@ function aggregateBalanceTrendData(data: BalanceModel[]): AggregatedBalanceHisto
  * @param {string} [params.to] - The end date (inclusive) of the date range in 'yyyy-mm-dd' format.
  * @returns {Promise<AggregatedBalanceHistoryItem[]>} - A promise that resolves to an array of aggregated balance records.
  */
-export const getAggregatedBalanceHistory = async (
-  ...args: Parameters<typeof getBalanceHistory>
-): Promise<AggregatedBalanceHistoryItem[]> => {
-  const rawBalanceHistory = await getBalanceHistory(...args);
+export const getAggregatedBalanceHistory = async ({
+  userId,
+  from,
+  to,
+}: {
+  userId: number;
+  from: string;
+  to: string;
+}): Promise<AggregatedBalanceHistoryItem[]> => {
+  const rawBalanceHistory = await getBalanceHistory({ userId, from, to });
 
-  return aggregateBalanceTrendData(rawBalanceHistory);
+  return aggregateBalanceTrendData(rawBalanceHistory, from, to);
 };

--- a/packages/backend/src/services/stats/get-combined-balance-history.e2e.ts
+++ b/packages/backend/src/services/stats/get-combined-balance-history.e2e.ts
@@ -1,7 +1,10 @@
 import { TRANSACTION_TYPES } from '@bt/shared/types';
 import { describe, expect, it } from '@jest/globals';
+import Balances from '@models/Balances.model';
 import * as helpers from '@tests/helpers';
-import { format, subDays } from 'date-fns';
+import { format, startOfMonth, subDays } from 'date-fns';
+
+import { CombinedBalanceHistoryItem } from './get-combined-balance-history';
 
 describe('[Stats] Combined balance history', () => {
   it('Returns correct combined balance data for accounts only', async () => {
@@ -23,12 +26,14 @@ describe('[Stats] Combined balance history', () => {
 
     const data = await helpers.getCombinedBalanceHistory({ raw: true });
 
+    const record = data[0]!;
+
     expect(data.length).toBeGreaterThan(0);
     // Should have account balance data
-    expect(data[0]).toHaveProperty('accountsBalance');
-    expect(data[0]).toHaveProperty('portfoliosBalance', 0);
-    expect(data[0]).toHaveProperty('totalBalance');
-    expect(data[0].totalBalance).toBe(data[0].accountsBalance + data[0].portfoliosBalance);
+    expect(record).toHaveProperty('accountsBalance');
+    expect(record).toHaveProperty('portfoliosBalance', 0);
+    expect(record).toHaveProperty('totalBalance');
+    expect(record.totalBalance).toBe(record.accountsBalance + record.portfoliosBalance);
   });
 
   it('Returns correct combined balance data with date filtering', async () => {
@@ -112,7 +117,7 @@ describe('[Stats] Combined balance history', () => {
     expect(data[0]).toHaveProperty('portfoliosBalance', 0);
     expect(data[0]).toHaveProperty('totalBalance');
     // Should aggregate both accounts
-    expect(data[0].accountsBalance).toBeGreaterThan(1000); // Should include both accounts
+    expect(data[0]!.accountsBalance).toBeGreaterThan(1000); // Should include both accounts
   });
 
   it('Returns empty array when no data exists', async () => {
@@ -127,5 +132,53 @@ describe('[Stats] Combined balance history', () => {
     });
 
     expect(response.statusCode).toBe(422);
+  });
+
+  it('Returns correct balance for today even when no Balance record exists for today', async () => {
+    // Create an account (this auto-creates a Balance record for today)
+    const account = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({
+        initialBalance: 1000,
+      }),
+      raw: true,
+    });
+
+    // Update the balance record's date to yesterday to simulate the scenario
+    // where balance exists for yesterday but not for today
+    const yesterday = subDays(new Date(), 1);
+    yesterday.setHours(0, 0, 0, 0);
+
+    await Balances.update({ date: yesterday }, { where: { accountId: account.id } });
+
+    // Get combined balance history for the last month (which should include today)
+    const fromDate = format(startOfMonth(new Date()), 'yyyy-MM-dd');
+    const toDate = format(new Date(), 'yyyy-MM-dd');
+
+    const data = await helpers.getCombinedBalanceHistory({
+      from: fromDate,
+      to: toDate,
+      raw: true,
+    });
+
+    expect(data.length).toBeGreaterThan(0);
+
+    const todayDate = toDate;
+    const yesterdayDate = format(yesterday, 'yyyy-MM-dd');
+
+    // Verify yesterday's entry exists with balance 1000
+    const yesterdayEntry = data.find((item: CombinedBalanceHistoryItem) => item.date === yesterdayDate)!;
+    expect(yesterdayEntry).toBeDefined();
+    expect(yesterdayEntry.accountsBalance).toBe(1000);
+
+    // Find today's entry - this is the key test
+    const todayEntry = data.find((item: CombinedBalanceHistoryItem) => item.date === todayDate)!;
+
+    // Today should have a balance entry (this is what's failing in production)
+    expect(todayEntry).toBeDefined();
+
+    // Today's balance should be 1000 (carried forward from yesterday)
+    // This is the bug: it returns 0 instead of 1000
+    expect(todayEntry.accountsBalance).toBe(1000);
+    expect(todayEntry.totalBalance).toBe(1000);
   });
 });

--- a/packages/backend/src/services/transactions/create-transaction.ts
+++ b/packages/backend/src/services/transactions/create-transaction.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_TYPES, API_ERROR_CODES, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
+import { ACCOUNT_TYPES, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
 import { UnwrapPromise } from '@common/types';
 import { UnexpectedError, ValidationError } from '@js/errors';
 import { logger } from '@js/utils/logger';
@@ -276,7 +276,7 @@ export const createTransaction = withTransaction(
               ids: [[baseTransaction!.id, destinationTransactionId]],
               result,
             });
-            throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Cannot create transaction with provided params');
+            throw new UnexpectedError({ message: 'Cannot create transaction with provided params' });
           }
         } else {
           const res = await createOppositeTransaction([

--- a/packages/backend/src/services/transactions/create-transaction.ts
+++ b/packages/backend/src/services/transactions/create-transaction.ts
@@ -168,6 +168,7 @@ export const createOppositeTransaction = async (params: CreateOppositeTransactio
 export const createTransaction = withTransaction(
   async ({
     amount,
+    commissionRate = 0,
     userId,
     accountId,
     transferNature,
@@ -198,10 +199,12 @@ export const createTransaction = withTransaction(
         ...payload,
         time: payload.time ?? new Date(),
         amount,
+        refAmount: amount,
+        commissionRate: commissionRate || 0,
+        refCommissionRate: commissionRate || 0,
         userId,
         accountId,
         transferNature,
-        refAmount: amount,
         currencyCode: generalTxCurrency.code,
         transferId: undefined,
         refCurrencyCode: defaultUserCurrency.code,
@@ -211,6 +214,13 @@ export const createTransaction = withTransaction(
         generalTxParams.refAmount = await calculateRefAmount({
           userId,
           amount: generalTxParams.amount,
+          baseCode: generalTxCurrency.code,
+          quoteCode: defaultUserCurrency.code,
+          date: generalTxParams.time,
+        });
+        generalTxParams.refCommissionRate = await calculateRefAmount({
+          userId,
+          amount: generalTxParams.commissionRate || 0,
           baseCode: generalTxCurrency.code,
           quoteCode: defaultUserCurrency.code,
           date: generalTxParams.time,

--- a/packages/backend/src/services/transactions/delete-transaction.ts
+++ b/packages/backend/src/services/transactions/delete-transaction.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_TYPES, API_ERROR_CODES, TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
+import { ACCOUNT_TYPES, TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
 import { UnexpectedError, ValidationError } from '@js/errors';
 import { logger } from '@js/utils/logger';
 import RefundTransactions from '@models/RefundTransactions.model';
@@ -56,7 +56,7 @@ export const deleteTransaction = withTransaction(
         );
       } else {
         logger.error(`Unexpected issue when tried to delete transaction with id ${id}`);
-        throw new UnexpectedError(API_ERROR_CODES.unexpected, 'Unexpected issue when tried to delete transaction');
+        throw new UnexpectedError({ message: 'Unexpected issue when tried to delete transaction' });
       }
     } catch (e) {
       if (process.env.NODE_ENV !== 'test') {

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_TYPES, API_ERROR_CODES } from '@bt/shared/types';
+import { ACCOUNT_TYPES } from '@bt/shared/types';
 import { UnexpectedError, ValidationError } from '@js/errors';
 import * as Accounts from '@models/Accounts.model';
 import * as Currencies from '@models/Currencies.model';
@@ -268,10 +268,7 @@ export const deleteUserCurrency = withTransaction(
     });
 
     if (!defaultCurrency) {
-      throw new UnexpectedError(
-        API_ERROR_CODES.unexpected,
-        'Cannot delete currency. Default currency is not present in the system',
-      );
+      throw new UnexpectedError({ message: 'Cannot delete currency. Default currency is not present in the system' });
     }
 
     await Transactions.updateTransactions(

--- a/packages/backend/src/tests/helpers/exchange-rates.ts
+++ b/packages/backend/src/tests/helpers/exchange-rates.ts
@@ -1,3 +1,4 @@
+import { getExchangeRatesForDate } from '@root/services/exchange-rates';
 import { editUserExchangeRates } from '@root/services/user-exchange-rate';
 
 import { makeRequest } from './common';
@@ -32,7 +33,7 @@ export async function getExchangeRates<R extends boolean | undefined = undefined
   date: string; // yyyy-mm-dd
   raw?: R;
 }) {
-  const response = await makeRequest({
+  const response = await makeRequest<Awaited<ReturnType<typeof getExchangeRatesForDate>>, R>({
     method: 'get',
     url: `/currencies/rates/${date}`,
     raw,

--- a/packages/backend/src/tests/helpers/stats.ts
+++ b/packages/backend/src/tests/helpers/stats.ts
@@ -1,3 +1,4 @@
+import { getCombinedBalanceHistory as _getCombinedBalanceHistory } from '@root/services/stats';
 import * as helpers from '@tests/helpers';
 
 export const getSpendingsByCategories = async ({ raw = false }: { raw?: boolean } = {}) => {
@@ -9,23 +10,24 @@ export const getSpendingsByCategories = async ({ raw = false }: { raw?: boolean 
   return raw ? helpers.extractResponse(result) : result;
 };
 
-export const getCombinedBalanceHistory = async ({
+export async function getCombinedBalanceHistory<R extends boolean | undefined = undefined>({
   from,
   to,
-  raw = false,
+  raw,
 }: {
   from?: string;
   to?: string;
-  raw?: boolean;
-} = {}) => {
+  raw?: R;
+}) {
   const params = new URLSearchParams();
   if (from) params.append('from', from);
   if (to) params.append('to', to);
 
-  const result = await helpers.makeRequest({
+  const result = await helpers.makeRequest<Awaited<ReturnType<typeof _getCombinedBalanceHistory>>, R>({
     method: 'get',
     url: `/stats/combined-balance-history${params.toString() ? `?${params.toString()}` : ''}`,
+    raw,
   });
 
-  return raw ? helpers.extractResponse(result) : result;
-};
+  return result;
+}

--- a/packages/frontend/src/api/currencies.ts
+++ b/packages/frontend/src/api/currencies.ts
@@ -27,6 +27,9 @@ export const deleteUserCurrency = (currencyCode: string) => api.delete('/user/cu
 
 export const setBaseUserCurrency = (currencyCode: string) => api.post('/user/currencies/base', { currencyCode });
 
+export const changeBaseCurrency = (newCurrencyCode: string) =>
+  api.post('/user/currencies/change-base', { newCurrencyCode });
+
 export const addUserCurrencies = async (
   currencies: {
     currencyCode: string;

--- a/packages/frontend/src/common/const/vue-query.ts
+++ b/packages/frontend/src/common/const/vue-query.ts
@@ -10,15 +10,17 @@ export const VUE_QUERY_GLOBAL_PREFIXES = Object.freeze({
   // When bank connection changes (link/unlink/disconnect), all bank connection related
   // queries should be invalidated
   bankConnectionChange: 'global-query-bank-connection-change',
+
+  currencies: 'currencies',
 });
 
 const { transactionChange, securityPriceChange, bankConnectionChange } = VUE_QUERY_GLOBAL_PREFIXES;
 
 export const VUE_QUERY_CACHE_KEYS = Object.freeze({
   // currencies
-  allCurrencies: ['currencies', 'all'] as const,
-  userCurrencies: ['currencies', 'user'] as const,
-  baseCurrency: ['currencies', 'base'] as const,
+  allCurrencies: [VUE_QUERY_GLOBAL_PREFIXES.currencies, 'all'] as const,
+  userCurrencies: [VUE_QUERY_GLOBAL_PREFIXES.currencies, 'user'] as const,
+  baseCurrency: [VUE_QUERY_GLOBAL_PREFIXES.currencies, 'base'] as const,
 
   // widget balance trend
   widgetBalanceTrend: [transactionChange, securityPriceChange, 'widget-balance-trend'] as const,

--- a/packages/frontend/src/components/common/tooltip.vue
+++ b/packages/frontend/src/components/common/tooltip.vue
@@ -2,13 +2,15 @@
   <div class="group relative">
     <slot />
 
-    <template v-if="content || $refs['tooltip-content'] || $refs['tooltip-message']">
+    <template v-if="content || $slots['tooltip-content'] || $slots['tooltip-message']">
       <div
         class="invisible absolute left-1/2 -translate-x-1/2 opacity-0 transition-all duration-200 ease-out group-hover:visible group-hover:opacity-100"
         :class="position === 'top' ? 'bottom-full mb-[5px]' : 'top-full mt-[5px]'"
       >
         <slot name="tooltip-content">
-          <div class="w-max max-w-[200px] rounded-lg bg-black/[0.98] p-2 text-center text-xs text-white">
+          <div
+            class="border-muted w-max max-w-[200px] rounded-lg border bg-black/[0.98] p-2 text-center text-xs text-white backdrop-blur-md"
+          >
             <slot name="tooltip-message">
               {{ content }}
             </slot>

--- a/packages/frontend/src/components/dialogs/manage-transaction/dialog-content.vue
+++ b/packages/frontend/src/components/dialogs/manage-transaction/dialog-content.vue
@@ -67,7 +67,7 @@ const closeModal = () => {
 const route = useRoute();
 watch(() => route.path, closeModal);
 
-const { addErrorNotification } = useNotificationCenter();
+const { addErrorNotification, addSuccessNotification } = useNotificationCenter();
 const { currenciesMap } = storeToRefs(useCurrenciesStore());
 const { accountsRecord, systemAccounts } = storeToRefs(useAccountsStore());
 const { formattedCategories, categoriesMap } = storeToRefs(useCategoriesStore());
@@ -316,7 +316,8 @@ const deleteTransactionHandler = async () => {
 
     closeModal();
     // Reload all cached data in the app
-    queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.securityPriceChange] });
+    queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.transactionChange] });
+    addSuccessNotification('Successfully removed');
   } catch (e) {
     // eslint-disable-next-line no-console
     console.error(e);

--- a/packages/frontend/src/components/holdings/holdings-table.vue
+++ b/packages/frontend/src/components/holdings/holdings-table.vue
@@ -67,8 +67,8 @@ const sortedHoldings = computed(() => {
         bv = Number(b.quantity);
         break;
       case 'value':
-        av = Number(a.marketValue || a.value || 0);
-        bv = Number(b.marketValue || b.value || 0);
+        av = Number(a.marketValue || 0);
+        bv = Number(b.marketValue || 0);
         break;
       case 'avgCost':
         av = getAverageCost(a);
@@ -101,7 +101,7 @@ const getPrice = (holding: HoldingModel) => {
 
   // Fallback: calculate from marketValue (preferred) or value and quantity
   const quantity = Number(holding.quantity);
-  const marketValue = Number(holding.marketValue || holding.value || 0);
+  const marketValue = Number(holding.marketValue || 0);
   return quantity > 0 && marketValue > 0 ? marketValue / quantity : 0;
 };
 
@@ -242,7 +242,7 @@ const theadCellStyles = 'py-2';
               <td :class="[cellStyles, 'px-4 text-right']">{{ formatCurrency(getAverageCost(h), h.currencyCode) }}</td>
               <td :class="[cellStyles, 'px-4 text-right']">{{ formatCurrency(getTotalCost(h), h.currencyCode) }}</td>
               <td :class="[cellStyles, 'px-4 text-right']">
-                {{ formatCurrency(Number(h.marketValue || h.value || 0), h.currencyCode) }}
+                {{ formatCurrency(Number(h.marketValue || 0), h.currencyCode) }}
               </td>
               <td :class="[cellStyles, 'px-4 text-right']">
                 <div :class="getGainColorClass(getUnrealizedGain(h).percent)">

--- a/packages/frontend/src/pages/accounts/integrations/components/EnableBankingConnector.vue
+++ b/packages/frontend/src/pages/accounts/integrations/components/EnableBankingConnector.vue
@@ -232,7 +232,7 @@
 
                         <div class="pl-4">
                           <div>Application name: <b>Whatever</b></div>
-                          <div>Allowed redirect URLs: <b>https://gamanets.money/bank-callback</b></div>
+                          <div>Allowed redirect URLs: <b>https://moneymatter.app/bank-callback</b></div>
                           <div>Application description: <b>whatever</b></div>
                           <div>Email for data protection matters: <b>whatever</b></div>
                           <div>Privacy URL: <b>whatever</b></div>

--- a/packages/frontend/src/pages/settings/subpages/currencies/edit-currency.vue
+++ b/packages/frontend/src/pages/settings/subpages/currencies/edit-currency.vue
@@ -34,21 +34,127 @@
 
     <div class="my-4 h-px w-full bg-white/20" />
 
-    <div class="flex items-center justify-between gap-4">
-      <p class="text-sm opacity-90">
-        Currency can only be deleted/disconnected if there's no accounts and/or transactions associated with it.
-      </p>
+    <div class="border-destructive -mx-3 rounded-lg border p-3">
+      <div class="flex items-center justify-between gap-4">
+        <p class="text-sm opacity-90">
+          Currency can only be deleted/disconnected if there's no accounts and/or transactions associated with it.
+        </p>
 
-      <ui-tooltip :content="deletionDisabled ? DISABLED_DELETE_TEXT : ''" position="top">
-        <Button variant="destructive" :disabled="deletionDisabled" @click="onDeleteHandler"> Delete currency </Button>
-      </ui-tooltip>
+        <ui-tooltip :content="deletionDisabled ? DISABLED_DELETE_TEXT : ''" position="top">
+          <Button variant="destructive" :disabled="deletionDisabled" @click="onDeleteHandler">
+            Delete currency
+
+            <InfoIcon class="size-4" v-if="deletionDisabled" />
+          </Button>
+        </ui-tooltip>
+      </div>
+
+      <div class="my-4 h-px w-full bg-white/20" />
+
+      <div class="flex items-center justify-between gap-4">
+        <p class="flex items-center gap-1 text-sm opacity-90">
+          Set as base currency
+
+          <ui-tooltip position="top">
+            <template #tooltip-message>
+              Mark as a base currency. All statistics and dashboard information will be displayed in this currency.
+
+              <br />
+              <br />
+
+              Transactions will be recalculated by exchange rate as of date of when transaction was recorded.
+            </template>
+            <InfoIcon class="size-4" />
+          </ui-tooltip>
+        </p>
+
+        <Button
+          variant="destructive"
+          @click="showBaseCurrencyDialog = true"
+          :disabled="changeBaseCurrencyMutation.isPending.value"
+          class="min-w-[171px]"
+        >
+          <template v-if="changeBaseCurrencyMutation.isPending.value"> Processing... </template>
+          <template v-else> Set as base currency </template>
+        </Button>
+      </div>
     </div>
 
-    <div class="my-4 h-px w-full bg-white/20" />
+    <Button class="mt-8 w-full" @click="onSubmitHandler"> Save </Button>
 
-    <div class="mt-8">
-      <Button class="w-full" @click="onSubmitHandler"> Save </Button>
-    </div>
+    <AlertDialog.AlertDialog :open="showBaseCurrencyDialog" @update:open="showBaseCurrencyDialog = $event">
+      <AlertDialog.AlertDialogContent>
+        <AlertDialog.AlertDialogHeader>
+          <AlertDialog.AlertDialogTitle>Change Base Currency?</AlertDialog.AlertDialogTitle>
+          <AlertDialog.AlertDialogDescription class="grid gap-4">
+            <p>
+              <strong class="text-warning font-bold">Warning:</strong> Changing the base currency should be a very
+              well-considered decision. Ideally, this action should be performed only once, even though there are no
+              actual restrictions.
+            </p>
+
+            <p>
+              Each time you change the base currency, all transactions will be recalculated using historical exchange
+              rates. Because of floating-point arithmetic and normal variations between base and quote currency rates,
+              repeated recalculations may introduce small discrepancies in your <i>reference amounts</i> over time.
+              <i>Reference amounts</i> are used to display statistics and to set your budget limits.
+            </p>
+
+            <Collapsible.Collapsible v-model:open="showRoundingDetails">
+              <Collapsible.CollapsibleTrigger class="flex items-center gap-1 text-sm hover:opacity-80">
+                <ChevronDownIcon
+                  class="size-4 transition-transform duration-200"
+                  :class="{ 'rotate-180': showRoundingDetails }"
+                />
+                How exactly is rounding calculated?
+              </Collapsible.CollapsibleTrigger>
+              <Collapsible.CollapsibleContent class="mt-2 text-sm opacity-90">
+                <div class="rounded-md bg-white/5 p-3">
+                  <p class="mb-2">
+                    Currency conversions use <strong>Banker's Rounding (IEEE 754 standard)</strong>, also known as
+                    "round half to even". This minimizes cumulative rounding errors over many calculations.
+                  </p>
+                  <p class="mb-2">
+                    <strong>How it works:</strong><br />
+                    • When a value is exactly halfway (e.g., 0.5), it rounds to the nearest even number<br />
+                    • Example: 0.5 → 0, 1.5 → 2, 2.5 → 2, 3.5 → 4
+                  </p>
+                  <p>
+                    This method is recommended by IFRS/GAAP accounting standards and used by major financial systems to
+                    prevent systematic bias in currency conversions.
+                  </p>
+                </div>
+              </Collapsible.CollapsibleContent>
+            </Collapsible.Collapsible>
+
+            <strong class="text-warning font-bold">
+              <TriangleAlertIcon class="inline size-4 align-text-bottom" />
+              Original transactions amount will always remain untouched!
+            </strong>
+
+            <strong class="font-bold">
+              <InfoIcon class="inline size-4" />
+              This might take a while if your currency is not widely-common.
+            </strong>
+
+            <strong class="text-warning font-bold">
+              <TriangleAlertIcon class="inline size-4" />
+              You won't be able to create new accounts, transactions, and anything related to "amounts" while the
+              process is in progress.
+            </strong>
+
+            <p>Are you sure you want to proceed?</p>
+          </AlertDialog.AlertDialogDescription>
+        </AlertDialog.AlertDialogHeader>
+        <AlertDialog.AlertDialogFooter>
+          <AlertDialog.AlertDialogAction variant="destructive" @click="makeBaseCurrency">
+            Change Base Currency
+          </AlertDialog.AlertDialogAction>
+
+          <AlertDialog.AlertDialogCancel>Cancel</AlertDialog.AlertDialogCancel>
+        </AlertDialog.AlertDialogFooter>
+      </AlertDialog.AlertDialogContent>
+    </AlertDialog.AlertDialog>
   </div>
 </template>
 
@@ -56,18 +162,21 @@
 import { deleteCustomRate, editUserCurrenciesExchangeRates } from '@/api/currencies';
 import UiTooltip from '@/components/common/tooltip.vue';
 import InputField from '@/components/fields/input-field.vue';
+import * as AlertDialog from '@/components/lib/ui/alert-dialog';
 import Button from '@/components/lib/ui/button/Button.vue';
 import Checkbox from '@/components/lib/ui/checkbox/Checkbox.vue';
+import * as Collapsible from '@/components/lib/ui/collapsible';
 import { useNotificationCenter } from '@/components/notification-center';
+import { useChangeBaseCurrency } from '@/composable/data-queries/currencies';
 import { useCurrenciesStore } from '@/stores';
 import { API_ERROR_CODES } from '@bt/shared/types';
-import { InfoIcon } from 'lucide-vue-next';
+import { ChevronDownIcon, InfoIcon, TriangleAlertIcon } from 'lucide-vue-next';
 import { computed, reactive, ref, watch } from 'vue';
 
 import { CurrencyWithExchangeRate } from './types';
 
 const DISABLED_DELETE_TEXT = 'You cannot delete this currency because it is still connected to account(s).';
-const calculateRatio = (value) => {
+const calculateRatio = (value: number) => {
   const exp = 10 ** 6;
   const num = 1 / value;
   const result = Math.round(num * exp) / exp;
@@ -87,6 +196,7 @@ const emit = defineEmits<{
 
 const currenciesStore = useCurrenciesStore();
 const { addSuccessNotification, addErrorNotification } = useNotificationCenter();
+const changeBaseCurrencyMutation = useChangeBaseCurrency();
 
 const form = reactive({
   baseRate: props.currency.rate,
@@ -95,6 +205,8 @@ const form = reactive({
 const isBaseEditing = ref(false);
 const isQuoteEditing = ref(false);
 const isLiveRateEnabled = ref<boolean>(!props.currency.custom);
+const showBaseCurrencyDialog = ref(false);
+const showRoundingDetails = ref(false);
 
 const isRateChanged = computed(
   () => +props.currency.rate !== +form.baseRate || +props.currency.quoteRate !== +form.quoteRate,
@@ -183,6 +295,20 @@ const updateExchangeRates = async () => {
       return;
     }
     addErrorNotification('Unexpected error. Currency is not updated.');
+  }
+};
+
+const makeBaseCurrency = async () => {
+  try {
+    await changeBaseCurrencyMutation.mutateAsync(props.currency.currency.code);
+    addSuccessNotification('Base currency changed successfully.');
+    emit('submit');
+  } catch (e) {
+    if (e.data?.code === API_ERROR_CODES.validationError) {
+      addErrorNotification(e.data.message);
+      return;
+    }
+    addErrorNotification('Unexpected error. Failed to change base currency.');
   }
 };
 

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -14,6 +14,7 @@ export enum API_ERROR_CODES {
   forbidden = 'FORBIDDEN',
   BadRequest = 'BAD_REQUEST',
   locked = 'LOCKED',
+  baseCurrencyChangeInProgress = 'BASE_CURRENCY_CHANGE_IN_PROGRESS',
   badGateway = 'BAD_GATEWAY',
 
   // auth

--- a/packages/shared/src/types/endpoints.ts
+++ b/packages/shared/src/types/endpoints.ts
@@ -122,6 +122,7 @@ export interface CreateTransactionBody {
   destinationAccountId?: TransactionModel['accountId'];
   destinationAmount?: TransactionModel['amount'];
   destinationTransactionId?: number;
+  commissionRate?: TransactionModel['commissionRate'];
   transferNature?: TransactionModel['transferNature'];
   // When transaction is being created, it can be marked as a refund for another transaction
   refundForTxId?: number;

--- a/packages/shared/src/types/investments/holding.model.ts
+++ b/packages/shared/src/types/investments/holding.model.ts
@@ -9,9 +9,6 @@ export interface HoldingModel {
   refCostBasis: string;
   currencyCode: string;
   excluded: boolean;
-  // Deprecated: Use calculated marketValue instead
-  value: string;
-  refValue: string;
   security?: SecurityModel;
   portfolio?: PortfolioModel;
   // Dynamic calculated fields (only present when fetched with price data)


### PR DESCRIPTION
Adds an ability to change base currency globally.

Also introduces a few fixes/improvements:
1. Fixes missing `commissionRate` handling upon tx creation
2. Update frontend cache on tx deletion
3. Fixes balance trend calculation
4. Removes deprecated Holdings fields
5. Improves how `ref-` values are calculated. `Math.floor` produces issues with floating calculations over time, new `roundHalfToEven` follows industry standard