### PR TITLE
fix: EnableBanking transaction date and uniqueId determining

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -43,7 +43,7 @@ FRANKFURTER_BASE_URL=http://frankfurter:8080
 
 # Enable Banking configuration
 # Redirect URL for OAuth flow (must match the URL registered in Enable Banking portal)
-ENABLE_BANKING_REDIRECT_URL=http://localhost:8100/bank-callback
+ENABLE_BANKING_REDIRECT_URL=https://localhost:8100/bank-callback
 
 # e2e tests are running in parallel. To achieve that, we need to define a strict
 # amount of workers, so that the same amount of DBs will be created to avoid collisions

--- a/packages/backend/src/migrations/20251223000000-fix-enablebanking-transaction-original-ids.ts
+++ b/packages/backend/src/migrations/20251223000000-fix-enablebanking-transaction-original-ids.ts
@@ -1,0 +1,174 @@
+import crypto from 'crypto';
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+/**
+ * Migration to fix Enable Banking transaction originalId values.
+ *
+ * The hash generation algorithm was updated to:
+ * 1. Include accountExternalId (entry_reference is only unique per account, not globally)
+ * 2. Use priority-based date selection (transaction_date > value_date > booking_date)
+ *
+ * This migration recalculates originalId for all existing Enable Banking transactions
+ * using the new algorithm to prevent duplicates on future syncs.
+ */
+
+interface EnableBankingTransaction {
+  entry_reference?: string;
+  transaction_amount: {
+    amount: string;
+    currency: string;
+  };
+  credit_debit_indicator: string;
+  transaction_date?: string;
+  value_date?: string;
+  booking_date?: string;
+  debtor_account?: {
+    iban?: string;
+  };
+  creditor_account?: {
+    iban?: string;
+  };
+}
+
+interface TransactionRow {
+  id: number;
+  accountId: number;
+  externalData: {
+    rawTransaction?: EnableBankingTransaction;
+    entryReference?: string;
+    transactionDate?: string;
+    valueDate?: string;
+    bookingDate?: string;
+  } | null;
+  accountExternalId: string;
+}
+
+/**
+ * Get the transaction date string using priority-based selection.
+ * Priority: transaction_date > value_date > booking_date
+ */
+function getTransactionDateString(tx: EnableBankingTransaction): string | null {
+  return tx.transaction_date || tx.value_date || tx.booking_date || null;
+}
+
+/**
+ * Generate unique hash for a transaction using the new algorithm.
+ */
+function generateTransactionHash({
+  tx,
+  accountExternalId,
+}: {
+  tx: EnableBankingTransaction;
+  accountExternalId: string;
+}): string {
+  // If entry_reference is available, it's the most reliable unique identifier
+  if (tx.entry_reference) {
+    return crypto
+      .createHash('sha256')
+      .update(JSON.stringify({ account: accountExternalId, entry_ref: tx.entry_reference }))
+      .digest('hex');
+  }
+
+  // Fall back to combination of transaction attributes
+  const hashData = {
+    account_external_id: accountExternalId,
+    amount: tx.transaction_amount.amount,
+    currency: tx.transaction_amount.currency,
+    credit_debit_indicator: tx.credit_debit_indicator,
+    date: getTransactionDateString(tx),
+    debtor_account: tx.debtor_account?.iban,
+    creditor_account: tx.creditor_account?.iban,
+  };
+
+  return crypto.createHash('sha256').update(JSON.stringify(hashData)).digest('hex');
+}
+
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const sequelize = queryInterface.sequelize;
+
+    // Fetch all Enable Banking transactions with their account's externalId
+    const transactions = await sequelize.query<TransactionRow>(
+      `
+      SELECT
+        t.id,
+        t."accountId",
+        t."externalData",
+        a."externalId" as "accountExternalId"
+      FROM "Transactions" t
+      INNER JOIN "Accounts" a ON t."accountId" = a.id
+      WHERE t."accountType" = 'enable-banking'
+        AND t."externalData" IS NOT NULL
+      `,
+      { type: QueryTypes.SELECT },
+    );
+
+    console.log(`Found ${transactions.length} Enable Banking transactions to migrate`);
+
+    let updated = 0;
+    let skipped = 0;
+    let errors = 0;
+
+    for (const tx of transactions) {
+      try {
+        // Get rawTransaction from externalData
+        const rawTransaction = tx.externalData?.rawTransaction;
+
+        if (!rawTransaction) {
+          // Try to reconstruct from parsed fields if rawTransaction is missing
+          const entryReference = tx.externalData?.entryReference;
+
+          if (entryReference && tx.accountExternalId) {
+            // Can generate hash from entry_reference
+            const newOriginalId = crypto
+              .createHash('sha256')
+              .update(JSON.stringify({ account: tx.accountExternalId, entry_ref: entryReference }))
+              .digest('hex');
+
+            await sequelize.query(`UPDATE "Transactions" SET "originalId" = :newOriginalId WHERE id = :id`, {
+              replacements: { newOriginalId, id: tx.id },
+              type: QueryTypes.UPDATE,
+            });
+            updated++;
+          } else {
+            console.warn(`Transaction ${tx.id}: Missing rawTransaction and entry_reference, skipping`);
+            skipped++;
+          }
+          continue;
+        }
+
+        if (!tx.accountExternalId) {
+          console.warn(`Transaction ${tx.id}: Missing accountExternalId, skipping`);
+          skipped++;
+          continue;
+        }
+
+        // Generate new originalId using the updated algorithm
+        const newOriginalId = generateTransactionHash({
+          tx: rawTransaction,
+          accountExternalId: tx.accountExternalId,
+        });
+
+        // Update the transaction
+        await sequelize.query(`UPDATE "Transactions" SET "originalId" = :newOriginalId WHERE id = :id`, {
+          replacements: { newOriginalId, id: tx.id },
+          type: QueryTypes.UPDATE,
+        });
+
+        updated++;
+      } catch (error) {
+        console.error(`Error migrating transaction ${tx.id}:`, error);
+        errors++;
+      }
+    }
+
+    console.log(`Migration complete: ${updated} updated, ${skipped} skipped, ${errors} errors`);
+  },
+
+  down: async (): Promise<void> => {
+    // This migration cannot be easily reversed as we don't store the old originalId values.
+    // The down migration is a no-op. If needed, transactions would need to be re-synced
+    // from Enable Banking to regenerate the old hash format.
+    console.log('Down migration is a no-op. To revert, you would need to re-sync transactions from Enable Banking.');
+  },
+};

--- a/packages/backend/src/services/bank-data-providers/enablebanking/types.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/types.ts
@@ -493,7 +493,7 @@ export interface EnableBankingTransaction {
    * Booking date (ISO 8601). Booking date of the transaction on the account,
    * i.e. the date at which the transaction has been recorded on books
    */
-  booking_date: string;
+  booking_date?: string;
 
   /**
    * (ISO 8601) Value date of the transaction on the account, i.e. the date at
@@ -501,6 +501,14 @@ export interface EnableBankingTransaction {
    * or cease to be available to the account holder (in case of a debit transaction)
    */
   value_date?: string;
+
+  /**
+   * (ISO 8601) Date used for specific purposes:
+   * - for card transaction: date of the transaction
+   * - for credit transfer: acquiring date of the transaction
+   * - for direct debit: receiving date of the transaction
+   */
+  transaction_date?: string;
 
   /**
    * Payment details. For credit transfers may contain free text, reference number

--- a/packages/backend/src/tests/helpers/enablebanking.ts
+++ b/packages/backend/src/tests/helpers/enablebanking.ts
@@ -1,5 +1,6 @@
 import * as helpers from '@tests/helpers';
 import {
+  FixedTransaction,
   MOCK_AUTHORIZATION_ID,
   MOCK_AUTH_CODE,
   MOCK_BANK_COUNTRY,
@@ -7,6 +8,8 @@ import {
   MOCK_ENABLE_BANKING_APP_ID,
   MOCK_ENABLE_BANKING_PRIVATE_KEY,
   getMockedASPSPData,
+  resetMockTransactionConfig,
+  setMockTransactionConfig,
 } from '@tests/mocks/enablebanking/data';
 import { resetSessionCounter as resetMockSessionCounter } from '@tests/mocks/enablebanking/mock-api';
 
@@ -108,6 +111,22 @@ const resetSessionCounter = () => {
   resetMockSessionCounter();
 };
 
+/**
+ * Set fixed transactions for testing.
+ * Use this to control exactly what transactions are returned by the mock API.
+ */
+const setFixedTransactions = (transactions: FixedTransaction[]) => {
+  setMockTransactionConfig({ fixedTransactions: transactions });
+};
+
+/**
+ * Reset mock transaction configuration to defaults.
+ * Call this after tests that modify transaction config.
+ */
+const resetTransactionConfig = () => {
+  resetMockTransactionConfig();
+};
+
 export default {
   listCountries,
   listBanks,
@@ -117,6 +136,8 @@ export default {
   mockCredentials,
   getConnectionState,
   resetSessionCounter,
+  setFixedTransactions,
+  resetTransactionConfig,
   // Export mock constants for direct use in tests
   mockAppId: MOCK_ENABLE_BANKING_APP_ID,
   mockPrivateKey: MOCK_ENABLE_BANKING_PRIVATE_KEY,


### PR DESCRIPTION
**Changes:**
- Add `transaction_date` field support (priority: `transaction_date` > `value_date` > `booking_date`)
- Include `accountExternalId` in hash generation (`entry_reference` is only unique per account)
- Update existing transactions when `booking_date` appears on re-sync (from `null` to an actual value)
- Add migration to recalculate `originalId` for existing transactions

**Why:**
Prevents duplicate transactions when banks progressively populate date fields