### PR TITLE
fix: Unblock e2e tests on preview deployments

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -227,6 +227,13 @@ jobs:
                   docker exec -i preview-pr-${PR_NUMBER}-db psql -U preview -d budget_tracker_preview
 
                 echo "Database restore completed!"
+
+                # JWKS private keys in the backup are AES-encrypted with the prod
+                # BETTER_AUTH_SECRET. Preview uses a different secret, so better-auth
+                # would throw on every getSession (oauth-provider plugin forces the jwt
+                # code path). Clear them so better-auth regenerates with the preview secret.
+                docker exec -i preview-pr-${PR_NUMBER}-db \
+                  psql -U preview -d budget_tracker_preview -c 'TRUNCATE ba_jwks;'
               fi
 
               # Start the full stack (backend will auto-run migrations)
@@ -281,8 +288,28 @@ jobs:
         if: steps.prepare-env.outputs.cache-hit != 'true'
         run: npm ci --ignore-scripts
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+        working-directory: packages/frontend
+
+      - name: Install Playwright OS deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
         working-directory: packages/frontend
 
       - name: Run Playwright tests

--- a/packages/backend/src/middlewares/better-auth.ts
+++ b/packages/backend/src/middlewares/better-auth.ts
@@ -30,10 +30,15 @@ export function invalidateAppUserCache({ authUserId }: { authUserId: string }): 
  */
 export const authenticateSession = async (req: Request, res: Response, next: NextFunction) => {
   try {
-    // Get session from better-auth using request headers (cookies)
-    const session = await auth.api.getSession({
-      headers: req.headers as unknown as Headers,
-    });
+    // better-auth expects a Fetch API Headers instance, not Express's plain
+    // headers object. Cast-only was silently throwing inside getSession.
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+      if (value === undefined) continue;
+      headers.set(key, Array.isArray(value) ? value.join(', ') : value);
+    }
+
+    const session = await auth.api.getSession({ headers });
 
     if (!session || !session.user) {
       return res.status(401).json({

--- a/packages/backend/src/tests/mocks/better-auth/index.ts
+++ b/packages/backend/src/tests/mocks/better-auth/index.ts
@@ -198,9 +198,15 @@ export function betterAuth(config: BetterAuthConfig): AuthInstance {
 
     api: {
       getSession: async ({ headers }: { headers: unknown }) => {
-        // Check for session cookie in headers
-        const headerObj = headers as Record<string, string | undefined>;
-        const cookie = headerObj.cookie || headerObj.Cookie;
+        // Middleware may pass a Fetch Headers instance (real better-auth shape)
+        // or a plain object (older callers). Support both.
+        let cookie: string | undefined;
+        if (headers instanceof Headers) {
+          cookie = headers.get('cookie') ?? headers.get('Cookie') ?? undefined;
+        } else {
+          const headerObj = headers as Record<string, string | undefined>;
+          cookie = headerObj.cookie || headerObj.Cookie;
+        }
         const sessionToken = extractSessionToken(cookie);
 
         if (sessionToken) {

--- a/packages/frontend/e2e/tests/transfers/account-to-portfolio-manage-tx.spec.ts
+++ b/packages/frontend/e2e/tests/transfers/account-to-portfolio-manage-tx.spec.ts
@@ -117,7 +117,7 @@ test.describe('Manage-transaction dialog: account-to-portfolio transfer', () => 
     await createTransaction({
       request: page.request,
       accountId: testAccount.id,
-      amount: -75,
+      amount: 75,
       transactionType: 'expense',
     });
 


### PR DESCRIPTION
## Summary

Splits the e2e / preview-deploy fixes out of the light-theme branch so they can ship independently. Five issues bundled into one commit:

- **better-auth middleware (`packages/backend/src/middlewares/better-auth.ts`)** — passed `req.headers as unknown as Headers` to `auth.api.getSession`. Express's plain headers object has no `.get()` method, so better-auth silently saw no cookie and returned `null` → every protected route 401'd even with a valid session. Now builds a real `Fetch Headers` instance.
- **better-auth test mock (`packages/backend/src/tests/mocks/better-auth/index.ts`)** — accept both `Headers` instances and plain objects so tests line up with the new middleware call shape.
- **Preview deploy workflow (`.github/workflows/preview-deploy.yml`)** — `TRUNCATE ba_jwks` right after restoring the R2 backup. JWKS private keys are AES-encrypted with `BETTER_AUTH_SECRET`; preview uses `PREVIEW_BETTER_AUTH_SECRET`, so without this every `getSession` throws `Failed to decrypt private key` (the oauth-provider plugin forces the jwt plugin's decrypt code path).
- **Playwright browser cache** — resolve the `@playwright/test` version from `package-lock.json` and cache `~/.cache/ms-playwright` under that key. On hit we skip the ~28s download and only run `install-deps chromium` for apt packages.
- **E2E test amount (`account-to-portfolio-manage-tx.spec.ts`)** — switch `amount: -75` → `amount: 75`. `create-transaction.ts` enforces `z.number().positive()`, and `transactionType: 'expense'` already encodes direction.

## Why separate from the light-theme PR

We don't yet know when the light-theme branch will merge, and these fixes unblock the preview-deploy CI pipeline for *every* PR, not just that one.

## Test plan

- [ ] Preview Deploy workflow runs against this PR with the `preview` label
- [ ] `deploy` job succeeds (first-deploy path will hit the new `TRUNCATE ba_jwks` step)
- [ ] `test-preview` job goes green — Playwright suite passes end-to-end
- [ ] Follow-up run shows the `Cache Playwright browsers` step as a cache hit and skips the full install