### PR TITLE
fix: skip Resend sends to `@test.local` recipients in dev

### DIFF
--- a/packages/backend/src/config/auth.ts
+++ b/packages/backend/src/config/auth.ts
@@ -5,15 +5,12 @@ import { createSessionHooks } from '@config/auth-hooks/session-hooks';
 import { logger } from '@js/utils/logger';
 import { identifyUser, trackSignup } from '@js/utils/posthog';
 import { captureException } from '@js/utils/sentry';
+import { sendEmail } from '@services/email/send-email';
 import { createAppUserWithUniqueUsername, seedUserDefaults } from '@services/user/create-user-with-defaults.service';
 import bcrypt from 'bcryptjs';
 import { betterAuth } from 'better-auth';
 import { jwt } from 'better-auth/plugins';
 import { Pool } from 'pg';
-import { Resend } from 'resend';
-
-// Initialize Resend for transactional emails
-const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 // Fail-fast: AUTH_ORIGIN must be set in production. Without it, OAuth error
 // redirects, login/consent pages, and trusted origins all fall back to
@@ -65,16 +62,11 @@ export const auth = betterAuth({
       // Send verification to the NEW email address (not the old one)
       // This is critical for legacy @app.migrated users who can't receive emails at their current address
       sendChangeEmailVerification: async ({ newEmail, url }) => {
-        if (!resend) {
-          logger.warn('Email change verification skipped: RESEND_API_KEY not configured');
-          return;
-        }
-
         const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
         const appName = process.env.AUTH_RP_NAME || 'MoneyMatter';
 
         try {
-          const result = await resend.emails.send({
+          const result = await sendEmail({
             from: `${appName} <${fromEmail}>`,
             to: newEmail, // Send to NEW email, not current
             subject: `Verify your new ${appName} email`,
@@ -97,7 +89,9 @@ export const auth = betterAuth({
               </div>
             `,
           });
-          logger.info(`Email change verification sent to ${newEmail}, resendId: ${result.data?.id}`);
+          if (result) {
+            logger.info(`Email change verification sent to ${newEmail}, resendId: ${result.data?.id}`);
+          }
 
           // Track this email to prevent duplicate verification email
           recentlyChangedEmails.set(newEmail, Date.now());
@@ -158,11 +152,6 @@ export const auth = betterAuth({
     sendOnSignUp: true,
     autoSignInAfterVerification: true,
     sendVerificationEmail: async ({ user, url }) => {
-      if (!resend) {
-        logger.warn('Email verification skipped: RESEND_API_KEY not configured');
-        return;
-      }
-
       // Check if this email was recently changed via changeEmail flow
       // If so, skip sending duplicate verification (better-auth bug workaround)
       const changedAt = recentlyChangedEmails.get(user.email);
@@ -176,7 +165,7 @@ export const auth = betterAuth({
       const appName = process.env.AUTH_RP_NAME || 'MoneyMatter';
 
       try {
-        const result = await resend.emails.send({
+        const result = await sendEmail({
           from: `${appName} <${fromEmail}>`,
           to: user.email,
           subject: `Verify your ${appName} email`,
@@ -199,7 +188,9 @@ export const auth = betterAuth({
             </div>
           `,
         });
-        logger.info(`Verification email sent to ${user.email}, resendId: ${result.data?.id}`);
+        if (result) {
+          logger.info(`Verification email sent to ${user.email}, resendId: ${result.data?.id}`);
+        }
       } catch (error) {
         logger.error({ message: 'Failed to send verification email', error: error as Error });
         throw error;

--- a/packages/backend/src/controllers/user/migrate-legacy-email.ts
+++ b/packages/backend/src/controllers/user/migrate-legacy-email.ts
@@ -3,15 +3,12 @@ import { createController } from '@controllers/helpers/controller-factory';
 import { t } from '@i18n/index';
 import { ValidationError } from '@js/errors';
 import { logger } from '@js/utils/logger';
+import { isEmailServiceConfigured, sendEmail } from '@services/email/send-email';
 import crypto from 'crypto';
-import { Resend } from 'resend';
 import { z } from 'zod';
 
 const LEGACY_EMAIL_SUFFIX = '@app.migrated';
 const TOKEN_EXPIRY_MS = 60 * 60 * 1000; // 1 hour
-
-// Initialize Resend for verification emails
-const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 
 /**
  * Step 1: Request email change - sends verification email to new address
@@ -74,7 +71,7 @@ export const migrateLegacyEmail = createController(
     );
 
     // Send verification email
-    if (!resend) {
+    if (!isEmailServiceConfigured()) {
       logger.warn('Email verification skipped: RESEND_API_KEY not configured');
       throw new ValidationError({ message: t({ key: 'auth.migration.emailServiceNotConfigured' }) });
     }
@@ -85,7 +82,7 @@ export const migrateLegacyEmail = createController(
     const verifyUrl = `${frontendOrigin}/auth/verify-legacy-email?token=${token}`;
 
     try {
-      const result = await resend.emails.send({
+      const result = await sendEmail({
         from: `${appName} <${fromEmail}>`,
         to: newEmail.toLowerCase(),
         subject: t({ key: 'emails.legacyEmailMigration.subject', variables: { appName } }),
@@ -108,7 +105,9 @@ export const migrateLegacyEmail = createController(
           </div>
         `,
       });
-      logger.info(`Legacy email migration verification sent to ${newEmail}, resendId: ${result.data?.id}`);
+      if (result) {
+        logger.info(`Legacy email migration verification sent to ${newEmail}, resendId: ${result.data?.id}`);
+      }
     } catch (error) {
       logger.error({ message: 'Failed to send legacy email migration verification', error: error as Error });
       throw new ValidationError({ message: t({ key: 'auth.migration.failedToSendVerification' }) });

--- a/packages/backend/src/services/email/send-email.ts
+++ b/packages/backend/src/services/email/send-email.ts
@@ -1,0 +1,30 @@
+import { isTestEmail } from '@bt/shared/types';
+import { logger } from '@js/utils/logger';
+import { Resend } from 'resend';
+
+const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
+
+type SendEmailPayload = {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+};
+
+type SendEmailResult = Awaited<ReturnType<NonNullable<typeof resend>['emails']['send']>> | null;
+
+export async function sendEmail(payload: SendEmailPayload): Promise<SendEmailResult> {
+  if (!resend) {
+    logger.warn(`[Email] Skipped (RESEND_API_KEY not configured): "${payload.subject}" -> ${payload.to}`);
+    return null;
+  }
+  if (isTestEmail(payload.to)) {
+    logger.info(`[Email] Skipped (test recipient): "${payload.subject}" -> ${payload.to}`);
+    return null;
+  }
+  return resend.emails.send(payload);
+}
+
+export function isEmailServiceConfigured(): boolean {
+  return resend !== null;
+}

--- a/packages/backend/src/services/payment-reminders/email-queue.ts
+++ b/packages/backend/src/services/payment-reminders/email-queue.ts
@@ -1,11 +1,10 @@
-import { Money } from '@common/types/money';
 import { logger } from '@js/utils/logger';
 import { SentryTraceData, withQueueProcessSpan, withQueuePublishSpan } from '@js/utils/sentry';
 import { connection } from '@models/index';
 import PaymentReminderNotifications from '@models/payment-reminder-notifications.model';
 import Users from '@models/users.model';
+import { sendEmail } from '@services/email/send-email';
 import { Job, Queue, Worker } from 'bullmq';
-import { Resend } from 'resend';
 
 interface ReminderEmailJobData extends SentryTraceData {
   userId: number;
@@ -53,7 +52,6 @@ reminderEmailQueue.on('error', (err) => {
   }
 });
 
-const resend = process.env.RESEND_API_KEY ? new Resend(process.env.RESEND_API_KEY) : null;
 const fromEmail = process.env.RESEND_FROM_EMAIL || 'onboarding@resend.dev';
 const appName = process.env.AUTH_RP_NAME || 'MoneyMatter';
 const appUrl = process.env.APP_URL || 'https://moneymatter.app';
@@ -65,11 +63,6 @@ const reminderEmailWorker = new Worker<ReminderEmailJobData>(
       queueName,
       job,
       fn: async () => {
-        if (!resend) {
-          logger.warn('[Payment Reminder Email] Resend not configured, skipping email');
-          return;
-        }
-
         const { reminderName, dueDate, expectedAmount, currencyCode, reminderId } = job.data;
 
         // expectedAmount is already decimal (converted by model getter via Money.toJSON())
@@ -97,14 +90,16 @@ const reminderEmailWorker = new Worker<ReminderEmailJobData>(
           return;
         }
 
-        await resend.emails.send({
+        const result = await sendEmail({
           from: `${appName} <${fromEmail}>`,
           to: email,
           subject: `Payment reminder: ${reminderName} due ${dueDate}`,
           html,
         });
 
-        logger.info(`[Payment Reminder Email] Sent email to user ${job.data.userId} for reminder "${reminderName}"`);
+        if (result) {
+          logger.info(`[Payment Reminder Email] Sent email to user ${job.data.userId} for reminder "${reminderName}"`);
+        }
       },
     });
   },

--- a/packages/frontend/e2e/helpers/test-setup.ts
+++ b/packages/frontend/e2e/helpers/test-setup.ts
@@ -2,6 +2,10 @@ import { randomBytes } from 'crypto';
 
 import { signUpViaFetch, verifyEmailViaFetch } from './api-client';
 
+// Inlined from shared/src/types/testing.ts: shared has no "type": "module",
+// so Playwright loads it as CJS and named ESM imports break.
+const TEST_EMAIL_DOMAIN = 'test.local';
+
 // Required for raw fetch() calls (local dev uses self-signed certs)
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
 
@@ -18,7 +22,7 @@ export interface TestCredentials {
 export function buildTestCredentials({ prefix }: { prefix: string }): TestCredentials {
   const runId = randomBytes(4).toString('hex');
   return {
-    email: `pw-${prefix}-${runId}@test.local`,
+    email: `pw-${prefix}-${runId}@${TEST_EMAIL_DOMAIN}`,
     password: 'E2eTestPass123!',
     name: `pw-${prefix}-${runId}`,
   };

--- a/packages/frontend/e2e/helpers/test-user.ts
+++ b/packages/frontend/e2e/helpers/test-user.ts
@@ -1,6 +1,10 @@
 import type { APIRequestContext } from '@playwright/test';
 import { randomBytes } from 'crypto';
 
+// Inlined from shared/src/types/testing.ts: shared has no "type": "module",
+// so Playwright loads it as CJS and named ESM imports break.
+const TEST_EMAIL_DOMAIN = 'test.local';
+
 const API_BASE_URL = process.env.PLAYWRIGHT_API_BASE_URL || 'https://localhost:8081';
 
 export interface TestUser {
@@ -17,7 +21,7 @@ export interface TestUser {
 export function buildTestUser({ workerIndex }: { workerIndex: number }): TestUser {
   const runId = randomBytes(4).toString('hex');
   return {
-    email: `pw-${runId}-w${workerIndex}@test.local`,
+    email: `pw-${runId}-w${workerIndex}@${TEST_EMAIL_DOMAIN}`,
     name: `pw-${runId}-w${workerIndex}`,
     password: 'E2eTestPass123!',
   };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -12,4 +12,5 @@ export * from './statement-parser';
 export * from './sse';
 export * from './ai';
 export * from './money';
+export * from './testing';
 export { endpointsTypes };

--- a/packages/shared/src/types/testing.ts
+++ b/packages/shared/src/types/testing.ts
@@ -1,0 +1,5 @@
+export const TEST_EMAIL_DOMAIN = 'test.local';
+
+export function isTestEmail(email: string): boolean {
+  return email.toLowerCase().endsWith(`@${TEST_EMAIL_DOMAIN}`);
+}


### PR DESCRIPTION
Frontend Playwright tests run against the dev backend, which has a real `RESEND_API_KEY` – every test sign-up was hitting Resend. Centralized email sending now drops sends whose recipient matches the shared `TEST_EMAIL_DOMAIN` constant