### PR TITLE
fix: Transfers recommendations

### DIFF
--- a/.claude/commands/review-all.md
+++ b/.claude/commands/review-all.md
@@ -1,0 +1,21 @@
+Run a comprehensive review of the current branch changes by launching multiple specialized review agents in parallel.
+
+## Steps
+
+1. First, run `git diff main...HEAD --name-only` to get the list of changed files and determine whether frontend files (`packages/frontend/`) are affected.
+
+2. Launch the following review agents **in parallel** using the Agent tool:
+   - **pr-review-toolkit:code-simplifier** — review changed code for reuse, simplification opportunities, and unnecessary complexity
+   - **pr-review-toolkit:code-reviewer** — review code for adherence to project guidelines, style, and best practices
+   - **pr-review-toolkit:pr-test-analyzer** — analyze test coverage quality and completeness for the changes
+
+3. If any frontend files were changed, also launch in the same parallel batch:
+   - **Frontend rules compliance check** — read `.claude/skills/frontend-rules/SKILL.md`, then review all changed frontend files against those conventions and report violations. Use a general-purpose Agent for this.
+
+4. After all agents complete, compile findings into a single organized report:
+   - **Code Simplification** — findings from code-simplifier
+   - **Code Quality** — findings from code-reviewer
+   - **Test Coverage** — findings from pr-test-analyzer
+   - **Frontend Rules Compliance** — findings from frontend check, or "N/A — no frontend changes"
+
+   For each section, list actionable items. If a section has no issues, mark it as clean.

--- a/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
@@ -13,6 +13,35 @@ describe('Create transaction controller', () => {
 
     expect(res.statusCode).toEqual(ERROR_CODES.ValidationError);
   });
+
+  it('should reject negative amount', async () => {
+    const account = await helpers.createAccount({ raw: true });
+
+    const res = await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: -100,
+      }),
+      raw: false,
+    });
+
+    expect(res.statusCode).toEqual(ERROR_CODES.ValidationError);
+  });
+
+  it('should reject zero amount', async () => {
+    const account = await helpers.createAccount({ raw: true });
+
+    const res = await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: 0,
+      }),
+      raw: false,
+    });
+
+    expect(res.statusCode).toEqual(ERROR_CODES.ValidationError);
+  });
+
   it('should successfully create a transaction base currency', async () => {
     const account = await helpers.createAccount({ raw: true });
     const txPayload = helpers.buildTransactionPayload({

--- a/packages/backend/src/controllers/transactions.controller/transfer-linking/get-transfer-recommendations.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/transfer-linking/get-transfer-recommendations.e2e.ts
@@ -176,7 +176,7 @@ describe('getTransferRecommendations', () => {
       });
     });
 
-    describe('date filtering (2 weeks, income.time >= expense.time)', () => {
+    describe('date filtering (±14 days symmetric window)', () => {
       it('includes income after expense within 2 weeks', async () => {
         const account1 = await helpers.createAccount({ raw: true });
         const account2 = await helpers.createAccount({ raw: true });
@@ -213,13 +213,13 @@ describe('getTransferRecommendations', () => {
         expect(response.some((tx) => tx.id === incomeAfter.id)).toBe(true);
       });
 
-      it('excludes income before expense when searching from expense', async () => {
+      it('includes income before expense within symmetric window', async () => {
         const account1 = await helpers.createAccount({ raw: true });
         const account2 = await helpers.createAccount({ raw: true });
 
         const expenseDate = startOfDay(new Date());
 
-        // Income 5 days before expense
+        // Income 5 days before expense (within ±14 days)
         const [incomeBefore] = await helpers.createTransaction({
           payload: helpers.buildTransactionPayload({
             accountId: account2.id,
@@ -246,8 +246,8 @@ describe('getTransferRecommendations', () => {
           raw: true,
         });
 
-        // Income before expense should NOT be found (money can't arrive before being sent)
-        expect(response.some((tx) => tx.id === incomeBefore.id)).toBe(false);
+        // Symmetric window: income before expense IS included
+        expect(response.some((tx) => tx.id === incomeBefore.id)).toBe(true);
       });
 
       it('includes expense before income when searching from income', async () => {
@@ -286,7 +286,7 @@ describe('getTransferRecommendations', () => {
         expect(response.some((tx) => tx.id === expenseBefore.id)).toBe(true);
       });
 
-      it('excludes transactions outside 2-week window', async () => {
+      it('excludes transactions outside 2-week window (forward)', async () => {
         const account1 = await helpers.createAccount({ raw: true });
         const account2 = await helpers.createAccount({ raw: true });
 
@@ -320,6 +320,155 @@ describe('getTransferRecommendations', () => {
         });
 
         expect(response.some((tx) => tx.id === incomeTooLate.id)).toBe(false);
+      });
+
+      it('excludes transactions outside 2-week window (backward)', async () => {
+        const account1 = await helpers.createAccount({ raw: true });
+        const account2 = await helpers.createAccount({ raw: true });
+
+        const expenseDate = startOfDay(new Date());
+
+        // Create expense
+        const [expenseTx] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account1.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: expenseDate.toISOString(),
+          }),
+          raw: true,
+        });
+
+        // Income 20 days before expense (outside 2 weeks backward)
+        const [incomeTooEarly] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account2.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.income,
+            time: subDays(expenseDate, 20).toISOString(),
+          }),
+          raw: true,
+        });
+
+        const response = await helpers.getTransferRecommendations({
+          transactionId: expenseTx.id,
+          raw: true,
+        });
+
+        expect(response.some((tx) => tx.id === incomeTooEarly.id)).toBe(false);
+      });
+
+      it('includes transaction exactly at 14-day boundary', async () => {
+        const account1 = await helpers.createAccount({ raw: true });
+        const account2 = await helpers.createAccount({ raw: true });
+
+        const expenseDate = startOfDay(new Date());
+
+        const [expenseTx] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account1.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: expenseDate.toISOString(),
+          }),
+          raw: true,
+        });
+
+        // Income exactly 14 days after (should be included due to endOfDay)
+        const [incomeAtBoundary] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account2.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.income,
+            time: addDays(expenseDate, 14).toISOString(),
+          }),
+          raw: true,
+        });
+
+        const response = await helpers.getTransferRecommendations({
+          transactionId: expenseTx.id,
+          raw: true,
+        });
+
+        expect(response.some((tx) => tx.id === incomeAtBoundary.id)).toBe(true);
+      });
+
+      it('excludes transaction at 15-day boundary', async () => {
+        const account1 = await helpers.createAccount({ raw: true });
+        const account2 = await helpers.createAccount({ raw: true });
+
+        const expenseDate = startOfDay(new Date());
+
+        const [expenseTx] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account1.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: expenseDate.toISOString(),
+          }),
+          raw: true,
+        });
+
+        // Income 15 days after (should be excluded)
+        const [incomeOutsideBoundary] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account2.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.income,
+            time: addDays(expenseDate, 15).toISOString(),
+          }),
+          raw: true,
+        });
+
+        const response = await helpers.getTransferRecommendations({
+          transactionId: expenseTx.id,
+          raw: true,
+        });
+
+        expect(response.some((tx) => tx.id === incomeOutsideBoundary.id)).toBe(false);
+      });
+
+      it('includes same-day transactions regardless of time-of-day differences', async () => {
+        const account1 = await helpers.createAccount({ raw: true });
+        const account2 = await helpers.createAccount({ raw: true });
+
+        const baseDate = startOfDay(new Date());
+        const expenseTime = new Date(baseDate);
+        expenseTime.setHours(14, 0, 0, 0);
+        const incomeTime = new Date(baseDate);
+        incomeTime.setHours(8, 0, 0, 0);
+
+        const [expenseTx] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account1.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: expenseTime.toISOString(),
+          }),
+          raw: true,
+        });
+
+        const [incomeTx] = await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account2.id,
+            amount: 100,
+            transactionType: TRANSACTION_TYPES.income,
+            time: incomeTime.toISOString(),
+          }),
+          raw: true,
+        });
+
+        const responseFromExpense = await helpers.getTransferRecommendations({
+          transactionId: expenseTx.id,
+          raw: true,
+        });
+        expect(responseFromExpense.some((tx) => tx.id === incomeTx.id)).toBe(true);
+
+        const responseFromIncome = await helpers.getTransferRecommendations({
+          transactionId: incomeTx.id,
+          raw: true,
+        });
+        expect(responseFromIncome.some((tx) => tx.id === expenseTx.id)).toBe(true);
       });
     });
 
@@ -487,7 +636,7 @@ describe('getTransferRecommendations', () => {
     });
 
     describe('result limiting', () => {
-      it('returns maximum 5 recommendations', async () => {
+      it('returns maximum 7 recommendations', async () => {
         const account1 = await helpers.createAccount({ raw: true });
         const account2 = await helpers.createAccount({ raw: true });
 
@@ -501,8 +650,8 @@ describe('getTransferRecommendations', () => {
           raw: true,
         });
 
-        // Create more than 5 income transactions
-        for (let i = 0; i < 7; i++) {
+        // Create more than 7 income transactions
+        for (let i = 0; i < 10; i++) {
           await helpers.createTransaction({
             payload: helpers.buildTransactionPayload({
               accountId: account2.id,
@@ -518,7 +667,7 @@ describe('getTransferRecommendations', () => {
           raw: true,
         });
 
-        expect(response.length).toBeLessThanOrEqual(5);
+        expect(response.length).toBeLessThanOrEqual(7);
       });
     });
 

--- a/packages/backend/src/controllers/transactions.controller/transfer-linking/get-transfer-recommendations.ts
+++ b/packages/backend/src/controllers/transactions.controller/transfer-linking/get-transfer-recommendations.ts
@@ -7,13 +7,14 @@ import Transactions, { getTransactionById } from '@models/Transactions.model';
 import { serializeTransactions } from '@root/serializers';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import * as transactionsService from '@services/transactions';
+import { addDays, endOfDay, startOfDay, subDays } from 'date-fns';
 import { z } from 'zod';
 
 // ±10% of refAmount for transfer recommendations
 const RECOMMENDATION_PERCENT_RANGE = 0.1;
-// 2 weeks date range
+// ±14 days from the transaction date
 const RECOMMENDATION_DAYS_RANGE = 14;
-const RECOMMENDATION_LIMIT = 5;
+const RECOMMENDATION_LIMIT = 7;
 
 const schema = z.object({
   query: z
@@ -105,30 +106,14 @@ export default createController(schema, async ({ user, query }) => {
   const refAmountGte = Money.fromCents(Math.max(0, Math.floor(centerCents * (1 - RECOMMENDATION_PERCENT_RANGE))));
   const refAmountLte = Money.fromCents(Math.ceil(centerCents * (1 + RECOMMENDATION_PERCENT_RANGE)));
 
-  // Calculate date range based on transaction type
-  // For transfers: income.time >= expense.time (money arrives after being sent)
-  let startDate: Date;
-  let endDate: Date;
-
-  if (query.transactionId) {
-    // Source is existing transaction
-    if (searchTransactionType === TRANSACTION_TYPES.income) {
-      // Source is expense, searching for income: income.time >= expense.time
-      startDate = new Date(sourceTime);
-      endDate = new Date(sourceTime);
-      endDate.setDate(endDate.getDate() + RECOMMENDATION_DAYS_RANGE);
-    } else {
-      // Source is income, searching for expense: expense.time <= income.time
-      startDate = new Date(sourceTime);
-      startDate.setDate(startDate.getDate() - RECOMMENDATION_DAYS_RANGE);
-      endDate = new Date(sourceTime);
-    }
-  } else {
-    // Form data - use current time as reference
-    startDate = new Date();
-    startDate.setDate(startDate.getDate() - RECOMMENDATION_DAYS_RANGE);
-    endDate = new Date();
-  }
+  // ±N days from the transaction date (symmetric window).
+  // For form data (new transaction), sourceTime is already set to `new Date()` above
+  // and we don't look forward since the transaction hasn't happened yet.
+  const referenceDate = new Date(sourceTime);
+  const startDate = subDays(startOfDay(referenceDate), RECOMMENDATION_DAYS_RANGE);
+  const endDate = query.transactionId
+    ? addDays(endOfDay(referenceDate), RECOMMENDATION_DAYS_RANGE)
+    : endOfDay(referenceDate);
 
   // Fetch more than needed to allow for filtering and sorting
   const fetchLimit = RECOMMENDATION_LIMIT * 3;

--- a/packages/backend/src/controllers/transactions.controller/update-transaction.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/update-transaction.e2e.ts
@@ -6,6 +6,30 @@ import { EXTERNAL_ACCOUNT_RESTRICTED_UPDATION_FIELDS } from '@services/transacti
 import * as helpers from '@tests/helpers';
 
 describe('Update transaction controller', () => {
+  it('should reject negative amount', async () => {
+    const [baseTx] = await helpers.createTransaction({ raw: true });
+
+    const res = await helpers.updateTransaction({
+      id: baseTx.id,
+      payload: { amount: -100 },
+      raw: false,
+    });
+
+    expect(res.statusCode).toEqual(ERROR_CODES.ValidationError);
+  });
+
+  it('should reject zero amount', async () => {
+    const [baseTx] = await helpers.createTransaction({ raw: true });
+
+    const res = await helpers.updateTransaction({
+      id: baseTx.id,
+      payload: { amount: 0 },
+      raw: false,
+    });
+
+    expect(res.statusCode).toEqual(ERROR_CODES.ValidationError);
+  });
+
   it('should make basic updation', async () => {
     const [baseTx] = await helpers.createTransaction({ raw: true });
     const txAmount = Number(baseTx.amount);

--- a/packages/backend/src/migrations/20260317000000-fix-negative-transaction-amounts.ts
+++ b/packages/backend/src/migrations/20260317000000-fix-negative-transaction-amounts.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    // Fix transactions that have negative amount, refAmount, or cashbackAmount.
+    // All monetary values in Transactions should be stored as positive integers
+    // (the sign is determined by transactionType: expense vs income).
+    await queryInterface.sequelize.query(`
+      UPDATE "Transactions"
+      SET
+        amount = ABS(amount),
+        "refAmount" = ABS("refAmount"),
+        "commissionRate" = ABS("commissionRate"),
+        "refCommissionRate" = ABS("refCommissionRate"),
+        "cashbackAmount" = ABS("cashbackAmount")
+      WHERE amount < 0 OR "refAmount" < 0 OR "commissionRate" < 0 OR "refCommissionRate" < 0 OR "cashbackAmount" < 0
+    `);
+  },
+
+  down: async (): Promise<void> => {
+    // Cannot reliably revert since we don't know which records were originally negative
+  },
+};


### PR DESCRIPTION
- change transfer recommendation date filtering from directional to ±14 days symmetric window with startOfDay/endOfDay normalization
- increase recommendation limit from 5 to 7
- add validation rejecting negative/zero amounts on create and update endpoints
- add migration to fix existing negative monetary values (all Money fields)
- add e2e tests for boundary conditions and negative amount validation