### PR TITLE
fix: Sentry issues

### DIFF
--- a/packages/backend/src/app.ts
+++ b/packages/backend/src/app.ts
@@ -40,43 +40,42 @@ logger.info('Attempting to start server...');
 
 let serverInstance: https.Server | ReturnType<typeof app.listen>;
 
-const certPath = path.join(__dirname, '../../../docker/dev/certs/cert.pem');
-const keyPath = path.join(__dirname, '../../../docker/dev/certs/key.pem');
-const certsExist = fs.existsSync(certPath) && fs.existsSync(keyPath);
+const isProduction = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
 
-// Use HTTPS when certs exist (dev or prod), HTTP for tests or when no certs
-if (process.env.NODE_ENV !== 'test' && certsExist) {
-  const httpsOptions = {
-    key: fs.readFileSync(keyPath),
-    cert: fs.readFileSync(certPath),
-  };
+const onServerReady = ({ protocol }: { protocol: 'http' | 'https' }) => {
+  const port = app.get('port') as number;
+  logger.info(`[OK] ${protocol.toUpperCase()} Server is running on ${protocol}://localhost:${port}`);
+  logger.info(`API Prefix: ${API_PREFIX}`);
+  initializeBackgroundJobs();
+};
 
-  serverInstance = https.createServer(httpsOptions, app);
-  serverInstance.listen(app.get('port'), () => {
-    logger.info(`[OK] HTTPS Server is running on https://localhost:${app.get('port')}`);
-    logger.info(`API Prefix: ${API_PREFIX}`);
-    initializeBackgroundJobs();
-  });
-} else if (process.env.NODE_ENV !== 'test' && !certsExist) {
-  // Non-test mode without certs - warn but allow HTTP (for CI/CD or reverse proxy setups)
-  logger.warn(`SSL certificates not found at ${certPath} and ${keyPath}`);
-  logger.warn('Running in HTTP mode. For HTTPS, run: cd docker/dev/certs && mkcert localhost 127.0.0.1 ::1');
-
-  serverInstance = app.listen(app.get('port'), () => {
-    logger.info(`[OK] HTTP Server is running on http://localhost:${app.get('port')}`);
-    logger.info(`API Prefix: ${API_PREFIX}`);
-    initializeBackgroundJobs();
-  });
+if (isTest) {
+  // Test mode: HTTP on a random port to avoid conflicts with parallel runs
+  serverInstance = app.listen(0, () => onServerReady({ protocol: 'http' }));
+} else if (isProduction) {
+  // Production: always HTTP — TLS is terminated by the reverse proxy (Traefik)
+  serverInstance = app.listen(app.get('port'), () => onServerReady({ protocol: 'http' }));
 } else {
-  // Test mode uses HTTP for simplicity
-  // Cause some tests can be parallelized, the port might be in use, so we need to allow dynamic port
-  serverInstance = app.listen(0, () => {
-    logger.info(
-      `[OK] ${String(process.env.NODE_ENV).toUpperCase()} server is running on http://localhost:${app.get('port')}`,
-    );
-    logger.info(`API Prefix: ${API_PREFIX}`);
-    initializeBackgroundJobs();
-  });
+  // Dev: use HTTPS if local certs exist, otherwise fall back to HTTP
+  const certPath = path.join(__dirname, '../../../docker/dev/certs/cert.pem');
+  const keyPath = path.join(__dirname, '../../../docker/dev/certs/key.pem');
+  const certsExist = fs.existsSync(certPath) && fs.existsSync(keyPath);
+
+  if (certsExist) {
+    const httpsOptions = {
+      key: fs.readFileSync(keyPath),
+      cert: fs.readFileSync(certPath),
+    };
+
+    serverInstance = https.createServer(httpsOptions, app);
+    serverInstance.listen(app.get('port'), () => onServerReady({ protocol: 'https' }));
+  } else {
+    logger.warn(`SSL certificates not found at ${certPath} and ${keyPath}`);
+    logger.warn('Running in HTTP mode. For HTTPS, run: cd docker/dev/certs && mkcert localhost 127.0.0.1 ::1');
+
+    serverInstance = app.listen(app.get('port'), () => onServerReady({ protocol: 'http' }));
+  }
 }
 
 export { serverInstance };

--- a/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
+++ b/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
@@ -128,9 +128,10 @@ const securitiesPricesSyncImpl = async (): Promise<SecuritiesPricesSyncResult> =
 
         result.successfulUpdates = securityPricesToUpsert.length;
         logger.info(`Bulk created/updated ${securityPricesToUpsert.length} security prices`);
-      } catch {
-        logger.warn(
-          `Bulk create failed, falling back to individual upserts for ${securityPricesToUpsert.length} records`,
+      } catch (bulkError) {
+        const bulkErrorMessage = bulkError instanceof Error ? bulkError.message : 'Unknown error';
+        logger.info(
+          `Bulk create failed (${bulkErrorMessage}), falling back to individual upserts for ${securityPricesToUpsert.length} records`,
         );
 
         for (const priceData of securityPricesToUpsert) {
@@ -151,7 +152,7 @@ const securitiesPricesSyncImpl = async (): Promise<SecuritiesPricesSyncResult> =
               error: errorMessage,
             });
 
-            logger.warn(
+            logger.error(
               `Failed to upsert price for security ${security?.symbol || priceData.securityId}: ${errorMessage}`,
             );
           }

--- a/packages/backend/src/services/subscriptions/get-subscriptions-summary.ts
+++ b/packages/backend/src/services/subscriptions/get-subscriptions-summary.ts
@@ -51,6 +51,7 @@ const getSubscriptionsSummaryImpl = async ({ userId, type }: GetSubscriptionsSum
         userId,
         date: new Date(),
         baseCode: sub.expectedCurrencyCode!,
+        quoteCode: baseCurrencyCode,
       });
 
       const multiplier = MONTHLY_MULTIPLIERS[sub.frequency] ?? 1;

--- a/packages/backend/src/services/tx-refunds/create-single-refund.service.ts
+++ b/packages/backend/src/services/tx-refunds/create-single-refund.service.ts
@@ -103,7 +103,7 @@ export const createSingleRefund = withTransaction(
 
         // Check if refund amount is not greater than target amount
         // When targeting a split, compare against split's refAmount; otherwise use transaction's refAmount
-        const targetRefAmount = targetSplit ? Number(targetSplit.refAmount) : originalTx.refAmount.toNumber();
+        const targetRefAmount = targetSplit ? targetSplit.refAmount.toNumber() : originalTx.refAmount.toNumber();
         if (Math.abs(refundTx.refAmount.toNumber()) > Math.abs(targetRefAmount)) {
           throw new ValidationError({
             message: targetSplit
@@ -160,7 +160,7 @@ export const createSingleRefund = withTransaction(
         }, Math.abs(refundTx.refAmount.toNumber()));
 
         // Check if the new refund would exceed the target amount (split or transaction)
-        const targetRefAmount = targetSplit ? Number(targetSplit.refAmount) : originalTx.refAmount.toNumber();
+        const targetRefAmount = targetSplit ? targetSplit.refAmount.toNumber() : originalTx.refAmount.toNumber();
         if (totalRefundedAmount > Math.abs(targetRefAmount)) {
           throw new ValidationError({
             message: targetSplit

--- a/packages/frontend/src/composable/use-account-currency-code.ts
+++ b/packages/frontend/src/composable/use-account-currency-code.ts
@@ -1,18 +1,10 @@
-import { useCurrenciesStore } from "@/stores";
-import { AccountModel } from "@bt/shared/types";
-import { storeToRefs } from "pinia";
-import { type Ref, computed } from "vue";
+import { useCurrenciesStore } from '@/stores';
+import { AccountModel } from '@bt/shared/types';
+import { storeToRefs } from 'pinia';
+import { type Ref, computed } from 'vue';
 
-export const useAccountCurrencyCode = ({
-  account,
-}: {
-  account: Ref<AccountModel>;
-}) => {
+export const useAccountCurrencyCode = ({ account }: { account: Ref<AccountModel> }) => {
   const { currenciesMap } = storeToRefs(useCurrenciesStore());
 
-  return computed(
-    () =>
-      currenciesMap.value[account.value.currencyCode]?.currency?.code ??
-      account.value.currencyCode,
-  );
+  return computed(() => currenciesMap.value[account.value.currencyCode]?.currency?.code ?? account.value.currencyCode);
 };


### PR DESCRIPTION
Fixes several Sentry issues

<hr> 

### fix: refund split validation and N+1 query on subscriptions summary

Fix Money object conversion in refund validation — `Number(splitRefAmount)` returned NaN for Money instances, breaking split refund amount checks. Changed to `.toNumber()` on both validation points (single refund and cumulative refund checks).

Fix N+1 query on GET /api/v1/subscriptions/summary by passing the already-fetched `baseCurrencyCode` as `quoteCode` to `calculateRefAmount`, eliminating redundant UsersCurrencies queries per subscription iteration.

Fixes MONEY-MATTER-BACKEND-3K
Fixes MONEY-MATTER-BACKEND-3H

<hr>

### fix: prevent dev cert warnings from being reported to Sentry in preview env

Preview runs the production Docker image (NODE_ENV=production) without SSL certs, causing logger.warn → Sentry on every startup.

Production sits behind Traefik which handles TLS, so the app should always start in plain HTTP there. Moved the dev cert check into the dev-only branch.

Also extracted a shared onServerReady callback to deduplicate listen handlers.

Fixes MONEY-MATTER-BACKEND-3, MONEY-MATTER-BACKEND-4

<hr> 

### fix: reduce Sentry noise from securities price bulk upsert fallback

Demotes the handled fallback to info so it no longer fires a Sentry alert, captures the original bulk error message for visibility, and upgrades individual upsert failures to error so real failures still page. Fixes MONEY-MATTER-BACKEND-6