### PR TITLE
fix: investment portfolio UI improvements

### DIFF
--- a/packages/backend/src/services/investments/portfolios/transfers/list-portfolio-transfers.service.ts
+++ b/packages/backend/src/services/investments/portfolios/transfers/list-portfolio-transfers.service.ts
@@ -72,7 +72,10 @@ export async function listPortfolioTransfers({
       { model: Currencies, as: 'currency' },
       { model: Currencies, as: 'toCurrency' },
     ],
-    order: [[sortBy, sortDirection]],
+    order: [
+      [sortBy, sortDirection],
+      ['createdAt', sortDirection],
+    ],
     limit,
     offset,
   });

--- a/packages/frontend/src/components/forms/direct-cash-transaction-form.vue
+++ b/packages/frontend/src/components/forms/direct-cash-transaction-form.vue
@@ -18,6 +18,7 @@ import {
   usePortfolioToAccountTransfer,
 } from '@/composable/data-queries/portfolio-transfers';
 import { useFormValidation } from '@/composable/form-validator';
+import { usePortfolioBalances } from '@/composable/data-queries/portfolio-balances';
 import { useAccountsStore, useCurrenciesStore } from '@/stores';
 import type { AccountModel, PortfolioModel, TransactionModel, UserCurrencyModel } from '@bt/shared/types';
 import { TRANSACTION_TYPES } from '@bt/shared/types';
@@ -49,6 +50,38 @@ const accountsStore = useAccountsStore();
 const { systemAccounts, accountsRecord } = storeToRefs(accountsStore);
 const { currencies } = storeToRefs(useCurrenciesStore());
 const { formatAmountByCurrencyCode } = useFormatCurrency();
+const { data: portfolioBalances } = usePortfolioBalances(computed(() => props.portfolioId));
+
+const balancesByCurrency = computed(() => {
+  const map = new Map<string, number>();
+  if (portfolioBalances.value) {
+    for (const balance of portfolioBalances.value) {
+      map.set(balance.currencyCode, Number(balance.availableCash));
+    }
+  }
+  return map;
+});
+
+const sortedCurrencies = computed(() => {
+  const list = [...(currencies.value || [])];
+  return list.sort((a, b) => {
+    const balA = balancesByCurrency.value.get(a.currencyCode) ?? 0;
+    const balB = balancesByCurrency.value.get(b.currencyCode) ?? 0;
+    if (balA !== 0 && balB !== 0) return balB - balA;
+    if (balA !== 0) return -1;
+    if (balB !== 0) return 1;
+    return a.currencyCode.localeCompare(b.currencyCode);
+  });
+});
+
+const currencyLabel = (currency: UserCurrencyModel) => {
+  const code = currency.currency!.code;
+  const balance = balancesByCurrency.value.get(currency.currencyCode);
+  if (balance !== undefined && balance !== 0) {
+    return `${code} (${formatAmountByCurrencyCode(balance, currency.currencyCode)})`;
+  }
+  return code;
+};
 
 // Mutations
 const directCashMutation = useCreateDirectCashTransaction();
@@ -428,9 +461,9 @@ const accountLabel = computed(() =>
         <SelectField
           v-model="directForm.selectedCurrency"
           :label="$t('forms.directCashTransaction.currencyLabel')"
-          :values="currencies || []"
+          :values="sortedCurrencies"
           value-key="currencyCode"
-          :label-key="(currency: UserCurrencyModel) => currency.currency!.code"
+          :label-key="currencyLabel"
           :placeholder="$t('forms.directCashTransaction.currencyPlaceholder')"
           :disabled="isAnyMutationPending || disabled"
           :error-message="getDirectFieldError('directForm.selectedCurrency')"
@@ -501,9 +534,9 @@ const accountLabel = computed(() =>
             v-if="showTransferCurrency"
             v-model="transferForm.selectedCurrency"
             :label="$t('forms.directCashTransaction.currencyLabel')"
-            :values="currencies || []"
+            :values="sortedCurrencies"
             value-key="currencyCode"
-            :label-key="(currency: UserCurrencyModel) => currency.currency!.code"
+            :label-key="currencyLabel"
             :placeholder="$t('forms.directCashTransaction.currencyPlaceholder')"
             :disabled="isAnyMutationPending || disabled"
             :error-message="getTransferFieldError('transferForm.selectedCurrency')"

--- a/packages/frontend/src/components/forms/exchange-currency-form.vue
+++ b/packages/frontend/src/components/forms/exchange-currency-form.vue
@@ -5,6 +5,7 @@ import SelectField from '@/components/fields/select-field.vue';
 import TextareaField from '@/components/fields/textarea-field.vue';
 import UiButton from '@/components/lib/ui/button/Button.vue';
 import { NotificationType, useNotificationCenter } from '@/components/notification-center';
+import { useFormatCurrency } from '@/composable';
 import { usePortfolioBalances } from '@/composable/data-queries/portfolio-balances';
 import { useExchangeCurrency } from '@/composable/data-queries/portfolio-transfers';
 import { useFormValidation } from '@/composable/form-validator';
@@ -32,6 +33,7 @@ const emit = defineEmits<Emit>();
 const { t } = useI18n();
 const { addNotification } = useNotificationCenter();
 const { currencies } = storeToRefs(useCurrenciesStore());
+const { formatAmountByCurrencyCode } = useFormatCurrency();
 
 const portfolioId = toRef(props, 'portfolioId');
 const { data: balances } = usePortfolioBalances(portfolioId);
@@ -54,34 +56,51 @@ const form = reactive<{
   description: '',
 });
 
-// Sort currencies: portfolio balances first, then the rest
+const balancesByCurrency = computed(() => {
+  const map = new Map<string, number>();
+  if (balances.value) {
+    for (const balance of balances.value) {
+      map.set(balance.currencyCode, Number(balance.availableCash));
+    }
+  }
+  return map;
+});
+
+// Sort currencies: non-zero balances first (by amount desc), then the rest alphabetically
 const sortedCurrencies = computed(() => {
   if (!currencies.value) return [];
 
-  const balanceCodes = new Set(balances.value?.map((b) => b.currencyCode) ?? []);
-
   return [...currencies.value].sort((a, b) => {
-    const aHasBalance = balanceCodes.has(a.currencyCode);
-    const bHasBalance = balanceCodes.has(b.currencyCode);
-
-    if (aHasBalance && !bHasBalance) return -1;
-    if (!aHasBalance && bHasBalance) return 1;
+    const balA = balancesByCurrency.value.get(a.currencyCode) ?? 0;
+    const balB = balancesByCurrency.value.get(b.currencyCode) ?? 0;
+    if (balA !== 0 && balB !== 0) return balB - balA;
+    if (balA !== 0) return -1;
+    if (balB !== 0) return 1;
     return a.currencyCode.localeCompare(b.currencyCode);
   });
 });
 
+// Exclude the other field's selection so the same currency can't be picked in both
+const fromCurrencies = computed(() =>
+  sortedCurrencies.value.filter((c) => c.currencyCode !== form.toCurrency?.currencyCode),
+);
+const toCurrencies = computed(() =>
+  sortedCurrencies.value.filter((c) => c.currencyCode !== form.fromCurrency?.currencyCode),
+);
+
 const currencyLabel = (currency: UserCurrencyModel) => {
   const code = currency.currency?.code ?? currency.currencyCode;
-  const name = currency.currency?.currency;
-  return name ? `${code} — ${name}` : code;
+  const balance = balancesByCurrency.value.get(currency.currencyCode);
+  if (balance !== undefined && balance !== 0) {
+    return `${code} (${formatAmountByCurrencyCode(balance, currency.currencyCode)})`;
+  }
+  return code;
 };
 
 // Get available cash for the selected "from" currency
 const fromAvailableCash = computed(() => {
-  if (!form.fromCurrency || !balances.value) return null;
-
-  const balance = balances.value.find((b) => b.currencyCode === form.fromCurrency!.currencyCode);
-  return balance ? Number(balance.availableCash) : null;
+  if (!form.fromCurrency) return null;
+  return balancesByCurrency.value.get(form.fromCurrency.currencyCode) ?? null;
 });
 
 const handleMaxAmount = () => {
@@ -179,7 +198,7 @@ const onSubmit = async () => {
     <SelectField
       v-model="form.fromCurrency"
       :label="$t('forms.exchangeCurrency.fromCurrencyLabel')"
-      :values="sortedCurrencies"
+      :values="fromCurrencies"
       value-key="currencyCode"
       :label-key="currencyLabel"
       with-search
@@ -218,7 +237,7 @@ const onSubmit = async () => {
     <SelectField
       v-model="form.toCurrency"
       :label="$t('forms.exchangeCurrency.toCurrencyLabel')"
-      :values="sortedCurrencies"
+      :values="toCurrencies"
       value-key="currencyCode"
       :label-key="currencyLabel"
       with-search

--- a/packages/frontend/src/components/forms/portfolio-transfer-form.vue
+++ b/packages/frontend/src/components/forms/portfolio-transfer-form.vue
@@ -17,6 +17,7 @@ import {
   useLinkTransactionToPortfolio,
   usePortfolioToAccountTransfer,
 } from '@/composable/data-queries/portfolio-transfers';
+import { usePortfolioBalances } from '@/composable/data-queries/portfolio-balances';
 import { usePortfolios } from '@/composable/data-queries/portfolios';
 import { useFormValidation } from '@/composable/form-validator';
 import { formatUIAmount } from '@/js/helpers';
@@ -59,7 +60,7 @@ const accountToPortfolioMutation = useAccountToPortfolioTransfer();
 const portfolioToAccountMutation = usePortfolioToAccountTransfer();
 const linkToPortfolioMutation = useLinkTransactionToPortfolio();
 
-// Form state
+// Form state — defined before balance logic so balance computeds can reference it
 const form = reactive<{
   fromPortfolio: PortfolioModel | null;
   toPortfolio: PortfolioModel | null;
@@ -81,6 +82,41 @@ const form = reactive<{
   date: new Date(),
   description: '',
 });
+
+// Portfolio balance data for currency sorting
+const sourcePortfolioId = computed(() => form.fromPortfolio?.id ?? 0);
+const { data: portfolioBalances } = usePortfolioBalances(sourcePortfolioId);
+
+const balancesByCurrency = computed(() => {
+  const map = new Map<string, number>();
+  if (portfolioBalances.value) {
+    for (const balance of portfolioBalances.value) {
+      map.set(balance.currencyCode, Number(balance.availableCash));
+    }
+  }
+  return map;
+});
+
+const sortedCurrencies = computed(() => {
+  const list = [...(currencies.value || [])];
+  return list.sort((a, b) => {
+    const balA = balancesByCurrency.value.get(a.currencyCode) ?? 0;
+    const balB = balancesByCurrency.value.get(b.currencyCode) ?? 0;
+    if (balA !== 0 && balB !== 0) return balB - balA;
+    if (balA !== 0) return -1;
+    if (balB !== 0) return 1;
+    return a.currencyCode.localeCompare(b.currencyCode);
+  });
+});
+
+const currencyLabel = (currency: UserCurrencyModel) => {
+  const code = currency.currency!.code;
+  const balance = balancesByCurrency.value.get(currency.currencyCode);
+  if (balance !== undefined && balance !== 0) {
+    return `${code} (${formatAmountByCurrencyCode(balance, currency.currencyCode)})`;
+  }
+  return code;
+};
 
 // Computed values for easier access
 const transferType = computed(() => form.transferTypeOption?.value || 'portfolio-to-portfolio');
@@ -489,8 +525,12 @@ const isSubmitDisabled = computed(() => {
       :values="availableToPortfolios"
       value-key="id"
       label-key="name"
-      :placeholder="$t('forms.portfolioTransfer.toPortfolioPlaceholder')"
-      :disabled="isAnyMutationPending || disabled"
+      :placeholder="
+        availableToPortfolios.length
+          ? $t('forms.portfolioTransfer.toPortfolioPlaceholder')
+          : $t('forms.portfolioTransfer.noPortfoliosAvailable')
+      "
+      :disabled="isAnyMutationPending || disabled || !availableToPortfolios.length"
     />
 
     <SelectField
@@ -538,9 +578,9 @@ const isSubmitDisabled = computed(() => {
         v-if="transferType !== 'account-to-portfolio'"
         v-model="form.selectedCurrency"
         :label="$t('forms.portfolioTransfer.currencyLabel')"
-        :values="currencies || []"
+        :values="sortedCurrencies"
         value-key="currencyCode"
-        :label-key="(currency: UserCurrencyModel) => currency.currency!.code"
+        :label-key="currencyLabel"
         :placeholder="$t('forms.portfolioTransfer.currencyPlaceholder')"
         :disabled="isAnyMutationPending || disabled"
         :error-message="getFieldErrorMessage('form.selectedCurrency')"

--- a/packages/frontend/src/i18n/locales/chunks/en/forms.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/forms.json
@@ -87,7 +87,8 @@
         "error": "Transfer failed. Please try again."
       },
       "linkExistingTransaction": "Link existing transaction",
-      "linkedTransactionLabel": "Transaction"
+      "linkedTransactionLabel": "Transaction",
+      "noPortfoliosAvailable": "No other portfolios available"
     },
     "createAccount": {
       "nameLabel": "Account name",

--- a/packages/frontend/src/i18n/locales/chunks/uk/forms.json
+++ b/packages/frontend/src/i18n/locales/chunks/uk/forms.json
@@ -87,7 +87,8 @@
         "error": "Переказ не вдався. Спробуйте ще раз."
       },
       "linkExistingTransaction": "Прив'язати існуючу транзакцію",
-      "linkedTransactionLabel": "Транзакція"
+      "linkedTransactionLabel": "Транзакція",
+      "noPortfoliosAvailable": "Немає інших доступних портфелів"
     },
     "createAccount": {
       "nameLabel": "Назва рахунку",

--- a/packages/frontend/src/pages/investments/components/portfolio-card-balance.vue
+++ b/packages/frontend/src/pages/investments/components/portfolio-card-balance.vue
@@ -49,7 +49,7 @@ const { data: summary, isLoading } = usePortfolioSummary(portfolioId);
 const { formatCompactAmount } = useFormatCurrency();
 
 const hasValue = computed(
-  () => summary.value && summary.value.totalCurrentValue !== undefined && summary.value.totalCurrentValue !== null,
+  () => summary.value && summary.value.totalPortfolioValue !== undefined && summary.value.totalPortfolioValue !== null,
 );
 
 const findUserCurrency = (currencyCode: string) =>
@@ -63,7 +63,7 @@ const formatCurrency = ({ amount, currencyCode }: { amount: number; currencyCode
 const formattedValue = computed(() => {
   if (!summary.value) return '';
   return formatCurrency({
-    amount: Number(summary.value.totalCurrentValue),
+    amount: Number(summary.value.totalPortfolioValue),
     currencyCode: summary.value.currencyCode,
   });
 });


### PR DESCRIPTION
- Show currency balances in transfer/withdrawal/exchange dropdowns, sorted by amount
- Add secondary sort by createdAt for same-day cash transactions
- Include cash balance in portfolio total value on /investments page
- Prevent selecting same currency in exchange dialog
- Disable "To Portfolio" field when no other portfolios available