### PR TITLE
feat: Exclude same-account transactions from transfer linking list

### DIFF
--- a/packages/backend/src/controllers/transactions.controller/get-transaction.ts
+++ b/packages/backend/src/controllers/transactions.controller/get-transaction.ts
@@ -71,6 +71,12 @@ const schema = z.object({
           z.array(z.number().int().positive()),
         )
         .optional(),
+      excludeAccountIds: z
+        .preprocess(
+          (val) => (typeof val === 'string' ? parseCommaSeparatedNumbers(val) : val),
+          z.array(z.number().int().positive()),
+        )
+        .optional(),
       includeSplits: booleanQuery().optional(),
       includeTags: booleanQuery().optional(),
       excludeTransfer: booleanQuery().optional(),

--- a/packages/backend/src/services/transactions/get-transactions.e2e.ts
+++ b/packages/backend/src/services/transactions/get-transactions.e2e.ts
@@ -346,6 +346,42 @@ describe('Retrieve transactions with filters', () => {
     expect(res.every((t) => t.accountId === expense.accountId)).toBe(true);
   });
 
+  describe('excludeAccountIds', () => {
+    it('excludes transactions from the specified account', async () => {
+      const { income, expense } = await createMockTransactions();
+
+      const res = await helpers.getTransactions({
+        excludeAccountIds: [income.accountId],
+        raw: true,
+      });
+
+      // income is in accountA, expense is in accountB
+      // accountA has: income, transferIncome, refundOriginal, refundTx (4 txs)
+      // accountB has: expense, transferExpense (2 txs)
+      expect(res.length).toBe(2);
+      expect(res.every((t) => t.accountId !== income.accountId)).toBe(true);
+    });
+
+    it('excludes transactions from multiple accounts', async () => {
+      const { income, expense } = await createMockTransactions();
+
+      const res = await helpers.getTransactions({
+        excludeAccountIds: [income.accountId, expense.accountId],
+        raw: true,
+      });
+
+      expect(res.length).toBe(0);
+    });
+
+    it('returns all transactions when excludeAccountIds is not provided', async () => {
+      await createMockTransactions();
+
+      const res = await helpers.getTransactions({ raw: true });
+
+      expect(res.length).toBe(6);
+    });
+  });
+
   describe('filter by amount', () => {
     it('`amountLte`', async () => {
       await createMockTransactions();

--- a/packages/frontend/src/api/transactions.ts
+++ b/packages/frontend/src/api/transactions.ts
@@ -38,6 +38,7 @@ export const loadTransactions = async (params: {
   sort?: SORT_DIRECTIONS;
   excludeTransfer?: boolean;
   excludeRefunds?: boolean;
+  excludeAccountIds?: number[];
   transferFilter?: FILTER_OPERATION;
   refundFilter?: FILTER_OPERATION;
   startDate?: string;

--- a/packages/frontend/src/components/dialogs/manage-transaction/components/transfer-records-list.vue
+++ b/packages/frontend/src/components/dialogs/manage-transaction/components/transfer-records-list.vue
@@ -115,6 +115,7 @@ const fetchTransactions = ({ pageParam, filter }: { pageParam: number; filter: t
       transactionType: props.transactionType,
       excludeTransfer: true,
       excludeRefunds: true, // Exclude refund-linked transactions for transfers
+      excludeAccountIds: props.originAccountId ? [props.originAccountId] : undefined,
       endDate: isDate(filter.end) ? filter.end!.toISOString() : undefined,
       startDate: isDate(filter.start) ? filter.start!.toISOString() : undefined,
       amountGte: filter.amountGte ?? undefined,
@@ -133,6 +134,7 @@ const {
     ...VUE_QUERY_CACHE_KEYS.recordsPageTransactionList,
     'transfer-list',
     props.transactionType,
+    props.originAccountId,
     appliedFilters,
   ],
   queryFn: ({ pageParam }) => fetchTransactions({ pageParam, filter: appliedFilters.value }),


### PR DESCRIPTION
When linking a transfer, transactions from the origin account are now filtered out since transferring from an account to itself is not valid. Adds `excludeAccountIds` query param to GET `/transactions` endpoint