### PR TITLE
fix: widen cents columns to BIGINT to prevent integer overflow

### DIFF
--- a/packages/backend/src/common/types/money-column.ts
+++ b/packages/backend/src/common/types/money-column.ts
@@ -11,7 +11,7 @@ import { Money } from './money';
  * Use with class getter/setter pairs and the moneyGet / moneySet helpers.
  *
  * @example
- * // INTEGER column storing cents:
+ * // BIGINT column storing cents:
  * @Column(MoneyColumn({ storage: 'cents' }))
  * get amount(): Money { return moneyGetCents(this, 'amount'); }
  * set amount(val: Money | number) { moneySetCents(this, 'amount', val); }
@@ -25,8 +25,10 @@ export function MoneyColumn(opts: MoneyColumnCentsOptions): MoneyColumnConfig;
 export function MoneyColumn(opts: MoneyColumnDecimalOptions): MoneyColumnConfig;
 export function MoneyColumn(opts: MoneyColumnOptions): MoneyColumnConfig {
   if (opts.storage === 'cents') {
+    // BIGINT (not INTEGER) so that low-denomination currencies (IDR, VND, etc.)
+    // or any large balance can exceed the 32-bit INTEGER ceiling without overflow.
     return {
-      type: DataType.INTEGER,
+      type: DataType.BIGINT,
       allowNull: opts.allowNull ?? false,
       defaultValue: opts.defaultValue ?? 0,
     };
@@ -50,7 +52,7 @@ interface ModelDataAccess {
   setDataValue(key: string, value: unknown): void;
 }
 
-/** Getter helper for INTEGER (cents) columns → returns Money */
+/** Getter helper for BIGINT (cents) columns → returns Money */
 export function moneyGetCents(model: ModelDataAccess, field: string): Money {
   const raw = model.getDataValue(field);
   if (raw === null || raw === undefined) return null as unknown as Money;
@@ -59,7 +61,7 @@ export function moneyGetCents(model: ModelDataAccess, field: string): Money {
   return Money.fromCents(raw as number);
 }
 
-/** Setter helper for INTEGER (cents) columns ← accepts Money or raw number */
+/** Setter helper for BIGINT (cents) columns ← accepts Money or raw number */
 export function moneySetCents(model: ModelDataAccess, field: string, val: Money | number | null): void {
   if (val === null) {
     model.setDataValue(field, null);

--- a/packages/backend/src/controllers/accounts.controller.e2e.ts
+++ b/packages/backend/src/controllers/accounts.controller.e2e.ts
@@ -98,6 +98,29 @@ describe('Accounts controller', () => {
 
       expect(res.statusCode).toBe(ERROR_CODES.ValidationError);
     });
+
+    it('accepts balances above the legacy 32-bit INTEGER ceiling', async () => {
+      // Regression: SequelizeDatabaseError "value … is out of range for type integer".
+      // 25_000_000 decimal → 2_500_000_000 cents, comfortably above the old
+      // 2_147_483_647 cap; common for low-denomination currencies (IDR, VND).
+      const LARGE_BALANCE = 25_000_000;
+
+      const account = await helpers.createAccount({
+        payload: {
+          ...helpers.buildAccountPayload(),
+          initialBalance: LARGE_BALANCE,
+          creditLimit: LARGE_BALANCE,
+        },
+        raw: true,
+      });
+
+      expect(account.initialBalance).toStrictEqual(LARGE_BALANCE);
+      expect(account.refInitialBalance).toStrictEqual(LARGE_BALANCE);
+      expect(account.currentBalance).toStrictEqual(LARGE_BALANCE);
+      expect(account.refCurrentBalance).toStrictEqual(LARGE_BALANCE);
+      expect(account.creditLimit).toStrictEqual(LARGE_BALANCE);
+      expect(account.refCreditLimit).toStrictEqual(LARGE_BALANCE);
+    });
   });
   describe('update account', () => {
     it('should return 404 if try to update unexisting account', async () => {

--- a/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
+++ b/packages/backend/src/controllers/transactions.controller/create-transaction.e2e.ts
@@ -63,6 +63,34 @@ describe('Create transaction controller', () => {
     expect(baseTx.transferNature).toBe(TRANSACTION_TRANSFER_NATURE.not_transfer);
     expect(baseTx).toStrictEqual(transactions![0]);
   });
+  it('accepts transaction amounts above the legacy 32-bit INTEGER ceiling', async () => {
+    // Regression: SequelizeDatabaseError "value … is out of range for type integer".
+    // 25_000_000 decimal → 2_500_000_000 cents, above the old 2_147_483_647 cap.
+    // Common for low-denomination currencies (IDR, VND).
+    const LARGE_AMOUNT = 25_000_000;
+    const LARGE_COMMISSION = 50_000;
+
+    const account = await helpers.createAccount({ raw: true });
+
+    const txPayload = helpers.buildTransactionPayload({
+      accountId: account.id,
+      amount: LARGE_AMOUNT,
+      commissionRate: LARGE_COMMISSION,
+    });
+    const [baseTx] = await helpers.createTransaction({
+      payload: txPayload,
+      raw: true,
+    });
+
+    expect(baseTx.amount).toBe(LARGE_AMOUNT);
+    expect(baseTx.refAmount).toBe(LARGE_AMOUNT);
+    expect(baseTx.commissionRate).toBe(LARGE_COMMISSION);
+    expect(baseTx.refCommissionRate).toBe(LARGE_COMMISSION);
+
+    const accountAfter = await helpers.getAccount({ id: account.id, raw: true });
+    // default account starts at 0 balance; expense subtracts LARGE_AMOUNT
+    expect(accountAfter.currentBalance).toBe(-LARGE_AMOUNT);
+  });
   it('should successfully create a transaction for account with currency different from base one', async () => {
     // Create account with non-default currency
     const currency = global.MODELS_CURRENCIES!.find((item) => item.code === 'UAH');

--- a/packages/backend/src/migrations/20260519000000-widen-cents-columns-to-bigint.ts
+++ b/packages/backend/src/migrations/20260519000000-widen-cents-columns-to-bigint.ts
@@ -1,0 +1,54 @@
+import { QueryInterface } from 'sequelize';
+
+// Cents columns were originally INTEGER (32-bit signed, max ~2.14B). That
+// overflows for accounts denominated in low-unit currencies (IDR, VND, etc.)
+// or for very large balances. Widening every cents column to BIGINT (64-bit)
+// removes the ceiling without changing semantics — existing values fit cleanly.
+//
+// NOTE: ALTER COLUMN TYPE INTEGER → BIGINT rewrites the entire table under an
+// ACCESS EXCLUSIVE lock. For large tables (Transactions, Balances) this can
+// take minutes; reads and writes are blocked the whole time. Plan accordingly.
+const CENTS_COLUMNS: [string, string][] = [
+  ['Accounts', 'initialBalance'],
+  ['Accounts', 'refInitialBalance'],
+  ['Accounts', 'currentBalance'],
+  ['Accounts', 'refCurrentBalance'],
+  ['Accounts', 'creditLimit'],
+  ['Accounts', 'refCreditLimit'],
+  ['Balances', 'amount'],
+  ['Budgets', 'limitAmount'],
+  ['PaymentReminders', 'expectedAmount'],
+  ['SubscriptionCandidates', 'averageAmount'],
+  ['Subscriptions', 'expectedAmount'],
+  ['TransactionSplits', 'amount'],
+  ['TransactionSplits', 'refAmount'],
+  ['Transactions', 'amount'],
+  ['Transactions', 'refAmount'],
+  ['Transactions', 'commissionRate'],
+  ['Transactions', 'refCommissionRate'],
+  ['Transactions', 'cashbackAmount'],
+];
+
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      for (const [table, column] of CENTS_COLUMNS) {
+        await queryInterface.sequelize.query(`ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE BIGINT`, {
+          transaction,
+        });
+      }
+    });
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      for (const [table, column] of CENTS_COLUMNS) {
+        // Narrowing back to INTEGER will fail if any row exceeds 2.14B — that
+        // is the intended behaviour: a forced narrow would lose data.
+        await queryInterface.sequelize.query(`ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE INTEGER`, {
+          transaction,
+        });
+      }
+    });
+  },
+};

--- a/packages/backend/src/models/index.ts
+++ b/packages/backend/src/models/index.ts
@@ -1,3 +1,4 @@
+import { types as pgTypes } from 'pg';
 import { Sequelize } from 'sequelize-typescript';
 
 import AccountGroupingModel from './accounts-groups/account-grouping.model';
@@ -45,6 +46,13 @@ import UserMerchantCategoryCodesModel from './user-merchant-category-codes.model
 import UserSettingsModel from './user-settings.model';
 import UsersCurrenciesModel from './users-currencies.model';
 import UsersModel from './users.model';
+
+// node-postgres returns BIGINT as string to preserve precision. Our cents
+// columns are BIGINT, but cent values stay far below JS Number's safe 2^53
+// ceiling (~$90T). Parse to Number so model getters, hooks, raw queries, and
+// API serializers all see numbers uniformly. pg only invokes the parser for
+// non-null values, so we don't need a null branch.
+pgTypes.setTypeParser(pgTypes.builtins.INT8, (val) => Number(val));
 
 const DBConfig: Record<string, unknown> = {
   host: process.env.APPLICATION_DB_HOST,

--- a/packages/backend/src/models/subscription-candidates.model.ts
+++ b/packages/backend/src/models/subscription-candidates.model.ts
@@ -39,7 +39,7 @@ export default class SubscriptionCandidates extends Model {
   detectedFrequency!: SUBSCRIPTION_FREQUENCIES;
 
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.BIGINT,
     allowNull: false,
     comment: 'Average amount in cents',
   })

--- a/packages/backend/src/models/subscriptions.model.ts
+++ b/packages/backend/src/models/subscriptions.model.ts
@@ -42,7 +42,7 @@ export default class Subscriptions extends Model {
   type!: SUBSCRIPTION_TYPES;
 
   @Column({
-    type: DataType.INTEGER,
+    type: DataType.BIGINT,
     allowNull: true,
   })
   expectedAmount!: number | null;


### PR DESCRIPTION
INTEGER cents columns overflowed for low-unit currencies (IDR, VND) and large balances above ~$21M; widens every cents column to BIGINT and parses pg INT8 as Number so model getters and serializers stay uniform