### PR TITLE
fix: upgrade lodash/lodash-es to 4.18.x to resolve prototype pollution CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18648,15 +18648,15 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -27037,7 +27037,7 @@
         "i18next-fs-backend": "^2.6.1",
         "ioredis": "^5.8.2",
         "js-tiktoken": "^1.0.21",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "morgan": "^1.10.1",
         "pdf-parse": "^1.1.0",
         "pg": "8.11.5",
@@ -27297,7 +27297,7 @@
         "d3": "^7.9.0",
         "date-fns": "^3.6.0",
         "fuse.js": "^7.1.0",
-        "lodash-es": "^4.17.21",
+        "lodash-es": "^4.18.0",
         "lucide-vue-next": "0.559.0",
         "pinia": "^2.3.0",
         "posthog-js": "^1.316.0",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -50,7 +50,7 @@
     "i18next-fs-backend": "^2.6.1",
     "ioredis": "^5.8.2",
     "js-tiktoken": "^1.0.21",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "morgan": "^1.10.1",
     "pdf-parse": "^1.1.0",
     "pg": "8.11.5",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -40,7 +40,7 @@
     "d3": "^7.9.0",
     "date-fns": "^3.6.0",
     "fuse.js": "^7.1.0",
-    "lodash-es": "^4.17.21",
+    "lodash-es": "^4.18.0",
     "lucide-vue-next": "0.559.0",
     "pinia": "^2.3.0",
     "posthog-js": "^1.316.0",


### PR DESCRIPTION
Resolves Dependabot alerts #94 (CVE-2026-4800, high) and #95 (CVE-2026-2950, medium).