### PR TITLE
fix: base currency crash on fractional cents

### DIFF
--- a/packages/backend/src/services/calculate-ref-amount.service.ts
+++ b/packages/backend/src/services/calculate-ref-amount.service.ts
@@ -1,5 +1,4 @@
 import { Money } from '@common/types/money';
-import { roundHalfToEven } from '@common/utils/round-half-to-even';
 import { t } from '@i18n/index';
 import { ValidationError } from '@js/errors';
 import { CacheClient } from '@js/utils/cache';
@@ -8,6 +7,7 @@ import * as Currencies from '@models/currencies.model';
 import * as UsersCurrencies from '@models/users-currencies.model';
 import * as userExchangeRateService from '@services/user-exchange-rate';
 
+import { calculateRefAmountFromParams } from './calculate-ref-amount.utils';
 import { withTransaction } from './common/with-transaction';
 
 const refAmountCache = new CacheClient<string>({
@@ -99,29 +99,7 @@ async function calculateRefAmountImpl(params: Params): Promise<Money> {
   }
 }
 
-export const calculateRefAmountFromParams = ({
-  amount,
-  rate,
-  useFloorAbs = true,
-}: {
-  amount: Money;
-  rate: number;
-  // For example in investments we're using raw float numbers, so it makes no sense to use it
-  useFloorAbs?: boolean;
-}): Money => {
-  const amountCents = amount.toCents();
-  const isNegative = amountCents < 0;
-
-  // Use Banker's Rounding (round half to even) per IEEE 754 and IFRS/GAAP standards.
-  // This minimizes cumulative rounding bias in bidirectional currency conversions (e.g., USD → EUR → USD).
-  // Since amounts are stored as integers (cents * 100), rounding still produces integers
-  // but with better reversibility and compliance with accounting standards.
-  const refAmount =
-    amountCents === 0 ? 0 : useFloorAbs ? roundHalfToEven(Math.abs(amountCents) * rate) : amountCents * rate;
-  const finalAmount = isNegative ? refAmount * -1 : refAmount;
-
-  return Money.fromCents(finalAmount);
-};
+export { calculateRefAmountFromParams } from './calculate-ref-amount.utils';
 
 type Params = {
   amount: Money;

--- a/packages/backend/src/services/calculate-ref-amount.utils.ts
+++ b/packages/backend/src/services/calculate-ref-amount.utils.ts
@@ -1,0 +1,32 @@
+import { Money } from '@common/types/money';
+import { roundHalfToEven } from '@common/utils/round-half-to-even';
+
+export const calculateRefAmountFromParams = ({
+  amount,
+  rate,
+  useFloorAbs = true,
+}: {
+  amount: Money;
+  rate: number;
+  // Investments use DECIMAL columns and need full decimal precision instead of integer cents.
+  useFloorAbs?: boolean;
+}): Money => {
+  if (!useFloorAbs) {
+    // Investments are stored as DECIMAL columns - preserve full precision via Money arithmetic
+    // instead of round-tripping through integer cents (which both loses precision and would
+    // throw when amountCents * rate produces a fractional result like 128479.5).
+    return amount.multiply(rate);
+  }
+
+  const amountCents = amount.toCents();
+  const isNegative = amountCents < 0;
+
+  // Use Banker's Rounding (round half to even) per IEEE 754 and IFRS/GAAP standards.
+  // This minimizes cumulative rounding bias in bidirectional currency conversions (e.g., USD → EUR → USD).
+  // Since amounts are stored as integers (cents * 100), rounding still produces integers
+  // but with better reversibility and compliance with accounting standards.
+  const refAmount = amountCents === 0 ? 0 : roundHalfToEven(Math.abs(amountCents) * rate);
+  const finalAmount = isNegative ? refAmount * -1 : refAmount;
+
+  return Money.fromCents(finalAmount);
+};

--- a/packages/backend/src/services/calculate-ref-amount.utils.unit.ts
+++ b/packages/backend/src/services/calculate-ref-amount.utils.unit.ts
@@ -1,0 +1,79 @@
+import { Money } from '@common/types/money';
+import { describe, expect, it } from '@jest/globals';
+
+import { calculateRefAmountFromParams } from './calculate-ref-amount.utils';
+
+describe('calculateRefAmountFromParams', () => {
+  describe('useFloorAbs=true (default - regular transactions)', () => {
+    it("rounds fractional cent results to nearest integer using banker's rounding", () => {
+      // 205 cents * 0.5 = 102.5 → rounds to 102 (banker's rounding to even)
+      const result = calculateRefAmountFromParams({
+        amount: Money.fromCents(205),
+        rate: 0.5,
+      });
+      expect(result.toCents()).toBe(102);
+    });
+
+    it('returns zero for zero amount', () => {
+      const result = calculateRefAmountFromParams({
+        amount: Money.zero(),
+        rate: 1.5,
+      });
+      expect(result.toCents()).toBe(0);
+    });
+
+    it('preserves sign for negative amounts', () => {
+      // -200 cents * 1.5 = -300 cents
+      const result = calculateRefAmountFromParams({
+        amount: Money.fromCents(-200),
+        rate: 1.5,
+      });
+      expect(result.toCents()).toBe(-300);
+    });
+  });
+
+  describe('useFloorAbs=false (investments - DECIMAL precision)', () => {
+    // Reproduces FRONTEND-V2-XXX / MONEY-MATTER-BACKEND-5N:
+    // "Money.fromCents: expected integer, got 128479.5" thrown during base
+    // currency change for users with investment transactions whose
+    // amountCents * rate produces a fractional result.
+    it('does not throw when amountCents * rate produces a fractional cent', () => {
+      // 205 cents * 0.5 = 102.5 (fractional) — must not throw
+      expect(() =>
+        calculateRefAmountFromParams({
+          amount: Money.fromCents(205),
+          rate: 0.5,
+          useFloorAbs: false,
+        }),
+      ).not.toThrow();
+    });
+
+    it('preserves decimal precision instead of rounding to whole cents', () => {
+      // 205 cents (= $2.05) * 0.5 = $1.025 — should keep the half-cent precision
+      const result = calculateRefAmountFromParams({
+        amount: Money.fromCents(205),
+        rate: 0.5,
+        useFloorAbs: false,
+      });
+      expect(result.toNumber()).toBe(1.025);
+    });
+
+    it('preserves sign for negative amounts with fractional results', () => {
+      const result = calculateRefAmountFromParams({
+        amount: Money.fromCents(-205),
+        rate: 0.5,
+        useFloorAbs: false,
+      });
+      expect(result.toNumber()).toBe(-1.025);
+    });
+
+    it('returns zero for zero amount', () => {
+      const result = calculateRefAmountFromParams({
+        amount: Money.zero(),
+        rate: 1.5,
+        useFloorAbs: false,
+      });
+      expect(result.toNumber()).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
Fixes MONEY-MATTER-BACKEND-5N
Investment ref columns are DECIMAL, so `amount * rate` often yields a fractional value (e.g. 128479.5). The `useFloorAbs=false` branch was still feeding that to `Money.fromCents`, which rejects non-integers. Extract the pure helper into `calculate-ref-amount.utils.ts` and switch the investment branch to `Money.multiply` so decimal precision is preserved end-to-end