### PR TITLE
fix: banks connection bugs

### DIFF
--- a/packages/backend/src/controllers/bank-data-providers/connections/reconcile-duplicates-for-account.ts
+++ b/packages/backend/src/controllers/bank-data-providers/connections/reconcile-duplicates-for-account.ts
@@ -1,0 +1,23 @@
+import { createController } from '@controllers/helpers/controller-factory';
+import { reconcileDuplicatesForAccount } from '@root/services/bank-data-providers/connection/reconcile-duplicates-for-account';
+import { z } from 'zod';
+
+export default createController(
+  z.object({
+    params: z.object({
+      connectionId: z.coerce.number(),
+    }),
+    body: z.object({
+      accountId: z.number(),
+    }),
+  }),
+  async ({ user, params, body }) => {
+    const result = await reconcileDuplicatesForAccount({
+      connectionId: params.connectionId,
+      userId: user.id,
+      accountId: body.accountId,
+    });
+
+    return { data: result };
+  },
+);

--- a/packages/backend/src/i18n/locales/en.json
+++ b/packages/backend/src/i18n/locales/en.json
@@ -178,6 +178,7 @@
     "onlySupportedForMonobank": "Loading transactions for period is only supported for Monobank",
     "transactionLoadingQueued": "Transaction loading queued. Estimated time: {{minutes}} minute(s)",
     "noValidAccountIds": "None of the selected account IDs are valid",
+    "accountCurrencyNotSupported": "Account currency \"{{currency}}\" is not supported by this system.",
     "monobank": {
       "invalidCredentialsFormat": "Invalid credentials format for Monobank",
       "invalidApiToken": "Invalid Monobank API token",

--- a/packages/backend/src/i18n/locales/en.json
+++ b/packages/backend/src/i18n/locales/en.json
@@ -176,6 +176,7 @@
     "fromMustBeValidDate": "\"from\" must be a valid date string",
     "toMustBeValidDate": "\"to\" must be a valid date string",
     "onlySupportedForMonobank": "Loading transactions for period is only supported for Monobank",
+    "reconciliationOnlyForEnableBanking": "Reconciliation is only available for Enable Banking connections",
     "transactionLoadingQueued": "Transaction loading queued. Estimated time: {{minutes}} minute(s)",
     "noValidAccountIds": "None of the selected account IDs are valid",
     "accountCurrencyNotSupported": "Account currency \"{{currency}}\" is not supported by this system.",

--- a/packages/backend/src/i18n/locales/uk.json
+++ b/packages/backend/src/i18n/locales/uk.json
@@ -179,6 +179,7 @@
     "fromMustBeValidDate": "\"from\" повинен бути дійсним рядком дати",
     "toMustBeValidDate": "\"to\" повинен бути дійсним рядком дати",
     "onlySupportedForMonobank": "Завантаження транзакцій за період підтримується лише для Monobank",
+    "reconciliationOnlyForEnableBanking": "Узгодження дублікатів доступне лише для з'єднань Enable Banking",
     "transactionLoadingQueued": "Завантаження транзакцій додано в чергу. Орієнтовний час: {{minutes}} хв.",
     "noValidAccountIds": "Жоден з обраних ID рахунків не є дійсним",
     "accountCurrencyNotSupported": "Валюта рахунку \"{{currency}}\" не підтримується системою.",

--- a/packages/backend/src/i18n/locales/uk.json
+++ b/packages/backend/src/i18n/locales/uk.json
@@ -181,6 +181,7 @@
     "onlySupportedForMonobank": "Завантаження транзакцій за період підтримується лише для Monobank",
     "transactionLoadingQueued": "Завантаження транзакцій додано в чергу. Орієнтовний час: {{minutes}} хв.",
     "noValidAccountIds": "Жоден з обраних ID рахунків не є дійсним",
+    "accountCurrencyNotSupported": "Валюта рахунку \"{{currency}}\" не підтримується системою.",
     "monobank": {
       "invalidCredentialsFormat": "Недійсний формат облікових даних для Monobank",
       "invalidApiToken": "Недійсний API токен Monobank",

--- a/packages/backend/src/migrations/20260424000000-add-unique-index-account-groups-bank-connection.ts
+++ b/packages/backend/src/migrations/20260424000000-add-unique-index-account-groups-bank-connection.ts
@@ -1,0 +1,40 @@
+import { QueryInterface, Transaction } from 'sequelize';
+
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const t: Transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      // Partial unique index: at most one AccountGroup per bank connection.
+      // Partial (WHERE NOT NULL) because the column is nullable for non-bank groups.
+      // Required to make findOrCreate races safe in connect-selected-accounts.
+      await queryInterface.sequelize.query(
+        `CREATE UNIQUE INDEX "account_groups_bank_data_provider_connection_id_unique"
+         ON "AccountGroups" ("bankDataProviderConnectionId")
+         WHERE "bankDataProviderConnectionId" IS NOT NULL`,
+        { transaction: t },
+      );
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    const t: Transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      await queryInterface.sequelize.query(
+        'DROP INDEX IF EXISTS "account_groups_bank_data_provider_connection_id_unique"',
+        { transaction: t },
+      );
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
+  },
+};

--- a/packages/backend/src/migrations/20260424000000-add-unique-index-account-groups-bank-connection.ts
+++ b/packages/backend/src/migrations/20260424000000-add-unique-index-account-groups-bank-connection.ts
@@ -5,6 +5,58 @@ module.exports = {
     const t: Transaction = await queryInterface.sequelize.transaction();
 
     try {
+      // Dedup any pre-existing duplicate AccountGroups before adding the
+      // unique index. The previous findOrCreate({ bankDataProviderConnectionId,
+      // userId }) in connect-selected-accounts has been live since
+      // 2026-03-15 and is racy under concurrent reconnects/double-clicks, so
+      // production may have accumulated rows that would block the index
+      // creation below. For each connection: keep the smallest-id group,
+      // re-home any AccountGroupings rows from the losers into the keeper
+      // (skipping rows that would violate the existing unique(accountId,
+      // groupId) constraint), then delete the loser groups.
+      await queryInterface.sequelize.query(
+        `INSERT INTO "AccountGroupings" ("accountId", "groupId", "createdAt", "updatedAt")
+         SELECT DISTINCT ag."accountId", d.keeper_id, NOW(), NOW()
+         FROM "AccountGroupings" ag
+         JOIN (
+           SELECT
+             id,
+             MIN(id) OVER (PARTITION BY "bankDataProviderConnectionId") AS keeper_id
+           FROM "AccountGroups"
+           WHERE "bankDataProviderConnectionId" IS NOT NULL
+         ) d ON ag."groupId" = d.id AND d.id <> d.keeper_id
+         ON CONFLICT ("accountId", "groupId") DO NOTHING`,
+        { transaction: t },
+      );
+
+      await queryInterface.sequelize.query(
+        `DELETE FROM "AccountGroupings"
+         WHERE "groupId" IN (
+           SELECT id FROM (
+             SELECT
+               id,
+               MIN(id) OVER (PARTITION BY "bankDataProviderConnectionId") AS keeper_id
+             FROM "AccountGroups"
+             WHERE "bankDataProviderConnectionId" IS NOT NULL
+           ) d WHERE id <> keeper_id
+         )`,
+        { transaction: t },
+      );
+
+      await queryInterface.sequelize.query(
+        `DELETE FROM "AccountGroups"
+         WHERE id IN (
+           SELECT id FROM (
+             SELECT
+               id,
+               MIN(id) OVER (PARTITION BY "bankDataProviderConnectionId") AS keeper_id
+             FROM "AccountGroups"
+             WHERE "bankDataProviderConnectionId" IS NOT NULL
+           ) d WHERE id <> keeper_id
+         )`,
+        { transaction: t },
+      );
+
       // Partial unique index: at most one AccountGroup per bank connection.
       // Partial (WHERE NOT NULL) because the column is nullable for non-bank groups.
       // Required to make findOrCreate races safe in connect-selected-accounts.

--- a/packages/backend/src/models/currencies.model.ts
+++ b/packages/backend/src/models/currencies.model.ts
@@ -77,9 +77,9 @@ export const getAllCurrencies = async () => {
   return currencies;
 };
 
-export async function getCurrency({ currency }: { currency: string }): Promise<Currencies>;
-export async function getCurrency({ number }: { number: number }): Promise<Currencies>;
-export async function getCurrency({ code }: { code: string }): Promise<Currencies>;
+export async function getCurrency({ currency }: { currency: string }): Promise<Currencies | null>;
+export async function getCurrency({ number }: { number: number }): Promise<Currencies | null>;
+export async function getCurrency({ code }: { code: string }): Promise<Currencies | null>;
 export async function getCurrency({
   currency,
   number,

--- a/packages/backend/src/routes/bank-data-providers.route.ts
+++ b/packages/backend/src/routes/bank-data-providers.route.ts
@@ -8,6 +8,7 @@ import listExternalAccounts from '@controllers/bank-data-providers/connections/l
 import listUserConnections from '@controllers/bank-data-providers/connections/list-user-connections';
 import loadTransactionsForPeriod from '@controllers/bank-data-providers/connections/load-transactions-for-period';
 import reauthorizeConnection from '@controllers/bank-data-providers/connections/reauthorize-connection';
+import reconcileDuplicatesForAccount from '@controllers/bank-data-providers/connections/reconcile-duplicates-for-account';
 import syncTransactionsForAccount from '@controllers/bank-data-providers/connections/sync-transactions-for-account';
 import updateConnectionDetails from '@controllers/bank-data-providers/connections/update-connection-details';
 import listBanks from '@controllers/bank-data-providers/enablebanking/list-banks';
@@ -97,6 +98,13 @@ router.post(
   blockDemoUsers,
   validateEndpoint(syncTransactionsForAccount.schema),
   syncTransactionsForAccount.handler,
+);
+router.post(
+  '/connections/:connectionId/reconcile-duplicates',
+  authenticateSession,
+  blockDemoUsers,
+  validateEndpoint(reconcileDuplicatesForAccount.schema),
+  reconcileDuplicatesForAccount.handler,
 );
 router.post(
   '/connections/:connectionId/load-transactions-for-period',

--- a/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
@@ -121,6 +121,14 @@ const createAccountsForConnection = withTransaction(
       } else {
         // Ensure user has the currency for this account
         const currency = await getCurrency({ code: providerAccount.currency.toUpperCase() });
+        if (!currency) {
+          throw new BadRequestError({
+            message: t({
+              key: 'bankDataProviders.accountCurrencyNotSupported',
+              variables: { currency: providerAccount.currency },
+            }),
+          });
+        }
         await addUserCurrencies([{ userId, currencyCode: currency.code }]);
 
         const now = new Date();

--- a/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
@@ -123,12 +123,24 @@ const createAccountsForConnection = withTransaction(
         const currency = await getCurrency({ code: providerAccount.currency.toUpperCase() });
         await addUserCurrencies([{ userId, currencyCode: currency.code }]);
 
+        const now = new Date();
         const accountRefBalance = await calculateRefAmount({
           amount: Money.fromCents(providerAccount.balance),
           userId,
-          date: new Date(),
+          date: now,
           baseCode: providerAccount.currency,
         });
+
+        const creditLimitCents = (providerAccount.metadata?.creditLimit as number) || 0;
+        const refCreditLimit =
+          creditLimitCents > 0
+            ? await calculateRefAmount({
+                amount: Money.fromCents(creditLimitCents),
+                userId,
+                date: now,
+                baseCode: providerAccount.currency,
+              })
+            : Money.zero();
 
         // Create new account
         const accountName =
@@ -146,8 +158,8 @@ const createAccountsForConnection = withTransaction(
           refInitialBalance: accountRefBalance,
           currentBalance: providerAccount.balance,
           refCurrentBalance: accountRefBalance,
-          creditLimit: (providerAccount.metadata?.creditLimit as number) || 0,
-          refCreditLimit: (providerAccount.metadata?.creditLimit as number) || 0,
+          creditLimit: creditLimitCents,
+          refCreditLimit,
           externalId: providerAccount.externalId,
           externalData: providerAccount.metadata || {},
           bankDataProviderConnectionId: connectionId,

--- a/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
@@ -90,8 +90,11 @@ const createAccountsForConnection = withTransaction(
         },
       });
 
-      // If not found, check for a previously-linked account (archived accounts
-      // have their connection history stored in externalData after unlinking)
+      // If not found, check for a previously-linked account (disconnected
+      // accounts have their connection history stored in externalData after
+      // unlinking). Match by providerType + externalId — NOT by the stored
+      // connectionId, which is the OLD disconnected connection's id and will
+      // never equal the new one after a fresh connect.
       if (!existingAccount) {
         existingAccount = await Accounts.findOne({
           where: {
@@ -101,7 +104,7 @@ const createAccountsForConnection = withTransaction(
               connectionHistory: {
                 previousConnection: {
                   externalId: providerAccount.externalId,
-                  bankDataProviderConnectionId: connectionId,
+                  providerType: connection.providerType,
                 },
               },
             },

--- a/packages/backend/src/services/bank-data-providers/connection/disconnect-provider.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/disconnect-provider.e2e.ts
@@ -1,0 +1,58 @@
+import { API_ERROR_CODES, API_RESPONSE_STATUS, BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { VALID_MONOBANK_TOKEN } from '@tests/mocks/monobank/mock-api';
+
+/**
+ * E2E tests for DELETE /bank-data-providers/connections/:connectionId.
+ *
+ * Covers the lookup behavior for the shared `disconnectProvider` service
+ * (used across all providers). Provider-specific disconnect behavior is
+ * covered in each provider's flow e2e.
+ */
+describe('Disconnect provider', () => {
+  it('returns 404 when the connection does not exist', async () => {
+    // Regression: the service used to silently `return;` for missing
+    // connections, letting the controller report "Connection removed
+    // successfully" regardless. It now throws NotFoundError.
+    const response = await helpers.bankDataProviders.disconnectProvider({
+      connectionId: 999_999,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.body.status).toBe(API_RESPONSE_STATUS.error);
+    expect((response.body.response as unknown as { code: string }).code).toBe(API_ERROR_CODES.notFound);
+  });
+
+  it('returns 200 and removes the connection for a valid, owned connectionId', async () => {
+    const { connectionId } = await helpers.bankDataProviders.connectProvider({
+      providerType: BANK_PROVIDER_TYPE.MONOBANK,
+      credentials: { apiToken: VALID_MONOBANK_TOKEN },
+      raw: true,
+    });
+
+    const response = await helpers.bankDataProviders.disconnectProvider({ connectionId });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body.status).toBe(API_RESPONSE_STATUS.success);
+
+    const { connections } = await helpers.bankDataProviders.listUserConnections({ raw: true });
+    expect(connections.find((c) => c.id === connectionId)).toBeUndefined();
+  });
+
+  it('returns 404 on a second disconnect of the same connection', async () => {
+    // Regression: pre-fix, a double-disconnect returned 200 for both calls.
+    const { connectionId } = await helpers.bankDataProviders.connectProvider({
+      providerType: BANK_PROVIDER_TYPE.MONOBANK,
+      credentials: { apiToken: VALID_MONOBANK_TOKEN },
+      raw: true,
+    });
+
+    const first = await helpers.bankDataProviders.disconnectProvider({ connectionId });
+    expect(first.statusCode).toBe(200);
+
+    const second = await helpers.bankDataProviders.disconnectProvider({ connectionId });
+    expect(second.statusCode).toBe(404);
+    expect((second.body.response as unknown as { code: string }).code).toBe(API_ERROR_CODES.notFound);
+  });
+});

--- a/packages/backend/src/services/bank-data-providers/connection/disconnect-provider.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/disconnect-provider.ts
@@ -1,4 +1,6 @@
 import { BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
+import { t } from '@i18n/index';
 import AccountGrouping from '@models/accounts-groups/account-grouping.model';
 import AccountGroup from '@models/accounts-groups/account-groups.model';
 import Accounts from '@models/accounts.model';
@@ -18,16 +20,15 @@ export const disconnectProvider = withTransaction(
     userId: number;
     removeAssociatedAccounts?: boolean;
   }): Promise<void> => {
-    const connection = await BankDataProviderConnections.findOne({
-      where: {
-        id: connectionId,
-        userId,
-      },
+    const connection = await findOrThrowNotFound({
+      query: BankDataProviderConnections.findOne({
+        where: {
+          id: connectionId,
+          userId,
+        },
+      }),
+      message: t({ key: 'errors.connectionNotFound' }),
     });
-
-    if (!connection) {
-      return;
-    }
 
     const linkedAccounts = await Accounts.findAll({
       where: {

--- a/packages/backend/src/services/bank-data-providers/connection/get-connection-details.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/get-connection-details.ts
@@ -88,23 +88,38 @@ export async function getConnectionDetails(params: GetConnectionDetailsParams): 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const metadata = connection.metadata as any;
 
+  const parseValidDate = (raw: unknown): Date | null => {
+    if (!raw) return null;
+    const parsed = new Date(raw as string);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  };
+
   if (metadata?.consentValidUntil) {
-    const now = new Date();
-    const validUntil = new Date(metadata.consentValidUntil);
-    const validFrom = metadata.consentValidFrom ? new Date(metadata.consentValidFrom) : null;
+    const validUntil = parseValidDate(metadata.consentValidUntil);
+    const validFrom = parseValidDate(metadata.consentValidFrom);
 
-    const msRemaining = validUntil.getTime() - now.getTime();
-    const daysRemaining = Math.floor(msRemaining / (1000 * 60 * 60 * 24));
-    const isExpired = msRemaining <= 0;
-    const isExpiringSoon = !isExpired && daysRemaining <= 7;
+    if (validUntil) {
+      const msRemaining = validUntil.getTime() - Date.now();
+      const daysRemaining = Math.floor(msRemaining / (1000 * 60 * 60 * 24));
+      const isExpired = msRemaining <= 0;
+      const isExpiringSoon = !isExpired && daysRemaining <= 7;
 
-    consentInfo = {
-      validFrom: validFrom?.toISOString() || null,
-      validUntil: validUntil.toISOString(),
-      daysRemaining: isExpired ? 0 : daysRemaining,
-      isExpired,
-      isExpiringSoon,
-    };
+      consentInfo = {
+        validFrom: validFrom?.toISOString() || null,
+        validUntil: validUntil.toISOString(),
+        daysRemaining: isExpired ? 0 : daysRemaining,
+        isExpired,
+        isExpiringSoon,
+      };
+    } else {
+      consentInfo = {
+        validFrom: validFrom?.toISOString() || null,
+        validUntil: null,
+        daysRemaining: null,
+        isExpired: false,
+        isExpiringSoon: false,
+      };
+    }
   }
 
   return {
@@ -126,7 +141,7 @@ export async function getConnectionDetails(params: GetConnectionDetailsParams): 
       id: account.id,
       name: account.name,
       externalId: account.externalId,
-      currentBalance: account.currentBalance.toNumber(),
+      currentBalance: account.currentBalance?.toNumber() ?? 0,
       currencyCode: account.currencyCode,
       type: account.type,
     })),

--- a/packages/backend/src/services/bank-data-providers/connection/reconcile-duplicates-for-account.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/reconcile-duplicates-for-account.ts
@@ -1,0 +1,48 @@
+import { API_ERROR_CODES, BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { t } from '@i18n/index';
+import { BadRequestError, NotFoundError } from '@js/errors';
+import Accounts from '@models/accounts.model';
+import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import { withTransaction } from '@root/services/common/with-transaction';
+
+import { EnableBankingProvider } from '../enablebanking/enablebanking.provider';
+import { bankProviderRegistry } from '../registry';
+
+/**
+ * One-time reconciliation: deletes orphan duplicates (rows without
+ * entryReference where a sibling row with entryReference exists for the same
+ * fingerprint within ±2 days). Only enable_banking is supported today —
+ * other providers don't have this hash-drift class of bug.
+ */
+export const reconcileDuplicatesForAccount = withTransaction(
+  async ({ connectionId, userId, accountId }: { connectionId: number; userId: number; accountId: number }) => {
+    const connection = await BankDataProviderConnections.findOne({
+      where: { id: connectionId, userId },
+    });
+    if (!connection) {
+      throw new NotFoundError({
+        message: t({ key: 'errors.connectionNotFound' }),
+        code: API_ERROR_CODES.notFound,
+      });
+    }
+
+    const account = await Accounts.findOne({
+      where: { id: accountId, userId, bankDataProviderConnectionId: connectionId },
+    });
+    if (!account) {
+      throw new NotFoundError({
+        message: t({ key: 'bankDataProviders.accountNotLinkedToConnection' }),
+        code: API_ERROR_CODES.notFound,
+      });
+    }
+
+    if (connection.providerType !== BANK_PROVIDER_TYPE.ENABLE_BANKING) {
+      throw new BadRequestError({
+        message: 'Reconciliation is only available for Enable Banking connections',
+      });
+    }
+
+    const provider = bankProviderRegistry.get(connection.providerType) as EnableBankingProvider;
+    return provider.reconcileDuplicateTransactionsForAccount({ accountId });
+  },
+);

--- a/packages/backend/src/services/bank-data-providers/connection/reconcile-duplicates-for-account.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/reconcile-duplicates-for-account.ts
@@ -38,7 +38,7 @@ export const reconcileDuplicatesForAccount = withTransaction(
 
     if (connection.providerType !== BANK_PROVIDER_TYPE.ENABLE_BANKING) {
       throw new BadRequestError({
-        message: 'Reconciliation is only available for Enable Banking connections',
+        message: t({ key: 'bankDataProviders.reconciliationOnlyForEnableBanking' }),
       });
     }
 

--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
@@ -112,7 +112,10 @@ export class EnableBankingApiClient {
   }
 
   /**
-   * Test connection by fetching application info
+   * Test connection by fetching application info.
+   * Returns false only for a genuine auth failure (401/403). Network/5xx errors
+   * propagate via handleApiError so callers can distinguish "invalid creds" from
+   * "provider is down".
    * @link https://enablebanking.com/docs/api/reference#application-get
    */
   async testConnection(): Promise<boolean> {
@@ -122,6 +125,12 @@ export class EnableBankingApiClient {
       });
       return true;
     } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        if (status === 401 || status === 403) {
+          return false;
+        }
+      }
       this.handleApiError(error, 'testConnection');
     }
   }

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -1,0 +1,440 @@
+import { BANK_PROVIDER_TYPE, PAYMENT_TYPES, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { FixedTransaction, MOCK_IDENTIFICATION_HASH_1 } from '@tests/mocks/enablebanking/data';
+
+/**
+ * E2E tests for the Enable Banking transaction dedup improvements.
+ *
+ * Background: Enable Banking re-sends historical transactions on every sync.
+ * Hash-based duplicate detection breaks when fields used in the hash mutate
+ * across syncs (entry_reference appearing later, transaction_date being added,
+ * etc.). These tests pin down the contract for three improvements:
+ *
+ *  1. Lookup by entry_reference: when a tx initially has no entry_reference
+ *     and the bank populates it later, the existing row is matched (not duped)
+ *     and its originalId is re-anchored to the canonical hash.
+ *
+ *  3. Window fuzzy match: when no entry_reference is ever returned and the
+ *     selected date shifts between syncs (e.g. transaction_date appears later
+ *     and outranks booking_date), a ±2-day fingerprint match prevents dupes.
+ *
+ *  4. Reconciliation: an explicit endpoint cleans up duplicate pairs that
+ *     already exist in the DB from before #1 was deployed.
+ */
+describe('Enable Banking dedup improvements (E2E)', () => {
+  beforeEach(() => {
+    helpers.enablebanking.resetSessionCounter();
+  });
+
+  afterEach(() => {
+    helpers.enablebanking.resetTransactionConfig();
+  });
+
+  /**
+   * Set up an active connection with one synced account.
+   * Caller is expected to have already configured fixed transactions
+   * (or accept the default auto-generated set).
+   */
+  async function setupConnectionWithAccount(): Promise<{ connectionId: number; accountId: number }> {
+    const connectResult = await helpers.bankDataProviders.connectProvider({
+      providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+      credentials: helpers.enablebanking.mockCredentials(),
+      raw: true,
+    });
+    const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
+    await helpers.makeRequest({
+      method: 'post',
+      url: '/bank-data-providers/enablebanking/oauth-callback',
+      payload: {
+        connectionId: connectResult.connectionId,
+        code: helpers.enablebanking.mockAuthCode,
+        state,
+      },
+    });
+    const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+      connectionId: connectResult.connectionId,
+      accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
+      raw: true,
+    });
+    return {
+      connectionId: connectResult.connectionId,
+      accountId: syncedAccounts[0]!.id,
+    };
+  }
+
+  // ==========================================================================
+  // #1 — Lookup by entry_reference when it appears in a later sync
+  // ==========================================================================
+  describe('#1 entry_reference appears in later sync', () => {
+    it('does not duplicate a tx when entry_reference is populated on a later sync', async () => {
+      const sharedAttributes: FixedTransaction = {
+        amount: '42.50',
+        currency: 'EUR',
+        isExpense: true,
+        bookingDate: '2024-03-15',
+        valueDate: '2024-03-15',
+        counterpartyIban: 'FI1111111111111111',
+        remittanceInformation: ['Coffee shop purchase'],
+      };
+
+      // Sync 1: tx WITHOUT entry_reference (uses fallback hash)
+      helpers.enablebanking.setFixedTransactions([{ ...sharedAttributes }]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const txAfterFirstSync = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txAfterFirstSync.length).toBe(1);
+      const initialTx = txAfterFirstSync[0]!;
+      expect(initialTx.externalData?.entryReference ?? null).toBeNull();
+      const initialOriginalId = initialTx.originalId;
+
+      // Sync 2: same logical tx, now WITH entry_reference (uses canonical hash)
+      helpers.enablebanking.setFixedTransactions([{ ...sharedAttributes, entryReference: 'ref_appeared_later_001' }]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const txAfterSecondSync = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txAfterSecondSync.length).toBe(1);
+      // Same DB row — not a duplicate
+      expect(txAfterSecondSync[0]!.id).toBe(initialTx.id);
+      // entryReference is now persisted
+      expect(txAfterSecondSync[0]!.externalData?.entryReference).toBe('ref_appeared_later_001');
+      // originalId is re-anchored to canonical entry_reference hash
+      expect(txAfterSecondSync[0]!.originalId).not.toBe(initialOriginalId);
+    });
+
+    it('remains idempotent across many subsequent syncs once entry_reference is anchored', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '10.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-04-02',
+          counterpartyIban: 'FI3333333333333333',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      // Now bank populates entry_reference and we run sync many times
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '10.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-04-02',
+          counterpartyIban: 'FI3333333333333333',
+          entryReference: 'stable_ref_xyz',
+        },
+      ]);
+
+      for (let i = 0; i < 4; i++) {
+        await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+        const txs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+        expect(txs.length).toBe(1);
+      }
+    });
+
+    it('does not collapse two genuinely different txs that share an account but have different entry_references', async () => {
+      // Two distinct transactions, both with entry_reference, on the same day
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '5.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-05-10',
+          counterpartyIban: 'FI4444444444444444',
+          entryReference: 'distinct_a',
+        },
+        {
+          amount: '5.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-05-10',
+          counterpartyIban: 'FI4444444444444444',
+          entryReference: 'distinct_b',
+        },
+      ]);
+      const { accountId } = await setupConnectionWithAccount();
+
+      const txs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txs.length).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // #3 — Window fuzzy match (no entry_reference, date shifts)
+  // ==========================================================================
+  describe('#3 window-based fuzzy match', () => {
+    it('does not duplicate when transaction_date appears later and shifts the date used in the hash', async () => {
+      // Sync 1: only booking_date, no entry_reference
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '99.99',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-06-20',
+          counterpartyIban: 'FI5555555555555555',
+          remittanceInformation: ['Service fee'],
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+      const txAfterFirstSync = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txAfterFirstSync.length).toBe(1);
+
+      // Sync 2: transaction_date now also populated (a different date ~1 day earlier).
+      // Under the priority-based date selection, this would change the hash and
+      // create a duplicate without the fuzzy fallback.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '99.99',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-06-20',
+          transactionDate: '2024-06-19',
+          counterpartyIban: 'FI5555555555555555',
+          remittanceInformation: ['Service fee'],
+        },
+      ]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const txAfterSecondSync = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txAfterSecondSync.length).toBe(1);
+    });
+
+    it('still creates a new transaction when the candidate is outside the ±2 day window', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '12.34',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-07-01',
+          counterpartyIban: 'FI6666666666666666',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(1);
+
+      // A genuinely different transaction with the same amount/counterparty
+      // but more than two weeks away — must NOT be matched by the fuzzy fallback.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '12.34',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-07-01',
+          counterpartyIban: 'FI6666666666666666',
+        },
+        {
+          amount: '12.34',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-07-20',
+          counterpartyIban: 'FI6666666666666666',
+        },
+      ]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const txs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txs.length).toBe(2);
+    });
+
+    it('does not match when counterparty IBAN differs (avoids over-collapsing recurring same-amount payments to different parties)', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '5.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-08-01',
+          counterpartyIban: 'FI7777777777777777',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      // Same amount and date but different counterparty — should be a separate tx.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '5.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-08-01',
+          counterpartyIban: 'FI7777777777777777',
+        },
+        {
+          amount: '5.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-08-01',
+          counterpartyIban: 'FI8888888888888888',
+        },
+      ]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const txs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txs.length).toBe(2);
+    });
+  });
+
+  // ==========================================================================
+  // #4 — One-time reconciliation of pre-existing duplicates
+  // ==========================================================================
+  describe('#4 reconciliation of existing duplicates', () => {
+    /**
+     * Helper: insert a "manual orphan" — a transaction created via the
+     * regular POST /transactions endpoint on a bank account. It has no
+     * externalData.entryReference, mimicking what a pre-#1 sync would have
+     * left behind.
+     */
+    async function insertManualOrphan({
+      accountId,
+      amount,
+      time,
+      isExpense = true,
+    }: {
+      accountId: number;
+      amount: number;
+      time: string;
+      isExpense?: boolean;
+    }) {
+      const userCategory = (await helpers.getCategoriesList()) as { id: number }[];
+      const categoryId = userCategory[0]!.id;
+      const [tx] = await helpers.createTransaction({
+        payload: {
+          amount,
+          accountId,
+          time,
+          categoryId,
+          transactionType: isExpense ? TRANSACTION_TYPES.expense : TRANSACTION_TYPES.income,
+          paymentType: PAYMENT_TYPES.bankTransfer,
+          transferNature: TRANSACTION_TRANSFER_NATURE.not_transfer,
+        },
+        raw: true,
+      });
+      return tx;
+    }
+
+    it('merges a duplicate pair where one has entry_reference and the other does not', async () => {
+      // Step 1: bank-synced canonical tx (with entry_reference)
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '50.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-09-10',
+          counterpartyIban: 'FI9999999999999999',
+          entryReference: 'canonical_ref_001',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const txsAfterSync = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(txsAfterSync.length).toBe(1);
+      const canonicalTx = txsAfterSync[0]!;
+      expect(canonicalTx.externalData?.entryReference).toBe('canonical_ref_001');
+
+      // Step 2: simulate a pre-#1 orphan — same fingerprint, no entry_reference
+      const orphan = await insertManualOrphan({
+        accountId,
+        amount: 50.0,
+        time: new Date('2024-09-10').toISOString(),
+      });
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
+
+      // Step 3: trigger reconciliation
+      const reconcileResult = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(reconcileResult.mergedCount).toBe(1);
+      expect(reconcileResult.skippedCount).toBe(0);
+
+      // Step 4: only the canonical row remains
+      const finalTxs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(finalTxs.length).toBe(1);
+      expect(finalTxs[0]!.id).toBe(canonicalTx.id);
+      expect(finalTxs.find((t: { id: number }) => t.id === orphan.id)).toBeUndefined();
+    });
+
+    it('does not merge orphans that have child relations (tags) — preserves user data', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '75.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-10-05',
+          counterpartyIban: 'FI1010101010101010',
+          entryReference: 'canonical_ref_002',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+      const orphan = await insertManualOrphan({
+        accountId,
+        amount: 75.0,
+        time: new Date('2024-10-05').toISOString(),
+      });
+
+      // Attach a tag to the orphan — this makes it unsafe to delete
+      const tag = await helpers.createTag({
+        payload: { name: `protect-${Date.now()}`, color: '#3b82f6' },
+        raw: true,
+      });
+      await helpers.addTransactionsToTag({
+        tagId: tag.id,
+        transactionIds: [orphan.id],
+      });
+
+      const reconcileResult = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(reconcileResult.mergedCount).toBe(0);
+      expect(reconcileResult.skippedCount).toBe(1);
+
+      const finalTxs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(finalTxs.length).toBe(2); // orphan was preserved
+    });
+
+    it('is idempotent — running reconciliation twice has no extra effect', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '11.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-11-01',
+          counterpartyIban: 'FI2020202020202020',
+          entryReference: 'idem_ref',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+      await insertManualOrphan({
+        accountId,
+        amount: 11.0,
+        time: new Date('2024-11-01').toISOString(),
+      });
+
+      const r1 = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+      expect(r1.mergedCount).toBe(1);
+
+      const r2 = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+      expect(r2.mergedCount).toBe(0);
+      expect(r2.skippedCount).toBe(0);
+
+      const finalTxs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      expect(finalTxs.length).toBe(1);
+    });
+  });
+});

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -1,5 +1,6 @@
 import { BANK_PROVIDER_TYPE, PAYMENT_TYPES, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import Transactions from '@models/transactions.model';
 import * as helpers from '@tests/helpers';
 import { FixedTransaction, MOCK_IDENTIFICATION_HASH_1 } from '@tests/mocks/enablebanking/data';
 
@@ -278,36 +279,59 @@ describe('Enable Banking dedup improvements (E2E)', () => {
   // ==========================================================================
   describe('#4 reconciliation of existing duplicates', () => {
     /**
-     * Helper: insert a "manual orphan" — a transaction created via the
-     * regular POST /transactions endpoint on a bank account. It has no
-     * externalData.entryReference, mimicking what a pre-#1 sync would have
-     * left behind.
+     * Helper: insert an orphan that mimics a pre-#1 sync row — a transaction
+     * created via POST /transactions then patched directly on the model so its
+     * `externalData` carries the counterparty IBAN that a real sync would have
+     * stored. The reconcile path's IBAN gate matches on `creditorAccount`
+     * (expense) / `debtorAccount` (income), so orphans without one are skipped
+     * by design.
+     *
+     * Defaults `categoryId` to whatever an existing tx on the same account
+     * already has — pre-#1 orphans came from the same sync path as the
+     * canonical and shared its default category. Tests that want a divergent
+     * category override this explicitly.
      */
     async function insertManualOrphan({
       accountId,
       amount,
       time,
       isExpense = true,
+      counterpartyIban,
+      categoryId,
     }: {
       accountId: number;
       amount: number;
       time: string;
       isExpense?: boolean;
+      counterpartyIban?: string;
+      categoryId?: number;
     }) {
-      const userCategory = (await helpers.getCategoriesList()) as { id: number }[];
-      const categoryId = userCategory[0]!.id;
+      let resolvedCategoryId = categoryId;
+      if (resolvedCategoryId === undefined) {
+        const existing = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+        if (existing.length > 0) {
+          resolvedCategoryId = existing[0]!.categoryId;
+        } else {
+          const userCategory = (await helpers.getCategoriesList()) as { id: number }[];
+          resolvedCategoryId = userCategory[0]!.id;
+        }
+      }
       const [tx] = await helpers.createTransaction({
         payload: {
           amount,
           accountId,
           time,
-          categoryId,
+          categoryId: resolvedCategoryId,
           transactionType: isExpense ? TRANSACTION_TYPES.expense : TRANSACTION_TYPES.income,
           paymentType: PAYMENT_TYPES.bankTransfer,
           transferNature: TRANSACTION_TRANSFER_NATURE.not_transfer,
         },
         raw: true,
       });
+      if (counterpartyIban) {
+        const externalData = isExpense ? { creditorAccount: counterpartyIban } : { debtorAccount: counterpartyIban };
+        await Transactions.update({ externalData }, { where: { id: tx.id } });
+      }
       return tx;
     }
 
@@ -330,11 +354,13 @@ describe('Enable Banking dedup improvements (E2E)', () => {
       const canonicalTx = txsAfterSync[0]!;
       expect(canonicalTx.externalData?.entryReference).toBe('canonical_ref_001');
 
-      // Step 2: simulate a pre-#1 orphan — same fingerprint, no entry_reference
+      // Step 2: simulate a pre-#1 orphan — same fingerprint, no entry_reference,
+      // but with the same counterparty IBAN that the canonical row stored.
       const orphan = await insertManualOrphan({
         accountId,
         amount: 50.0,
         time: new Date('2024-09-10').toISOString(),
+        counterpartyIban: 'FI9999999999999999',
       });
       expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
 
@@ -372,6 +398,7 @@ describe('Enable Banking dedup improvements (E2E)', () => {
         accountId,
         amount: 75.0,
         time: new Date('2024-10-05').toISOString(),
+        counterpartyIban: 'FI1010101010101010',
       });
 
       // Attach a tag to the orphan — this makes it unsafe to delete
@@ -414,6 +441,7 @@ describe('Enable Banking dedup improvements (E2E)', () => {
         accountId,
         amount: 11.0,
         time: new Date('2024-11-01').toISOString(),
+        counterpartyIban: 'FI2020202020202020',
       });
 
       const r1 = (await helpers.makeRequest({
@@ -435,6 +463,155 @@ describe('Enable Banking dedup improvements (E2E)', () => {
 
       const finalTxs = await helpers.getTransactions({ accountIds: [accountId], raw: true });
       expect(finalTxs.length).toBe(1);
+    });
+
+    it('does not merge an orphan that has no counterparty IBAN — manual entries are not auto-collapsed', async () => {
+      // Bank-synced canonical with IBAN
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '20.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-12-01',
+          counterpartyIban: 'FI3030303030303030',
+          entryReference: 'no_iban_canonical',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      // Orphan with no IBAN — could be an unrelated manual cash expense that
+      // happens to share amount/currency/type. Must not be merged.
+      await insertManualOrphan({
+        accountId,
+        amount: 20.0,
+        time: new Date('2024-12-01').toISOString(),
+      });
+
+      const result = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(result.mergedCount).toBe(0);
+      // The IBAN gate short-circuits before the safety check, so the orphan
+      // is not even counted as a candidate — it is simply ignored.
+      expect(result.skippedCount).toBe(0);
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
+    });
+
+    it('does not merge an orphan whose counterparty IBAN differs from the canonical', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '30.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-12-05',
+          counterpartyIban: 'FI4040404040404040',
+          entryReference: 'diff_iban_canonical',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      await insertManualOrphan({
+        accountId,
+        amount: 30.0,
+        time: new Date('2024-12-05').toISOString(),
+        counterpartyIban: 'FI5050505050505050',
+      });
+
+      const result = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(result.mergedCount).toBe(0);
+      expect(result.skippedCount).toBe(0);
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
+    });
+
+    it('does not merge an orphan whose user-edited note diverges from the canonical', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '60.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-12-10',
+          counterpartyIban: 'FI6060606060606060',
+          entryReference: 'note_canonical',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const orphan = await insertManualOrphan({
+        accountId,
+        amount: 60.0,
+        time: new Date('2024-12-10').toISOString(),
+        counterpartyIban: 'FI6060606060606060',
+      });
+      // User annotated the orphan — destroying it would silently lose the note.
+      await helpers.updateTransaction({
+        id: orphan.id,
+        payload: { note: 'Coffee with Tom' },
+      });
+
+      const result = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(result.mergedCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
+    });
+
+    it('does not merge an orphan whose user-edited categoryId diverges from the canonical', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '70.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-12-15',
+          counterpartyIban: 'FI7070707070707070',
+          entryReference: 'cat_canonical',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const canonicalRows = await helpers.getTransactions({ accountIds: [accountId], raw: true });
+      const canonicalCategoryId = canonicalRows[0]!.categoryId;
+
+      // Pick a user-defined category that is different from the canonical's.
+      const userCategories = (await helpers.getCategoriesList()) as { id: number }[];
+      const otherCategory = userCategories.find((c) => c.id !== canonicalCategoryId);
+      expect(otherCategory).toBeDefined();
+
+      const orphan = await insertManualOrphan({
+        accountId,
+        amount: 70.0,
+        time: new Date('2024-12-15').toISOString(),
+        counterpartyIban: 'FI7070707070707070',
+      });
+      await helpers.updateTransaction({
+        id: orphan.id,
+        payload: { categoryId: otherCategory!.id },
+      });
+
+      const result = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectionId}/reconcile-duplicates`,
+        payload: { accountId },
+        raw: true,
+      })) as { mergedCount: number; skippedCount: number };
+
+      expect(result.mergedCount).toBe(0);
+      expect(result.skippedCount).toBe(1);
+      expect((await helpers.getTransactions({ accountIds: [accountId], raw: true })).length).toBe(2);
     });
   });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
@@ -2052,4 +2052,52 @@ describe('Enable Banking Data Provider E2E', () => {
       expect(connection.consent!.isExpiringSoon).toBe(false);
     });
   });
+
+  describe('Provider outage vs. invalid credentials', () => {
+    const APPLICATION_URL = 'https://api.enablebanking.com/application';
+
+    it('connect: should surface a provider 5xx as 502 BadGateway, not as invalid credentials', async () => {
+      global.mswMockServer.use(
+        http.get(APPLICATION_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/${BANK_PROVIDER_TYPE.ENABLE_BANKING}/connect`,
+        payload: {
+          credentials: helpers.enablebanking.mockCredentials(),
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toEqual(ERROR_CODES.BadGateway);
+    });
+
+    it('refreshCredentials: should surface a provider 5xx as 502 BadGateway, not as invalid credentials', async () => {
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+        credentials: helpers.enablebanking.mockCredentials(),
+        raw: true,
+      });
+
+      global.mswMockServer.use(
+        http.get(APPLICATION_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'patch',
+        url: `/bank-data-providers/connections/${connectResult.connectionId}`,
+        payload: {
+          credentials: helpers.enablebanking.mockCredentials(),
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toEqual(ERROR_CODES.BadGateway);
+    });
+  });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
@@ -2,6 +2,7 @@ import { ACCOUNT_STATUSES, BANK_PROVIDER_TYPE } from '@bt/shared/types';
 import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import { connection as dbConnection } from '@models/index';
 import * as helpers from '@tests/helpers';
 import {
   FixedTransaction,
@@ -1961,6 +1962,94 @@ describe('Enable Banking Data Provider E2E', () => {
         const { connection } = await helpers.bankDataProviders.getConnectionDetails({ connectionId, raw: true });
         expect(connection.isActive).toBe(true);
       });
+    });
+  });
+
+  describe('getConnectionDetails resilience to malformed stored data', () => {
+    async function setupActiveConnection(): Promise<{ connectionId: number; accountId: number }> {
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+        credentials: helpers.enablebanking.mockCredentials(),
+        raw: true,
+      });
+
+      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
+
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/bank-data-providers/enablebanking/oauth-callback',
+        payload: {
+          connectionId: connectResult.connectionId,
+          code: helpers.enablebanking.mockAuthCode,
+          state,
+        },
+      });
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectResult.connectionId,
+        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
+        raw: true,
+      });
+
+      return {
+        connectionId: connectResult.connectionId,
+        accountId: syncedAccounts[0]!.id,
+      };
+    }
+
+    it('should not crash when an account has a null currentBalance (legacy/historical rows)', async () => {
+      const { connectionId, accountId } = await setupActiveConnection();
+
+      // Simulate a historical row where currentBalance is NULL. The live schema
+      // is NOT NULL, so relax the constraint for this test and restore it
+      // afterwards to avoid polluting sibling tests in the same worker.
+      await dbConnection.sequelize.query(`ALTER TABLE "Accounts" ALTER COLUMN "currentBalance" DROP NOT NULL`);
+      try {
+        await dbConnection.sequelize.query(`UPDATE "Accounts" SET "currentBalance" = NULL WHERE id = :accountId`, {
+          replacements: { accountId },
+        });
+
+        const response = await helpers.bankDataProviders.getConnectionDetails({ connectionId });
+        expect(response.statusCode).toBe(200);
+
+        const { connection } = await helpers.bankDataProviders.getConnectionDetails({
+          connectionId,
+          raw: true,
+        });
+
+        const account = connection.accounts.find((acc) => acc.id === accountId)!;
+        expect(account).toBeDefined();
+        expect(account.currentBalance).toBe(0);
+      } finally {
+        await dbConnection.sequelize.query(`UPDATE "Accounts" SET "currentBalance" = 0 WHERE "currentBalance" IS NULL`);
+        await dbConnection.sequelize.query(`ALTER TABLE "Accounts" ALTER COLUMN "currentBalance" SET NOT NULL`);
+      }
+    });
+
+    it('should not crash when consentValidUntil is an unparseable date string', async () => {
+      const { connectionId } = await setupActiveConnection();
+
+      const dbRow = await BankDataProviderConnections.findByPk(connectionId);
+      const existingMetadata = (dbRow!.metadata as Record<string, unknown>) || {};
+      await BankDataProviderConnections.update(
+        { metadata: { ...existingMetadata, consentValidUntil: 'not-a-date', consentValidFrom: 'also-bad' } },
+        { where: { id: connectionId } },
+      );
+
+      const response = await helpers.bankDataProviders.getConnectionDetails({ connectionId });
+      expect(response.statusCode).toBe(200);
+
+      const { connection } = await helpers.bankDataProviders.getConnectionDetails({
+        connectionId,
+        raw: true,
+      });
+
+      expect(connection.consent).toBeDefined();
+      expect(connection.consent!.validUntil).toBeNull();
+      expect(connection.consent!.validFrom).toBeNull();
+      expect(connection.consent!.daysRemaining).toBeNull();
+      expect(connection.consent!.isExpired).toBe(false);
+      expect(connection.consent!.isExpiringSoon).toBe(false);
     });
   });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -437,11 +437,10 @@ export class EnableBankingProvider extends BaseBankDataProvider {
 
     const apiClient = new EnableBankingApiClient({ appId, privateKey });
 
-    try {
-      return await apiClient.testConnection();
-    } catch {
-      return false;
-    }
+    // testConnection returns false only for 401/403.
+    // Network/5xx errors propagate so callers can distinguish "invalid creds"
+    // from "provider is down".
+    return await apiClient.testConnection();
   }
 
   async refreshCredentials(connectionId: number, newCredentials: unknown): Promise<void> {

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -1229,9 +1229,13 @@ export class EnableBankingProvider extends BaseBankDataProvider {
    * One-time reconciliation: find pre-existing duplicate pairs (one row with
    * entryReference, one without) within ±2 days and delete the orphan.
    *
-   * Conservative: skips any orphan that has dependent rows (splits, tags,
-   * refunds, transferId, group membership, etc.) so user data is never lost.
-   * Returns counts for observability and idempotency assertions.
+   * Conservative: only collapses when (a) both rows share the same
+   * counterparty IBAN — mirroring the live-sync gate in
+   * findExistingTransactionForSync so different-party same-amount payments
+   * don't get merged — and (b) the orphan has no dependent rows and no
+   * user-edited scalars (note / categoryId / paymentType) that diverge from
+   * the canonical. Returns counts for observability and idempotency
+   * assertions.
    */
   async reconcileDuplicateTransactionsForAccount({
     accountId,
@@ -1245,8 +1249,8 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     });
 
     // Bucket by (amount, currency, transactionType) so we only compare candidates
-    // that could plausibly be the same logical tx. The date-window check happens
-    // inside each bucket.
+    // that could plausibly be the same logical tx. The date-window + IBAN gate
+    // happen inside each bucket.
     const buckets = new Map<string, Transactions[]>();
     for (const tx of allTxs) {
       const key = `${tx.amount.toCents()}|${tx.currencyCode}|${tx.transactionType}`;
@@ -1271,15 +1275,28 @@ export class EnableBankingProvider extends BaseBankDataProvider {
       if (canonicalRows.length === 0 || orphanRows.length === 0) continue;
 
       for (const orphan of orphanRows) {
+        // IBAN gate: require both rows to share the same counterparty IBAN.
+        // Expenses use creditorAccount (money going out to a creditor), income
+        // uses debtorAccount. If the orphan has no IBAN (e.g. a manual entry
+        // that happens to share amount/currency/type with a bank row), skip —
+        // same rule findExistingTransactionForSync applies for live syncs.
+        const orphanIban = this.getCounterpartyIban(orphan);
+        if (!orphanIban) continue;
+
         const canonical = canonicalRows.find(
-          (c) => Math.abs(c.time.getTime() - orphan.time.getTime()) <= 2 * 24 * 60 * 60 * 1000 && c.id !== orphan.id,
+          (c) =>
+            c.id !== orphan.id &&
+            Math.abs(c.time.getTime() - orphan.time.getTime()) <= 2 * 24 * 60 * 60 * 1000 &&
+            this.getCounterpartyIban(c) === orphanIban,
         );
         if (!canonical) continue;
 
-        const safeToDelete = await this.orphanIsSafeToDelete({ orphanId: orphan.id });
+        const safeToDelete = await this.orphanIsSafeToDelete({ orphan, canonical });
         if (!safeToDelete) {
           skippedCount++;
-          logger.info(`Reconcile: skipping orphan tx ${orphan.id} (account ${account.id}) — has dependent rows`);
+          logger.info(
+            `Reconcile: skipping orphan tx ${orphan.id} (account ${account.id}) — has dependent rows or divergent user edits`,
+          );
           continue;
         }
 
@@ -1295,12 +1312,40 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     return { mergedCount, skippedCount };
   }
 
+  private getCounterpartyIban(tx: Transactions): string | null {
+    const externalData = tx.externalData as Record<string, unknown> | null;
+    if (!externalData) return null;
+    const field = tx.transactionType === TRANSACTION_TYPES.expense ? 'creditorAccount' : 'debtorAccount';
+    const iban = externalData[field];
+    return typeof iban === 'string' && iban.length > 0 ? iban : null;
+  }
+
   /**
-   * Conservative dependency check used by reconciliation. If any of these
-   * exist for the orphan, we keep it — silent data loss is much worse than
-   * leaving a duplicate behind.
+   * Conservative safety check used by reconciliation. Refuses deletion when
+   *   - dependent rows exist (splits, tags, refunds, transferId, group
+   *     membership, etc.), OR
+   *   - the orphan has user-mutable scalars (note, categoryId, paymentType)
+   *     that diverge from the canonical — those values would be silently lost
+   *     on destroy(), which is strictly worse than leaving a duplicate behind.
    */
-  private async orphanIsSafeToDelete({ orphanId }: { orphanId: number }): Promise<boolean> {
+  private async orphanIsSafeToDelete({
+    orphan,
+    canonical,
+  }: {
+    orphan: Transactions;
+    canonical: Transactions;
+  }): Promise<boolean> {
+    if (orphan.transferId) return false;
+    if (orphan.refundLinked) return false;
+
+    // User-edited scalar divergence check. Treat null/empty note as "not set"
+    // on either side so a sync-default empty note doesn't block merging.
+    const orphanNote = orphan.note ?? '';
+    const canonicalNote = canonical.note ?? '';
+    if (orphanNote !== canonicalNote && orphanNote !== '') return false;
+    if (orphan.categoryId !== canonical.categoryId) return false;
+    if (orphan.paymentType !== canonical.paymentType) return false;
+
     // Loaded lazily to avoid a circular import wave at module load.
     const TransactionTags = (await import('@models/transaction-tags.model')).default;
     const TransactionSplits = (await import('@models/transaction-splits.model')).default;
@@ -1309,11 +1354,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     const SubscriptionTransactions = (await import('@models/subscription-transactions.model')).default;
     const TransactionGroupItems = (await import('@models/transaction-group-items.model')).default;
 
-    const orphan = await Transactions.findByPk(orphanId);
-    if (!orphan) return false;
-    if (orphan.transferId) return false;
-    if (orphan.refundLinked) return false;
-
+    const orphanId = orphan.id;
     const [tagCount, splitCount, refundFromCount, refundToCount, budgetCount, subCount, groupCount] = await Promise.all(
       [
         TransactionTags.count({ where: { transactionId: orphanId } }),

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -26,7 +26,8 @@ import {
 } from '@services/bank-data-providers';
 import { createTransaction } from '@services/transactions';
 import crypto from 'crypto';
-import { startOfDay } from 'date-fns';
+import { addDays, startOfDay, subDays } from 'date-fns';
+import { Op, Sequelize } from 'sequelize';
 
 import { SyncStatus, setAccountSyncStatus } from '../sync/sync-status-tracker';
 import { encryptCredentials } from '../utils/credential-encryption';
@@ -701,26 +702,38 @@ export class EnableBankingProvider extends BaseBankDataProvider {
       let updatedCount = 0;
 
       for (const tx of providerTransactions) {
-        // Check if transaction already exists
-        const existingTx = await Transactions.findOne({
-          where: {
-            accountId: account.id,
-            originalId: tx.externalId,
-          },
+        // Match an existing tx using a tiered strategy that survives hash drift:
+        //   1. by entry_reference (ASPSP-promised stable id, may appear later)
+        //   2. by current originalId (the legacy hash)
+        //   3. by ±2-day fingerprint (amount + counterparty IBAN), as a final
+        //      fallback for ASPSPs that never populate entry_reference and
+        //      shift the date used in the hash between syncs
+        const existingTx = await this.findExistingTransactionForSync({
+          accountId: account.id,
+          tx,
         });
 
         if (existingTx) {
-          // Check if booking_date appeared (wasn't there before but is now)
-          // This handles cases where dates are progressively populated by the bank
-          const existingBookingDate = (existingTx.externalData as typeof tx.metadata)?.bookingDate;
-          const newBookingDate = tx.metadata?.bookingDate;
-          const bookingDateAppeared = !existingBookingDate && newBookingDate;
-
+          // Re-anchor originalId when matched by a non-hash path so subsequent
+          // syncs hit the canonical hash directly and don't pay the fallback cost.
+          const updates: Partial<{ originalId: string; time: Date; externalData: typeof tx.metadata }> = {};
+          if (existingTx.originalId !== tx.externalId) {
+            updates.originalId = tx.externalId;
+          }
+          // Backfill bookingDate / refresh metadata when the bank populates
+          // fields after the initial sync.
+          const existingMeta = existingTx.externalData as typeof tx.metadata;
+          const bookingDateAppeared = !existingMeta?.bookingDate && tx.metadata?.bookingDate;
           if (bookingDateAppeared) {
-            await existingTx.update({
-              time: tx.date, // Update to best available date
-              externalData: tx.metadata, // Update with latest payload including bookingDate
-            });
+            updates.time = tx.date;
+            updates.externalData = tx.metadata;
+          } else if (updates.originalId) {
+            // Even without a date change, refresh metadata so entryReference is persisted.
+            updates.externalData = { ...existingMeta, ...tx.metadata };
+          }
+
+          if (Object.keys(updates).length > 0) {
+            await existingTx.update(updates);
             updatedCount++;
           }
           continue;
@@ -1137,6 +1150,192 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     logger.info(`Migrated ${migratedCount} transaction hashes for account ${account.id}`);
 
     return migratedCount;
+  }
+
+  /**
+   * Tiered match for an incoming provider transaction against existing rows.
+   * Order matters — earlier paths are stronger guarantees.
+   */
+  private async findExistingTransactionForSync({
+    accountId,
+    tx,
+  }: {
+    accountId: number;
+    tx: ProviderTransaction;
+  }): Promise<Transactions | null> {
+    const entryReference = tx.metadata?.entryReference as string | undefined;
+
+    // (1) entry_reference: ASPSP promises this is unique + immutable per account.
+    // Cheapest, strongest match — short-circuits the rest.
+    if (entryReference) {
+      const byEntryRef = await Transactions.findOne({
+        where: {
+          accountId,
+          [Op.and]: [Sequelize.where(Sequelize.literal(`"externalData"->>'entryReference'`), entryReference)],
+        },
+      });
+      if (byEntryRef) return byEntryRef;
+    }
+
+    // (2) originalId: the legacy hash. Catches the steady state where the bank
+    // consistently returns the same fields (or no entry_reference at all).
+    const byOriginalId = await Transactions.findOne({
+      where: { accountId, originalId: tx.externalId },
+    });
+    if (byOriginalId) return byOriginalId;
+
+    // (3) ±2-day fingerprint fallback. Final safety net for ASPSPs that never
+    // populate entry_reference and shift the date used in the hash between
+    // syncs, OR for the moment a previously entry_reference-less tx finally
+    // gets one. Gated to require matching counterparty IBAN so recurring
+    // same-amount payments to different parties don't collapse.
+    //
+    // Crucially, match only against rows whose stored entryReference is null:
+    //   - if a row already has entry_reference X, step (1) would have caught
+    //     it when the incoming ref matches; if refs differ, the rows are
+    //     genuinely different and must not be collapsed.
+    //   - if a row has no entry_reference, it's an orphan from before #1
+    //     landed (or from an ASPSP that never returns one), and the
+    //     fingerprint is the only signal we have.
+    const isExpense = tx.metadata?.isExpense === true;
+    const counterpartyIban = isExpense
+      ? (tx.metadata?.creditorAccount as string | undefined)
+      : (tx.metadata?.debtorAccount as string | undefined);
+
+    if (!counterpartyIban) return null;
+
+    const fingerprintConditions: ReturnType<typeof Sequelize.where>[] = [
+      Sequelize.where(
+        Sequelize.literal(`"externalData"->>'${isExpense ? 'creditorAccount' : 'debtorAccount'}'`),
+        counterpartyIban,
+      ),
+      // Only consider rows that have no entryReference yet — anything with
+      // one already would have been handled by step (1).
+      Sequelize.where(Sequelize.literal(`"externalData"->>'entryReference'`), { [Op.is]: null as unknown as null }),
+    ];
+
+    return Transactions.findOne({
+      where: {
+        accountId,
+        amount: Math.abs(tx.amount),
+        currencyCode: tx.currency,
+        transactionType: isExpense ? TRANSACTION_TYPES.expense : TRANSACTION_TYPES.income,
+        time: { [Op.between]: [subDays(tx.date, 2), addDays(tx.date, 2)] },
+        [Op.and]: fingerprintConditions,
+      },
+    });
+  }
+
+  /**
+   * One-time reconciliation: find pre-existing duplicate pairs (one row with
+   * entryReference, one without) within ±2 days and delete the orphan.
+   *
+   * Conservative: skips any orphan that has dependent rows (splits, tags,
+   * refunds, transferId, group membership, etc.) so user data is never lost.
+   * Returns counts for observability and idempotency assertions.
+   */
+  async reconcileDuplicateTransactionsForAccount({
+    accountId,
+  }: {
+    accountId: number;
+  }): Promise<{ mergedCount: number; skippedCount: number }> {
+    const account = await this.getSystemAccount(accountId);
+    const allTxs = await Transactions.findAll({
+      where: { accountId: account.id },
+      order: [['time', 'ASC']],
+    });
+
+    // Bucket by (amount, currency, transactionType) so we only compare candidates
+    // that could plausibly be the same logical tx. The date-window check happens
+    // inside each bucket.
+    const buckets = new Map<string, Transactions[]>();
+    for (const tx of allTxs) {
+      const key = `${tx.amount.toCents()}|${tx.currencyCode}|${tx.transactionType}`;
+      const list = buckets.get(key) ?? [];
+      list.push(tx);
+      buckets.set(key, list);
+    }
+
+    let mergedCount = 0;
+    let skippedCount = 0;
+
+    for (const candidates of buckets.values()) {
+      if (candidates.length < 2) continue;
+
+      const canonicalRows = candidates.filter(
+        (c) => ((c.externalData as Record<string, unknown> | null)?.entryReference ?? null) !== null,
+      );
+      const orphanRows = candidates.filter(
+        (c) => ((c.externalData as Record<string, unknown> | null)?.entryReference ?? null) === null,
+      );
+
+      if (canonicalRows.length === 0 || orphanRows.length === 0) continue;
+
+      for (const orphan of orphanRows) {
+        const canonical = canonicalRows.find(
+          (c) => Math.abs(c.time.getTime() - orphan.time.getTime()) <= 2 * 24 * 60 * 60 * 1000 && c.id !== orphan.id,
+        );
+        if (!canonical) continue;
+
+        const safeToDelete = await this.orphanIsSafeToDelete({ orphanId: orphan.id });
+        if (!safeToDelete) {
+          skippedCount++;
+          logger.info(`Reconcile: skipping orphan tx ${orphan.id} (account ${account.id}) — has dependent rows`);
+          continue;
+        }
+
+        await orphan.destroy();
+        mergedCount++;
+      }
+    }
+
+    if (mergedCount > 0 || skippedCount > 0) {
+      logger.info(`Reconcile complete for account ${account.id}: merged=${mergedCount} skipped=${skippedCount}`);
+    }
+
+    return { mergedCount, skippedCount };
+  }
+
+  /**
+   * Conservative dependency check used by reconciliation. If any of these
+   * exist for the orphan, we keep it — silent data loss is much worse than
+   * leaving a duplicate behind.
+   */
+  private async orphanIsSafeToDelete({ orphanId }: { orphanId: number }): Promise<boolean> {
+    // Loaded lazily to avoid a circular import wave at module load.
+    const TransactionTags = (await import('@models/transaction-tags.model')).default;
+    const TransactionSplits = (await import('@models/transaction-splits.model')).default;
+    const RefundTransactions = (await import('@models/refund-transactions.model')).default;
+    const BudgetTransactions = (await import('@models/budget-transactions.model')).default;
+    const SubscriptionTransactions = (await import('@models/subscription-transactions.model')).default;
+    const TransactionGroupItems = (await import('@models/transaction-group-items.model')).default;
+
+    const orphan = await Transactions.findByPk(orphanId);
+    if (!orphan) return false;
+    if (orphan.transferId) return false;
+    if (orphan.refundLinked) return false;
+
+    const [tagCount, splitCount, refundFromCount, refundToCount, budgetCount, subCount, groupCount] = await Promise.all(
+      [
+        TransactionTags.count({ where: { transactionId: orphanId } }),
+        TransactionSplits.count({ where: { transactionId: orphanId } }),
+        RefundTransactions.count({ where: { originalTxId: orphanId } }),
+        RefundTransactions.count({ where: { refundTxId: orphanId } }),
+        BudgetTransactions.count({ where: { transactionId: orphanId } }),
+        SubscriptionTransactions.count({ where: { transactionId: orphanId } }),
+        TransactionGroupItems.count({ where: { transactionId: orphanId } }),
+      ],
+    );
+
+    return (
+      tagCount === 0 &&
+      splitCount === 0 &&
+      refundFromCount === 0 &&
+      refundToCount === 0 &&
+      budgetCount === 0 &&
+      subCount === 0 &&
+      groupCount === 0
+    );
   }
 
   /**

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
@@ -854,6 +854,11 @@ describe('LunchFlow Data Provider E2E', () => {
 
     it('should sync transactions after reconnecting', async () => {
       const MOCK_AMOUNT = 3;
+      // Use the same mocked transaction set for both syncs so the secondary
+      // dedup (via externalData.originalSource.originalId) can re-match the
+      // pre-disconnect transactions — otherwise we end up with unrelated
+      // transactions from both syncs on the re-linked account.
+      const mockedTransactions = helpers.lunchflow.mockedTransactionData(MOCK_AMOUNT);
 
       // Connect and sync
       const firstConnect = await helpers.bankDataProviders.connectProvider({
@@ -869,7 +874,7 @@ describe('LunchFlow Data Provider E2E', () => {
 
       global.mswMockServer.use(
         getLunchFlowTransactionsMock({
-          response: helpers.lunchflow.mockedTransactionData(MOCK_AMOUNT),
+          response: mockedTransactions,
           accountId: externalAccounts1[0]!.externalId,
         }),
         getLunchFlowBalanceMock({ accountId: externalAccounts1[0]!.externalId }),
@@ -903,7 +908,7 @@ describe('LunchFlow Data Provider E2E', () => {
       // Set up mocks for second connection sync
       global.mswMockServer.use(
         getLunchFlowTransactionsMock({
-          response: helpers.lunchflow.mockedTransactionData(MOCK_AMOUNT),
+          response: mockedTransactions,
           accountId: externalAccounts2[0]!.externalId,
         }),
         getLunchFlowBalanceMock({ accountId: externalAccounts2[0]!.externalId }),
@@ -915,7 +920,7 @@ describe('LunchFlow Data Provider E2E', () => {
         raw: true,
       });
 
-      // New account should have synced transactions
+      // Re-linked account should have the same transactions — no duplicates
       const transactions = await Transactions.findAll({
         where: { accountId: syncedAccounts[0]!.id },
         raw: true,
@@ -1021,6 +1026,74 @@ describe('LunchFlow Data Provider E2E', () => {
       expect(relinkedAccount.type).toBe(ACCOUNT_TYPES.lunchflow);
       expect(relinkedAccount.bankDataProviderConnectionId).toBe(secondConnect.connectionId);
       expect(relinkedAccount.externalId).toBe(externalAccountId);
+    });
+
+    it('should re-link (not duplicate) the existing account when reconnecting via connectSelectedAccounts with a fresh connection', async () => {
+      // Regression: after a disconnect, externalData.connectionHistory stores the
+      // OLD connectionId. A fresh connectProvider returns a NEW connectionId.
+      // The fallback matcher in connectSelectedAccounts used to require
+      // previousConnection.bankDataProviderConnectionId === <new connectionId>,
+      // which is impossible — so a duplicate account was created.
+      const externalAccountId = getMockedLunchFlowAccounts().accounts[0]!.id.toString();
+
+      // 1. Connect + select account
+      const firstConnect = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
+        credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+        raw: true,
+      });
+
+      global.mswMockServer.use(
+        getLunchFlowTransactionsMock({ accountId: externalAccountId }),
+        getLunchFlowBalanceMock({ accountId: externalAccountId }),
+      );
+
+      const { syncedAccounts: firstSelected } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: firstConnect.connectionId,
+        accountExternalIds: [externalAccountId],
+        raw: true,
+      });
+      const originalAccountId = firstSelected[0]!.id;
+
+      // 2. Disconnect (keep accounts → stores previousConnection metadata)
+      await helpers.bankDataProviders.disconnectProvider({
+        connectionId: firstConnect.connectionId,
+        removeAssociatedAccounts: false,
+        raw: true,
+      });
+
+      // 3. Create a brand-new connection (NEW connectionId)
+      const secondConnect = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
+        credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+        raw: true,
+      });
+      expect(secondConnect.connectionId).not.toBe(firstConnect.connectionId);
+
+      // 4. Call connectSelectedAccounts (the auto-matching path — NOT manual link)
+      global.mswMockServer.use(
+        getLunchFlowTransactionsMock({ accountId: externalAccountId }),
+        getLunchFlowBalanceMock({ accountId: externalAccountId }),
+      );
+
+      const { syncedAccounts: secondSelected } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: secondConnect.connectionId,
+        accountExternalIds: [externalAccountId],
+        raw: true,
+      });
+
+      // 5. Expect the SAME account was re-linked, not a duplicate
+      expect(secondSelected).toHaveLength(1);
+      expect(secondSelected[0]!.id).toBe(originalAccountId);
+
+      const allAccounts = await helpers.getAccounts();
+      const matchingRows = allAccounts.filter((a) => a.externalId === externalAccountId);
+      expect(matchingRows).toHaveLength(1);
+
+      const relinked = await helpers.getAccount({ id: originalAccountId, raw: true });
+      expect(relinked.type).toBe(ACCOUNT_TYPES.lunchflow);
+      expect(relinked.bankDataProviderConnectionId).toBe(secondConnect.connectionId);
+      expect(relinked.externalId).toBe(externalAccountId);
     });
   });
 

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
@@ -25,6 +25,7 @@ import {
   getLunchFlowTransactionsMock,
 } from '@tests/mocks/lunchflow/mock-api';
 import { addDays, subDays } from 'date-fns';
+import { HttpResponse, http } from 'msw';
 import { Op } from 'sequelize';
 
 /**
@@ -1455,6 +1456,54 @@ describe('LunchFlow Data Provider E2E', () => {
       });
 
       expect(reactivated.isActive).toBe(true);
+    });
+  });
+
+  describe('Provider outage vs. invalid credentials', () => {
+    const LUNCHFLOW_ACCOUNTS_URL = 'https://lunchflow.app/api/v1/accounts';
+
+    it('connect: should not treat a provider 5xx as invalid credentials', async () => {
+      global.mswMockServer.use(
+        http.get(LUNCHFLOW_ACCOUNTS_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/${BANK_PROVIDER_TYPE.LUNCHFLOW}/connect`,
+        payload: {
+          credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it('refreshCredentials: should not treat a provider 5xx as invalid credentials', async () => {
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
+        credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+        raw: true,
+      });
+
+      global.mswMockServer.use(
+        http.get(LUNCHFLOW_ACCOUNTS_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'patch',
+        url: `/bank-data-providers/connections/${connectResult.connectionId}`,
+        payload: {
+          credentials: { apiKey: VALID_LUNCHFLOW_API_KEY_2 },
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
     });
   });
 });

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
@@ -112,11 +112,10 @@ export class LunchFlowProvider extends BaseBankDataProvider {
 
     const apiClient = new LunchFlowApiClient(credentials.apiKey);
 
-    try {
-      return await apiClient.testConnection();
-    } catch {
-      return false;
-    }
+    // testConnection returns false only for 401/403.
+    // Network/5xx errors propagate so callers can distinguish "invalid key"
+    // from "provider is down".
+    return await apiClient.testConnection();
   }
 
   async refreshCredentials(connectionId: number, newCredentials: unknown): Promise<void> {

--- a/packages/backend/src/services/bank-data-providers/monobank/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/api-client.ts
@@ -155,21 +155,22 @@ export class MonobankApiClient {
   }
 
   /**
-   * Test if the API token is valid by making a simple API call
-   * @returns True if token is valid, false otherwise
+   * Test if the API token is valid.
+   * Returns false only for a genuine auth failure (Monobank returns 403 with
+   * "Unknown 'X-Token'", which `handleApiError` converts to ForbiddenError).
+   * Network/5xx/429 errors propagate so callers can distinguish "invalid token"
+   * from "provider is down".
    */
   async testConnection(): Promise<boolean> {
     try {
-      await this.getClientInfo();
+      // Bypass cache: this is a live connectivity check, not a data read.
+      // A stale cache hit would falsely report a now-invalid token as valid.
+      await this.getClientInfo({ bypassCache: true });
       return true;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const errorDescription = error.response?.data?.errorDescription;
-        if (errorDescription === "Unknown 'X-Token'") {
-          return false;
-        }
+      if (error instanceof ForbiddenError) {
+        return false;
       }
-      // For other errors (network, timeout, etc.), rethrow
       throw error;
     }
   }

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
@@ -1133,4 +1133,77 @@ describe('Monobank Data Provider E2E', () => {
       expect(JSON.parse(raw!).status).toBe(SyncStatus.COMPLETED);
     });
   });
+
+  describe('Provider outage vs. invalid credentials', () => {
+    it('connect: should not treat a provider 5xx as invalid credentials', async () => {
+      global.mswMockServer.use(
+        http.get(MONOBANK_URLS_MOCK.clientInfo, () => {
+          return new HttpResponse(null, { status: 503, statusText: 'Service Unavailable' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/${BANK_PROVIDER_TYPE.MONOBANK}/connect`,
+        payload: {
+          credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        },
+      });
+
+      // A provider outage must NOT be reported to the user as an auth failure.
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it('connect: should surface a 429 as TooManyRequests, not as invalid credentials', async () => {
+      global.mswMockServer.use(
+        http.get(MONOBANK_URLS_MOCK.clientInfo, () => {
+          return HttpResponse.json(
+            { errorDescription: 'Too many requests' },
+            { status: 429, statusText: 'Too Many Requests' },
+          );
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/${BANK_PROVIDER_TYPE.MONOBANK}/connect`,
+        payload: {
+          credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        },
+      });
+
+      // Rate limiting is distinct from invalid credentials.
+      expect(result.status).toEqual(ERROR_CODES.TooManyRequests);
+    });
+
+    it('refreshCredentials: should not treat a provider 5xx as invalid credentials', async () => {
+      // Set up an active connection with valid credentials first.
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      // Simulate provider outage during the refresh attempt.
+      global.mswMockServer.use(
+        http.get(MONOBANK_URLS_MOCK.clientInfo, () => {
+          return new HttpResponse(null, { status: 503, statusText: 'Service Unavailable' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'patch',
+        url: `/bank-data-providers/connections/${connectResult.connectionId}`,
+        payload: {
+          credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        },
+      });
+
+      // User attempted to refresh their (valid) token but the provider was down —
+      // we must NOT tell them the credentials are invalid.
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
+    });
+  });
 });

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
@@ -3,8 +3,16 @@ import { Money } from '@common/types/money';
 import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
 import Accounts from '@models/accounts.model';
+import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import Currencies from '@models/currencies.model';
 import Transactions from '@models/transactions.model';
+import { redisClient } from '@root/redis-client';
+import { handleCompletedBatch } from '@root/services/bank-data-providers/monobank/transaction-sync-queue';
+import {
+  REDIS_KEYS,
+  SyncStatus,
+  setAccountSyncStatus,
+} from '@root/services/bank-data-providers/sync/sync-status-tracker';
 import { calculateRefAmount } from '@root/services/calculate-ref-amount.service';
 import * as helpers from '@tests/helpers';
 import {
@@ -13,6 +21,7 @@ import {
   VALID_MONOBANK_TOKEN,
   getMonobankTransactionsMock,
 } from '@tests/mocks/monobank/mock-api';
+import { Job } from 'bullmq';
 import { HttpResponse, http } from 'msw';
 import { Op } from 'sequelize';
 
@@ -953,6 +962,175 @@ describe('Monobank Data Provider E2E', () => {
       const countAfter = connectionsAfter.length;
 
       expect(countAfter).toBe(countBefore); // No new connection created
+    });
+  });
+
+  describe('Multi-batch completion accounting', () => {
+    // Regression: the 'completed' handler used to derive "all batches done"
+    // from the queue's completed set. Under concurrent syncs the queue's
+    // `removeOnComplete` eviction removes earlier batches from that set,
+    // so the query returns fewer than `totalBatches` and the final
+    // COMPLETED transition is never triggered — the account sits SYNCING
+    // until the 20-minute stale sweep. The counter-based implementation
+    // increments a dedicated Redis key per jobGroupId, so each batch
+    // contributes exactly one INCR no matter how the queue trims itself.
+    //
+    // This test calls `handleCompletedBatch` directly for N fabricated
+    // batches of a single group. None of them are real jobs in BullMQ, so
+    // any queue-snapshot-based implementation would see zero completed
+    // jobs in the group on every call and never fire the transition.
+    // Only the counter approach accumulates across calls, reaches
+    // totalBatches, and sets COMPLETED.
+    const buildFakeJob = (params: {
+      jobGroupId: string;
+      batchIndex: number;
+      totalBatches: number;
+      userId: number;
+      accountId: number;
+      connectionId: number;
+      externalAccountId: string;
+    }): Job =>
+      ({
+        id: `${params.jobGroupId}-${params.batchIndex}`,
+        data: {
+          userId: params.userId,
+          accountId: params.accountId,
+          connectionId: params.connectionId,
+          externalAccountId: params.externalAccountId,
+          apiToken: 'unused-in-handler',
+          fromTimestamp: 0,
+          toTimestamp: 0,
+          batchIndex: params.batchIndex,
+          totalBatches: params.totalBatches,
+        },
+      }) as unknown as Job;
+
+    it('should flip account to COMPLETED exactly when the Nth batch of N completes', async () => {
+      const { connectionId } = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId,
+        raw: true,
+      });
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId,
+        accountExternalIds: [externalAccounts[0]!.externalId],
+        raw: true,
+      });
+
+      const accountId = syncedAccounts[0]!.id;
+      const account = await Accounts.findByPk(accountId);
+      const userId = account!.userId;
+
+      // Put the account into SYNCING, mirroring the worker's mid-sync state.
+      await setAccountSyncStatus({ accountId, status: SyncStatus.SYNCING, userId });
+
+      const totalBatches = 3;
+      const jobGroupId = `${userId}-${accountId}-${Date.now()}`;
+
+      for (let i = 0; i < totalBatches; i++) {
+        await handleCompletedBatch(
+          buildFakeJob({
+            jobGroupId,
+            batchIndex: i,
+            totalBatches,
+            userId,
+            accountId,
+            connectionId,
+            externalAccountId: externalAccounts[0]!.externalId,
+          }),
+        );
+
+        const raw = await redisClient.get(REDIS_KEYS.accountSyncStatus(accountId));
+        const parsed = JSON.parse(raw!);
+
+        if (i < totalBatches - 1) {
+          // Intermediate batches must not fire the final transition.
+          expect(parsed.status).toBe(SyncStatus.SYNCING);
+        } else {
+          // Last batch flips it.
+          expect(parsed.status).toBe(SyncStatus.COMPLETED);
+        }
+      }
+
+      // The connection's lastSyncAt is also bumped so the list view's
+      // "Last synced" column reflects this group, not just connect-time.
+      const reloadedConnection = await BankDataProviderConnections.findByPk(connectionId);
+      expect(reloadedConnection!.lastSyncAt).not.toBeNull();
+
+      // And the counter key is cleaned up once the group is settled —
+      // otherwise Redis slowly fills with orphan keys from every sync.
+      const counterKey = `jobgroup:${jobGroupId}:completions`;
+      const counterValue = await redisClient.get(counterKey);
+      expect(counterValue).toBeNull();
+    });
+
+    it('should not be confused by two concurrent groups on the same account', async () => {
+      // Two sync operations for one account running in parallel (rare but
+      // possible — e.g., auto-sync kicks in just as a manual load-for-period
+      // is triggered). Each group has its own jobGroupId → its own counter.
+      // The second group must be able to complete independently, even after
+      // the first already cleared its counter.
+      const { connectionId } = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId,
+        raw: true,
+      });
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId,
+        accountExternalIds: [externalAccounts[0]!.externalId],
+        raw: true,
+      });
+
+      const accountId = syncedAccounts[0]!.id;
+      const account = await Accounts.findByPk(accountId);
+      const userId = account!.userId;
+
+      const groupA = `${userId}-${accountId}-${Date.now()}-a`;
+      const groupB = `${userId}-${accountId}-${Date.now()}-b`;
+      const commonArgs = {
+        totalBatches: 2,
+        userId,
+        accountId,
+        connectionId,
+        externalAccountId: externalAccounts[0]!.externalId,
+      };
+
+      await setAccountSyncStatus({ accountId, status: SyncStatus.SYNCING, userId });
+
+      // Finish group A completely.
+      await handleCompletedBatch(buildFakeJob({ ...commonArgs, jobGroupId: groupA, batchIndex: 0 }));
+      await handleCompletedBatch(buildFakeJob({ ...commonArgs, jobGroupId: groupA, batchIndex: 1 }));
+
+      let raw = await redisClient.get(REDIS_KEYS.accountSyncStatus(accountId));
+      expect(JSON.parse(raw!).status).toBe(SyncStatus.COMPLETED);
+
+      // Back to SYNCING for group B, then finish it.
+      await setAccountSyncStatus({ accountId, status: SyncStatus.SYNCING, userId });
+      await handleCompletedBatch(buildFakeJob({ ...commonArgs, jobGroupId: groupB, batchIndex: 0 }));
+
+      raw = await redisClient.get(REDIS_KEYS.accountSyncStatus(accountId));
+      expect(JSON.parse(raw!).status).toBe(SyncStatus.SYNCING);
+
+      await handleCompletedBatch(buildFakeJob({ ...commonArgs, jobGroupId: groupB, batchIndex: 1 }));
+
+      raw = await redisClient.get(REDIS_KEYS.accountSyncStatus(accountId));
+      expect(JSON.parse(raw!).status).toBe(SyncStatus.COMPLETED);
     });
   });
 });

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
@@ -1,9 +1,16 @@
 import { ACCOUNT_STATUSES, BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { Money } from '@common/types/money';
 import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
+import Accounts from '@models/accounts.model';
 import Transactions from '@models/transactions.model';
+import { calculateRefAmount } from '@root/services/calculate-ref-amount.service';
 import * as helpers from '@tests/helpers';
-import { INVALID_MONOBANK_TOKEN, VALID_MONOBANK_TOKEN } from '@tests/mocks/monobank/mock-api';
+import {
+  INVALID_MONOBANK_TOKEN,
+  VALID_MONOBANK_TOKEN,
+  getMonobankTransactionsMock,
+} from '@tests/mocks/monobank/mock-api';
 import { Op } from 'sequelize';
 
 /**
@@ -386,9 +393,6 @@ describe('Monobank Data Provider E2E', () => {
 
       const accountIds = externalAccounts.slice(0, 2).map((acc: { externalId: string }) => acc.externalId);
 
-      // Mock transaction data for the Monobank API
-      const { getMonobankTransactionsMock } = await import('@tests/mocks/monobank/mock-api');
-
       global.mswMockServer.use(
         ...accountIds.map((id) =>
           getMonobankTransactionsMock({ accountId: id, response: helpers.monobank.mockedTransactionData(MOCK_AMOUNT) }),
@@ -500,6 +504,80 @@ describe('Monobank Data Provider E2E', () => {
       expect(account.currentBalance).toBe(selectedExternal.balance);
       expect(account.initialBalance).toBe(selectedExternal.balance);
       expect(account.currencyCode).toBe(selectedExternal.currency);
+    });
+
+    it('should convert refCreditLimit to base currency when account currency differs', async () => {
+      // Regression: refCreditLimit used to be copied raw from the provider's
+      // native cents — causing order-of-magnitude errors in base-currency
+      // credit totals for non-base-currency accounts. It must now be converted
+      // via calculateRefAmount, consistent with refInitialBalance/refCurrentBalance.
+      const connectionResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+
+      // Mock has a UAH account with creditLimit = 2000 UAH (200_000 cents).
+      // Test base currency is AED (set in setupIntegrationTests.ts).
+      const uahExternal = externalAccounts.find((a: { currency: string }) => a.currency === 'UAH')!;
+      expect(uahExternal).toBeDefined();
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectionResult.connectionId,
+        accountExternalIds: [uahExternal.externalId],
+        raw: true,
+      });
+
+      const created = await Accounts.findByPk(syncedAccounts[0]!.id);
+      const creditLimitCents = created!.creditLimit.toCents();
+      const refCreditLimitCents = created!.refCreditLimit.toCents();
+
+      expect(creditLimitCents).toBe(200000);
+      expect(refCreditLimitCents).not.toBe(creditLimitCents);
+
+      const expected = await calculateRefAmount({
+        amount: Money.fromCents(creditLimitCents),
+        userId: created!.userId,
+        date: new Date(),
+        baseCode: 'UAH',
+      });
+      expect(refCreditLimitCents).toEqualRefValue(expected.toCents());
+    });
+
+    it('should set refCreditLimit = 0 when the account has no credit limit', async () => {
+      // Mock's USD account has creditLimit = 0. Both fields must be zero.
+      const connectionResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+
+      const usdExternal = externalAccounts.find((a: { currency: string }) => a.currency === 'USD')!;
+      expect(usdExternal).toBeDefined();
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectionResult.connectionId,
+        accountExternalIds: [usdExternal.externalId],
+        raw: true,
+      });
+
+      const created = await Accounts.findByPk(syncedAccounts[0]!.id);
+      expect(created!.creditLimit.toCents()).toBe(0);
+      expect(created!.refCreditLimit.toCents()).toBe(0);
     });
 
     it('should update connection lastSyncAt after connecting accounts', async () => {

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
@@ -1,16 +1,19 @@
-import { ACCOUNT_STATUSES, BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { ACCOUNT_STATUSES, API_ERROR_CODES, API_RESPONSE_STATUS, BANK_PROVIDER_TYPE, asCents } from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
 import Accounts from '@models/accounts.model';
+import Currencies from '@models/currencies.model';
 import Transactions from '@models/transactions.model';
 import { calculateRefAmount } from '@root/services/calculate-ref-amount.service';
 import * as helpers from '@tests/helpers';
 import {
   INVALID_MONOBANK_TOKEN,
+  MONOBANK_URLS_MOCK,
   VALID_MONOBANK_TOKEN,
   getMonobankTransactionsMock,
 } from '@tests/mocks/monobank/mock-api';
+import { HttpResponse, http } from 'msw';
 import { Op } from 'sequelize';
 
 /**
@@ -661,6 +664,74 @@ describe('Monobank Data Provider E2E', () => {
       });
 
       expect(new Date(afterResync.lastSyncAt!).getTime()).toBeGreaterThan(new Date(initialLastSyncAt!).getTime());
+    });
+
+    it('should return a 4xx error when the provider returns an unsupported currency', async () => {
+      // We pick DJF (Djiboutian Franc, ISO 4217 code 262), delete it from the
+      // Currencies table, and then mock Monobank to return an account with that currency.
+
+      // Pre-flight: make sure DJF is present, then remove it.
+      const djfBefore = await Currencies.findOne({ where: { code: 'DJF' } });
+      expect(djfBefore).not.toBeNull();
+      await Currencies.destroy({ where: { code: 'DJF' } });
+
+      try {
+        // Override /personal/client-info to return a single account in DJF.
+        global.mswMockServer.use(
+          http.get(MONOBANK_URLS_MOCK.clientInfo, () => {
+            return HttpResponse.json({
+              clientId: 'test-client',
+              name: 'Test User',
+              webHookUrl: '',
+              permissions: '',
+              accounts: [
+                {
+                  id: 'djf-account',
+                  sendId: 'sid-djf',
+                  balance: asCents(10000),
+                  creditLimit: asCents(0),
+                  type: 'black',
+                  currencyCode: 262, // DJF
+                  cashbackType: 'None',
+                  maskedPan: [],
+                  iban: 'djf-iban',
+                },
+              ],
+              jars: [],
+            });
+          }),
+        );
+
+        const { connectionId } = await helpers.bankDataProviders.connectProvider({
+          providerType: BANK_PROVIDER_TYPE.MONOBANK,
+          credentials: { apiToken: VALID_MONOBANK_TOKEN },
+          raw: true,
+        });
+
+        const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+          connectionId,
+          raw: true,
+        });
+        const djfExternal = externalAccounts.find((a: { currency: string }) => a.currency === 'DJF')!;
+        expect(djfExternal).toBeDefined();
+
+        global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+        const response = await helpers.bankDataProviders.connectSelectedAccounts({
+          connectionId,
+          accountExternalIds: [djfExternal.externalId],
+        });
+
+        // The endpoint must respond with a handled 4xx error, not a 500/crash from
+        // `currency.code` on null.
+        expect(response.statusCode).toBeGreaterThanOrEqual(400);
+        expect(response.statusCode).toBeLessThan(500);
+        expect(response.body.status).toBe(API_RESPONSE_STATUS.error);
+        expect((response.body.response as unknown as { code: string }).code).toBe(API_ERROR_CODES.BadRequest);
+      } finally {
+        // Restore DJF so later tests in the suite are unaffected.
+        await Currencies.create(djfBefore!.get({ plain: true }));
+      }
     });
 
     it('should enable existing disabled accounts when reconnecting', async () => {

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank-flow.e2e.ts
@@ -607,6 +607,62 @@ describe('Monobank Data Provider E2E', () => {
       expect(connectionAfter?.lastSyncAt).not.toBeNull();
     });
 
+    it('should advance connection lastSyncAt after a repeat Monobank sync', async () => {
+      // Regression: Monobank's queue-based sync wrote lastSyncAt only on the
+      // initial connect (via connect-selected-accounts). Subsequent syncs ran
+      // through the BullMQ worker, which updated account-level externalData
+      // timestamps but never the connection row — so the list view's "Last
+      // synced" column was frozen at connect-time.
+      const connectionResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectionResult.connectionId,
+        accountExternalIds: [externalAccounts[0]!.externalId],
+        raw: true,
+      });
+
+      // Give the initial sync time to hit the worker's 'completed' handler.
+      await helpers.sleep(1000);
+
+      const { connection: afterConnect } = await helpers.bankDataProviders.getConnectionDetails({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+      const initialLastSyncAt = afterConnect.lastSyncAt;
+      expect(initialLastSyncAt).not.toBeNull();
+
+      // Wait so a new timestamp would be visibly different.
+      await helpers.sleep(1100);
+
+      global.mswMockServer.use(getMonobankTransactionsMock({ response: [] }));
+      await helpers.bankDataProviders.syncTransactionsForAccount({
+        connectionId: connectionResult.connectionId,
+        accountId: syncedAccounts[0]!.id,
+        raw: true,
+      });
+
+      // Wait for all queued batches to complete.
+      await helpers.sleep(2000);
+
+      const { connection: afterResync } = await helpers.bankDataProviders.getConnectionDetails({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+
+      expect(new Date(afterResync.lastSyncAt!).getTime()).toBeGreaterThan(new Date(initialLastSyncAt!).getTime());
+    });
+
     it('should enable existing disabled accounts when reconnecting', async () => {
       const connectionResult = await helpers.bankDataProviders.connectProvider({
         providerType: BANK_PROVIDER_TYPE.MONOBANK,

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
@@ -96,12 +96,10 @@ export class MonobankProvider extends BaseBankDataProvider {
     const { apiToken } = credentials;
     const apiClient = new MonobankApiClient(apiToken);
 
-    try {
-      return await apiClient.testConnection();
-    } catch {
-      // Network or other errors - consider as invalid
-      return false;
-    }
+    // testConnection returns false only for a genuine auth failure.
+    // Network/5xx/429 errors propagate so callers can distinguish "invalid token"
+    // from "provider is down".
+    return await apiClient.testConnection();
   }
 
   async refreshCredentials(connectionId: number, newCredentials: unknown): Promise<void> {

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -9,6 +9,7 @@ import * as MerchantCategoryCodes from '@models/merchant-category-codes.model';
 import Transactions from '@models/transactions.model';
 import * as UserMerchantCategoryCodes from '@models/user-merchant-category-codes.model';
 import * as Users from '@models/users.model';
+import { redisClient } from '@root/redis-client';
 import * as accountsService from '@services/accounts.service';
 import * as transactionsService from '@services/transactions';
 import { Job, Queue, Worker } from 'bullmq';
@@ -333,28 +334,55 @@ export const transactionSyncWorker = new Worker<TransactionSyncJobData>(
   },
 );
 
-// Worker event listeners
-transactionSyncWorker.on('completed', async (job) => {
+// 24h safety TTL: if the worker crashes between intermediate batches, the
+// counter key expires rather than lingering in Redis forever.
+const JOB_GROUP_COMPLETIONS_TTL_SECONDS = 24 * 60 * 60;
+
+function jobGroupCompletionsKey(jobGroupId: string): string {
+  return `jobgroup:${jobGroupId}:completions`;
+}
+
+/**
+ * Handles a batch job's 'completed' event.
+ *
+ * Uses an atomic Redis counter (INCR) keyed by jobGroupId rather than
+ * enumerating the queue's completed set. The queue trims completed jobs via
+ * `removeOnComplete.count` — under concurrent syncs this can evict earlier
+ * batches of *this* group before the last one fires, and any approach that
+ * derives "are we done?" from the queue snapshot is racy. A dedicated counter
+ * is immune: each successful batch contributes exactly one INCR, and the call
+ * that returns `totalBatches` is the one that fires the final transition.
+ *
+ * Exported for direct testing.
+ */
+export async function handleCompletedBatch(job: Job<TransactionSyncJobData>): Promise<void> {
   logger.info(`Job ${job.id} completed successfully`);
 
-  // Extract jobGroupId and check if all batches are completed
-  const jobGroupId = job.id?.substring(0, job.id.lastIndexOf('-')) || '';
+  const jobId = job.id;
+  if (!jobId) return;
+  const jobGroupId = jobId.substring(0, jobId.lastIndexOf('-'));
   const { totalBatches, accountId, userId, connectionId } = job.data;
 
-  const progress = await getJobGroupProgress(jobGroupId);
+  const counterKey = jobGroupCompletionsKey(jobGroupId);
+  const completedCount = await redisClient.incr(counterKey);
+  await redisClient.expire(counterKey, JOB_GROUP_COMPLETIONS_TTL_SECONDS);
 
-  if (progress.completedBatches === totalBatches) {
-    await Promise.all([
-      setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId }),
-      // Mark the connection as synced. Enable Banking does this via
-      // base-provider's `updateLastSync`; Monobank's queue-based flow needs
-      // the equivalent write so the list view's "Last synced" column reflects
-      // reality for the connection, not just the account.
-      BankDataProviderConnections.update({ lastSyncAt: new Date() }, { where: { id: connectionId } }),
-    ]);
-    logger.info(`All batches completed for account ${accountId}, status set to COMPLETED`);
-  }
-});
+  if (completedCount < totalBatches) return;
+
+  await Promise.all([
+    setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId }),
+    // Mark the connection as synced. Enable Banking does this via
+    // base-provider's `updateLastSync`; Monobank's queue-based flow needs
+    // the equivalent write so the list view's "Last synced" column reflects
+    // reality for the connection, not just the account.
+    BankDataProviderConnections.update({ lastSyncAt: new Date() }, { where: { id: connectionId } }),
+  ]);
+  await redisClient.del(counterKey);
+  logger.info(`All batches completed for account ${accountId}, status set to COMPLETED`);
+}
+
+// Worker event listeners
+transactionSyncWorker.on('completed', (job) => handleCompletedBatch(job));
 
 transactionSyncWorker.on('failed', (job, err) => {
   logger.error({ message: `Job ${job?.id} failed`, error: err });

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -4,6 +4,7 @@ import { Money } from '@common/types/money';
 import { logger } from '@js/utils/logger';
 import { SentryTraceData, withQueueProcessSpan, withQueuePublishSpan } from '@js/utils/sentry';
 import Accounts from '@models/accounts.model';
+import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import * as MerchantCategoryCodes from '@models/merchant-category-codes.model';
 import Transactions from '@models/transactions.model';
 import * as UserMerchantCategoryCodes from '@models/user-merchant-category-codes.model';
@@ -338,12 +339,19 @@ transactionSyncWorker.on('completed', async (job) => {
 
   // Extract jobGroupId and check if all batches are completed
   const jobGroupId = job.id?.substring(0, job.id.lastIndexOf('-')) || '';
-  const { totalBatches, accountId, userId } = job.data;
+  const { totalBatches, accountId, userId, connectionId } = job.data;
 
   const progress = await getJobGroupProgress(jobGroupId);
 
   if (progress.completedBatches === totalBatches) {
-    await setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId });
+    await Promise.all([
+      setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId }),
+      // Mark the connection as synced. Enable Banking does this via
+      // base-provider's `updateLastSync`; Monobank's queue-based flow needs
+      // the equivalent write so the list view's "Last synced" column reflects
+      // reality for the connection, not just the account.
+      BankDataProviderConnections.update({ lastSyncAt: new Date() }, { where: { id: connectionId } }),
+    ]);
     logger.info(`All batches completed for account ${accountId}, status set to COMPLETED`);
   }
 });

--- a/packages/backend/src/services/bank-data-providers/walutomat/walutomat-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/walutomat/walutomat-flow.e2e.ts
@@ -12,6 +12,7 @@ import {
   getWalutomatHistoryByCurrencyMock,
   getWalutomatHistoryMock,
 } from '@tests/mocks/walutomat/mock-api';
+import { HttpResponse, http } from 'msw';
 import { Op } from 'sequelize';
 
 describe('Walutomat Data Provider E2E', () => {
@@ -436,6 +437,56 @@ describe('Walutomat Data Provider E2E', () => {
       const { connections } = await helpers.bankDataProviders.listUserConnections({ raw: true });
       const connection = connections.find((c: { id: number }) => c.id === connectionId);
       expect(connection).toBeUndefined();
+    });
+  });
+
+  describe('Provider outage vs. invalid credentials', () => {
+    const WALUTOMAT_BALANCES_URL = 'https://api.walutomat.pl/api/v2.0.0/account/balances';
+
+    it('connect: should not treat a provider 5xx as invalid credentials', async () => {
+      global.mswMockServer.use(
+        http.get(WALUTOMAT_BALANCES_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/${BANK_PROVIDER_TYPE.WALUTOMAT}/connect`,
+        payload: {
+          credentials: {
+            apiKey: VALID_WALUTOMAT_API_KEY,
+            privateKey: VALID_WALUTOMAT_PRIVATE_KEY,
+          },
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
+    });
+
+    it('refreshCredentials: should not treat a provider 5xx as invalid credentials', async () => {
+      const { connectionId } = await helpers.walutomat.pair();
+
+      global.mswMockServer.use(
+        http.get(WALUTOMAT_BALANCES_URL, () => {
+          return new HttpResponse(null, { status: 500, statusText: 'Internal Server Error' });
+        }),
+      );
+
+      const result = await helpers.makeRequest({
+        method: 'patch',
+        url: `/bank-data-providers/connections/${connectionId}`,
+        payload: {
+          credentials: {
+            apiKey: VALID_WALUTOMAT_API_KEY,
+            privateKey: VALID_WALUTOMAT_PRIVATE_KEY,
+          },
+        },
+      });
+
+      expect(result.status).not.toEqual(ERROR_CODES.Forbidden);
+      expect(result.status).toBeGreaterThanOrEqual(400);
     });
   });
 });

--- a/packages/backend/src/services/bank-data-providers/walutomat/walutomat.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/walutomat/walutomat.provider.ts
@@ -158,12 +158,12 @@ export class WalutomatProvider extends BaseBankDataProvider {
       return false;
     }
 
-    try {
-      const client = this.createApiClient(credentials);
-      return await client.testConnection();
-    } catch {
-      return false;
-    }
+    const client = this.createApiClient(credentials);
+
+    // testConnection returns false only for 401/403 or signing errors (bad private key).
+    // Network/5xx errors propagate so callers can distinguish "invalid creds"
+    // from "provider is down".
+    return await client.testConnection();
   }
 
   async refreshCredentials(connectionId: number, newCredentials: unknown): Promise<void> {

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -209,6 +209,9 @@ const setDefaultUserCurrency = withTransaction(
     });
 
     const currency = await Currencies.getCurrency({ code: currencyCode });
+    if (!currency) {
+      throw new UnexpectedError({ message: t({ key: 'userCurrencies.currencyCodeNotExist' }) });
+    }
 
     await Transactions.updateTransactions(
       {

--- a/packages/backend/src/tests/mocks/enablebanking/data.ts
+++ b/packages/backend/src/tests/mocks/enablebanking/data.ts
@@ -245,13 +245,21 @@ interface MockTransactionConfig {
 }
 
 export interface FixedTransaction {
-  entryReference: string;
+  /** Optional. Omit to simulate ASPSPs that don't return entry_reference initially. */
+  entryReference?: string;
   amount: string;
   currency: string;
   isExpense: boolean;
   bookingDate?: string;
   valueDate?: string;
   transactionDate?: string;
+  /**
+   * Optional override for the counterparty IBAN (creditor IBAN if expense, debtor IBAN if income).
+   * Defaults to a fixed placeholder. Use a stable per-tx value to make fingerprint matches work.
+   */
+  counterpartyIban?: string;
+  /** Optional override for remittance_information lines. */
+  remittanceInformation?: string[];
 }
 
 let mockTransactionConfig: MockTransactionConfig = {
@@ -283,27 +291,33 @@ export const resetMockTransactionConfig = () => {
 export const getMockedTransactions = (accountId: string, count: number = 10) => {
   // If fixed transactions are configured, use those
   if (mockTransactionConfig.fixedTransactions) {
-    return mockTransactionConfig.fixedTransactions.map((ft) => {
+    return mockTransactionConfig.fixedTransactions.map((ft, idx) => {
+      const counterpartyIban = ft.counterpartyIban || 'FI0000000000000000';
+      const ownIban = getMockedAccountDetails(accountId).account_id.iban;
       const tx: Record<string, unknown> = {
-        transaction_id: `tx_${accountId}_${ft.entryReference}`,
+        transaction_id: `tx_${accountId}_${ft.entryReference || `idx${idx}`}`,
         transaction_amount: {
           amount: ft.amount,
           currency: ft.currency,
         },
         credit_debit_indicator: ft.isExpense ? 'DBIT' : 'CRDT',
-        remittance_information: ['Test transaction'],
+        remittance_information: ft.remittanceInformation || ['Test transaction'],
         debtor: { name: ft.isExpense ? 'John Doe' : 'Test Company' },
         debtor_account: {
-          iban: ft.isExpense ? getMockedAccountDetails(accountId).account_id.iban : 'FI0000000000000000',
+          iban: ft.isExpense ? ownIban : counterpartyIban,
         },
         creditor: { name: ft.isExpense ? 'Test Company' : 'John Doe' },
         creditor_account: {
-          iban: ft.isExpense ? 'FI0000000000000000' : getMockedAccountDetails(accountId).account_id.iban,
+          iban: ft.isExpense ? counterpartyIban : ownIban,
         },
-        entry_reference: ft.entryReference,
         balance_after_transaction: { amount: '1000.00', currency: ft.currency },
         status: 'BOOK',
       };
+
+      // Only set entry_reference when provided — simulates ASPSPs that omit it.
+      if (ft.entryReference !== undefined) {
+        tx.entry_reference = ft.entryReference;
+      }
 
       // Add optional date fields if present
       if (ft.bookingDate) {

--- a/packages/backend/src/tests/mocks/monobank/mock-api.ts
+++ b/packages/backend/src/tests/mocks/monobank/mock-api.ts
@@ -28,10 +28,8 @@ export const monobankHandlers = [
     const token = request.headers.get('X-Token');
 
     if (token === INVALID_MONOBANK_TOKEN) {
-      return new HttpResponse(null, {
-        status: 403,
-        statusText: 'Forbidden',
-      });
+      // Matches Monobank's real 403 response body for an unknown API token.
+      return HttpResponse.json({ errorDescription: "Unknown 'X-Token'" }, { status: 403 });
     }
 
     return HttpResponse.json(getMockedClientData());


### PR DESCRIPTION
- fix: refCreditLimit calculation upon bank connection
- fix: disconnection fixes
- fix: update monobank `lastSynced` after sync
- fixes missing unique index on `AccountGroups.bankDataProviderConnection
- fix: re-linking bank accounts gaps
- fix: getConnectionDetails number convertions
- fix: bank providers — don't mask 5xx/429 as invalid credentials