### PR TITLE
Fix Sentry issues

### DIFF
--- a/packages/backend/src/migrations/20260526000000-migrate-legacy-yahoo-crypto-to-coingecko.ts
+++ b/packages/backend/src/migrations/20260526000000-migrate-legacy-yahoo-crypto-to-coingecko.ts
@@ -1,0 +1,157 @@
+import { QueryInterface, QueryTypes, Transaction } from 'sequelize';
+
+/**
+ * Convert legacy Yahoo-format crypto Securities (BTC-USD, ETH-USD, etc.) to
+ * CoinGecko-slug rows so the crypto sync pipeline can fetch their prices.
+ *
+ * Background: the migration that introduced `providerSymbol`
+ * (20260522000000-coingecko-crypto-support) blindly backfilled
+ * `providerSymbol := symbol`. For crypto Securities that pre-dated CoinGecko
+ * support, `symbol` was a Yahoo ticker like "BTC-USD" — but CoinGecko's API
+ * expects coin slugs like "bitcoin". The hourly crypto sync routes every
+ * `assetClass = 'crypto'` row to CoinGecko by design, so those legacy rows
+ * fail every run and flood Sentry with "no price data" errors.
+ *
+ * For each known Yahoo crypto symbol this migration:
+ *   1. If a coingecko row already exists for the target slug, re-points
+ *      Holdings / InvestmentTransactions / SecurityPricings to the existing
+ *      coingecko row and deletes the yahoo row. SecurityPricings rows that
+ *      would collide on the unique (securityId, date) index are dropped in
+ *      favour of the coingecko-originated price.
+ *   2. Otherwise rewrites the yahoo row in place: providerName -> coingecko,
+ *      providerSymbol -> slug. `symbol` (display ticker) is left untouched
+ *      so existing UI references keep working.
+ *
+ * Symbols not in the mapping table are surfaced via a console.warn so the
+ * mapping can be extended without further code changes.
+ */
+const LEGACY_YAHOO_CRYPTO_TO_COINGECKO_SLUG: Record<string, string> = {
+  // The four symbols actively erroring in Sentry as of 2026-05-26.
+  'BTC-USD': 'bitcoin',
+  'ETH-USD': 'ethereum',
+  'SOL-USD': 'solana',
+  'XAUT-USD': 'tether-gold',
+  // Top-cap coins likely to have been recorded under the previous Yahoo
+  // provider. Safe to over-include: entries that don't match any row are
+  // no-ops.
+  'BNB-USD': 'binancecoin',
+  'USDT-USD': 'tether',
+  'USDC-USD': 'usd-coin',
+  'ADA-USD': 'cardano',
+  'XRP-USD': 'ripple',
+  'DOGE-USD': 'dogecoin',
+  'DOT-USD': 'polkadot',
+  'AVAX-USD': 'avalanche-2',
+  'MATIC-USD': 'matic-network',
+  'LINK-USD': 'chainlink',
+  'LTC-USD': 'litecoin',
+  'BCH-USD': 'bitcoin-cash',
+  'TRX-USD': 'tron',
+  'SHIB-USD': 'shiba-inu',
+  'NEAR-USD': 'near',
+  'ATOM-USD': 'cosmos',
+  'XLM-USD': 'stellar',
+  'ETC-USD': 'ethereum-classic',
+  'UNI-USD': 'uniswap',
+  'APT-USD': 'aptos',
+};
+
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const t: Transaction = await queryInterface.sequelize.transaction();
+
+    try {
+      for (const [legacySymbol, slug] of Object.entries(LEGACY_YAHOO_CRYPTO_TO_COINGECKO_SLUG)) {
+        const yahooRows = (await queryInterface.sequelize.query(
+          `SELECT id FROM "Securities"
+             WHERE "providerName" = 'yahoo'
+               AND "assetClass" = 'crypto'
+               AND "providerSymbol" = :legacySymbol`,
+          { type: QueryTypes.SELECT, replacements: { legacySymbol }, transaction: t },
+        )) as Array<{ id: string }>;
+
+        if (yahooRows.length === 0) continue;
+
+        const coingeckoRows = (await queryInterface.sequelize.query(
+          `SELECT id FROM "Securities"
+             WHERE "providerName" = 'coingecko'
+               AND "providerSymbol" = :slug`,
+          { type: QueryTypes.SELECT, replacements: { slug }, transaction: t },
+        )) as Array<{ id: string }>;
+
+        const targetCoingeckoId = coingeckoRows[0]?.id ?? null;
+
+        for (const { id: yahooId } of yahooRows) {
+          if (targetCoingeckoId) {
+            await queryInterface.sequelize.query(
+              `UPDATE "Holdings" SET "securityId" = :coingeckoId WHERE "securityId" = :yahooId`,
+              { replacements: { coingeckoId: targetCoingeckoId, yahooId }, transaction: t },
+            );
+            await queryInterface.sequelize.query(
+              `UPDATE "InvestmentTransactions" SET "securityId" = :coingeckoId WHERE "securityId" = :yahooId`,
+              { replacements: { coingeckoId: targetCoingeckoId, yahooId }, transaction: t },
+            );
+            // Drop yahoo pricing rows whose `date` already has a coingecko row —
+            // the coingecko row is provider-of-record and takes precedence.
+            await queryInterface.sequelize.query(
+              `DELETE FROM "SecurityPricings" yp
+                 WHERE yp."securityId" = :yahooId
+                   AND EXISTS (
+                     SELECT 1 FROM "SecurityPricings" cg
+                      WHERE cg."securityId" = :coingeckoId
+                        AND cg."date" = yp."date"
+                   )`,
+              { replacements: { coingeckoId: targetCoingeckoId, yahooId }, transaction: t },
+            );
+            await queryInterface.sequelize.query(
+              `UPDATE "SecurityPricings" SET "securityId" = :coingeckoId WHERE "securityId" = :yahooId`,
+              { replacements: { coingeckoId: targetCoingeckoId, yahooId }, transaction: t },
+            );
+            await queryInterface.sequelize.query(`DELETE FROM "Securities" WHERE id = :yahooId`, {
+              replacements: { yahooId },
+              transaction: t,
+            });
+          } else {
+            await queryInterface.sequelize.query(
+              `UPDATE "Securities"
+                  SET "providerName" = 'coingecko',
+                      "providerSymbol" = :slug
+                WHERE id = :yahooId`,
+              { replacements: { slug, yahooId }, transaction: t },
+            );
+          }
+        }
+      }
+
+      const unmapped = (await queryInterface.sequelize.query(
+        `SELECT DISTINCT "providerSymbol" FROM "Securities"
+           WHERE "providerName" = 'yahoo'
+             AND "assetClass" = 'crypto'`,
+        { type: QueryTypes.SELECT, transaction: t },
+      )) as Array<{ providerSymbol: string }>;
+
+      if (unmapped.length > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          '[migration 20260526000000] Legacy yahoo crypto Securities without a CoinGecko mapping ' +
+            `(will continue to fail the sync until mapped): ${unmapped.map((r) => r.providerSymbol).join(', ')}`,
+        );
+      }
+
+      await t.commit();
+    } catch (error) {
+      await t.rollback();
+      throw error;
+    }
+  },
+
+  // The up migration merges pricing rows on collision, so it cannot be undone
+  // deterministically — reverting would amount to lossy guesswork. Throw
+  // rather than offer a misleading no-op.
+  down: async (): Promise<void> => {
+    throw new Error(
+      'Reverting 20260526000000-migrate-legacy-yahoo-crypto-to-coingecko is not supported: ' +
+        'the up migration merges pricing rows on collision, so it cannot be undone deterministically.',
+    );
+  },
+};

--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
@@ -346,6 +346,18 @@ export class EnableBankingApiClient {
         headers: this.getAuthHeaders(psuContext),
       });
     } catch (error) {
+      // Already-closed = nothing to revoke. Swallow the 400 so handleApiError
+      // doesn't log + throw on every reauthorize that follows a stale session.
+      if (axios.isAxiosError(error)) {
+        const status = error.response?.status;
+        const data = error.response?.data as { error?: unknown } | undefined;
+        if (status === 400 && data?.error === 'CLOSED_SESSION') {
+          logger.info(
+            `[EnableBankingApiClient] deleteSession: session ${sessionId} already closed upstream; treating as success`,
+          );
+          return;
+        }
+      }
       this.handleApiError(error, 'deleteSession');
     }
   }

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
@@ -17,6 +17,45 @@ import {
 } from '@tests/mocks/enablebanking/data';
 import { HttpResponse, http } from 'msw';
 
+/**
+ * Create a fully-active EnableBanking connection with one linked account.
+ * Shared across describe blocks that exercise post-setup state (session
+ * expiry, ASPSP errors, malformed-data resilience).
+ */
+async function setupActiveConnection(): Promise<{
+  connectionId: string;
+  accountId: string;
+}> {
+  const connectResult = await helpers.bankDataProviders.connectProvider({
+    providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+    credentials: helpers.enablebanking.mockCredentials(),
+    raw: true,
+  });
+
+  const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
+
+  await helpers.makeRequest({
+    method: 'post',
+    url: '/bank-data-providers/enablebanking/oauth-callback',
+    payload: {
+      connectionId: connectResult.connectionId,
+      code: helpers.enablebanking.mockAuthCode,
+      state,
+    },
+  });
+
+  const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+    connectionId: connectResult.connectionId,
+    accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
+    raw: true,
+  });
+
+  return {
+    connectionId: connectResult.connectionId,
+    accountId: syncedAccounts[0]!.id,
+  };
+}
+
 describe('Enable Banking Data Provider E2E', () => {
   // Reset mock session counter before each test to ensure predictable behavior
   // The counter determines whether mock returns original or reconnected account UIDs
@@ -1152,6 +1191,60 @@ describe('Enable Banking Data Provider E2E', () => {
 
       expect(connection.isActive).toBe(true);
     });
+
+    it('should succeed when upstream deleteSession reports CLOSED_SESSION', async () => {
+      // Reauthorize calls DELETE /sessions/:id on the old session before
+      // starting a new OAuth flow. If the session is already gone (user
+      // disconnected from the bank's side, natural expiry, etc.), Enable
+      // Banking responds with HTTP 400 + `error: "CLOSED_SESSION"`. That's
+      // the same end-state we wanted, so reauthorize must keep going rather
+      // than fail the request and noise up Sentry.
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+        credentials: helpers.enablebanking.mockCredentials(),
+        raw: true,
+      });
+
+      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/bank-data-providers/enablebanking/oauth-callback',
+        payload: {
+          connectionId: connectResult.connectionId,
+          code: helpers.enablebanking.mockAuthCode,
+          state,
+        },
+      });
+
+      global.mswMockServer.use(
+        http.delete('https://api.enablebanking.com/sessions/:sessionId', () => {
+          return new HttpResponse(
+            JSON.stringify({
+              code: 400,
+              message: 'Session is closed',
+              error: 'CLOSED_SESSION',
+              detail: null,
+            }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } },
+          );
+        }),
+      );
+
+      const reauthorizeResult = (await helpers.makeRequest({
+        method: 'post',
+        url: `/bank-data-providers/connections/${connectResult.connectionId}/reauthorize`,
+        raw: true,
+      })) as { authUrl: string };
+
+      expect(reauthorizeResult.authUrl).toBeDefined();
+      expect(reauthorizeResult.authUrl).toContain('https://');
+
+      const { connection } = await helpers.bankDataProviders.getConnectionDetails({
+        connectionId: connectResult.connectionId,
+        raw: true,
+      });
+      expect(connection.isActive).toBe(false);
+    });
   });
 
   describe('Reauthorization with stable externalId', () => {
@@ -1796,44 +1889,6 @@ describe('Enable Banking Data Provider E2E', () => {
   });
 
   describe('403 session expiry handling', () => {
-    /**
-     * Helper to create a fully-active connection with one linked account.
-     * Returns connectionId and the linked system accountId.
-     */
-    async function setupActiveConnection(): Promise<{
-      connectionId: string;
-      accountId: string;
-    }> {
-      const connectResult = await helpers.bankDataProviders.connectProvider({
-        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
-        credentials: helpers.enablebanking.mockCredentials(),
-        raw: true,
-      });
-
-      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
-
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/bank-data-providers/enablebanking/oauth-callback',
-        payload: {
-          connectionId: connectResult.connectionId,
-          code: helpers.enablebanking.mockAuthCode,
-          state,
-        },
-      });
-
-      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
-        connectionId: connectResult.connectionId,
-        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
-        raw: true,
-      });
-
-      return {
-        connectionId: connectResult.connectionId,
-        accountId: syncedAccounts[0]!.id,
-      };
-    }
-
     it('should mark connection as inactive when transactions API returns 403', async () => {
       const { connectionId, accountId } = await setupActiveConnection();
 
@@ -2060,40 +2115,6 @@ describe('Enable Banking Data Provider E2E', () => {
   });
 
   describe('getConnectionDetails resilience to malformed stored data', () => {
-    async function setupActiveConnection(): Promise<{
-      connectionId: string;
-      accountId: string;
-    }> {
-      const connectResult = await helpers.bankDataProviders.connectProvider({
-        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
-        credentials: helpers.enablebanking.mockCredentials(),
-        raw: true,
-      });
-
-      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
-
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/bank-data-providers/enablebanking/oauth-callback',
-        payload: {
-          connectionId: connectResult.connectionId,
-          code: helpers.enablebanking.mockAuthCode,
-          state,
-        },
-      });
-
-      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
-        connectionId: connectResult.connectionId,
-        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
-        raw: true,
-      });
-
-      return {
-        connectionId: connectResult.connectionId,
-        accountId: syncedAccounts[0]!.id,
-      };
-    }
-
     it('should not crash when an account has a null currentBalance (legacy/historical rows)', async () => {
       const { connectionId, accountId } = await setupActiveConnection();
 
@@ -2215,45 +2236,6 @@ describe('Enable Banking Data Provider E2E', () => {
   });
 
   describe('ASPSP_ERROR auth-failure classification', () => {
-    /**
-     * Helper to create a fully-active connection with one linked account.
-     * Duplicated from the 403 suite intentionally — keeps this block
-     * standalone and the dep injection trivial to follow.
-     */
-    async function setupActiveConnection(): Promise<{
-      connectionId: string;
-      accountId: string;
-    }> {
-      const connectResult = await helpers.bankDataProviders.connectProvider({
-        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
-        credentials: helpers.enablebanking.mockCredentials(),
-        raw: true,
-      });
-
-      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
-
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/bank-data-providers/enablebanking/oauth-callback',
-        payload: {
-          connectionId: connectResult.connectionId,
-          code: helpers.enablebanking.mockAuthCode,
-          state,
-        },
-      });
-
-      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
-        connectionId: connectResult.connectionId,
-        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
-        raw: true,
-      });
-
-      return {
-        connectionId: connectResult.connectionId,
-        accountId: syncedAccounts[0]!.id,
-      };
-    }
-
     it('promotes wrapped-400 ASPSP_ERROR with nested 403 to ForbiddenError + deactivates with auth_failure marker', async () => {
       const { connectionId, accountId } = await setupActiveConnection();
 

--- a/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
+++ b/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
@@ -203,9 +203,14 @@ const securitiesPricesSyncImpl = async (options: SyncOptions): Promise<Securitie
     // be 1000 of securities, but bulk will fail, we will need to process all 1000
     // individually – it's too costly.
     try {
+      // No `validate: true`: Sequelize runs per-instance validation before
+      // injecting timestamps, so the explicit `@Column({ allowNull: false })`
+      // on SecurityPricing.createdAt/updatedAt always trips the allowNull
+      // validator with "createdAt cannot be null". The DB still enforces
+      // NOT NULL at INSERT and the Money setter validates priceClose, so
+      // dropping app-layer validation loses no real coverage.
       await SecurityPricing.bulkCreate(securityPricesToUpsert, {
         updateOnDuplicate: ['priceClose', 'source'],
-        validate: true,
       });
 
       result.successfulUpdates = securityPricesToUpsert.length;

--- a/packages/backend/src/services/stats/get-combined-balance-history.e2e.ts
+++ b/packages/backend/src/services/stats/get-combined-balance-history.e2e.ts
@@ -1,10 +1,14 @@
 import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY, SECURITY_PROVIDER, TRANSACTION_TYPES } from '@bt/shared/types';
-import { describe, expect, it } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
 import Balances from '@models/balances.model';
+import ExchangeRates from '@models/exchange-rates.model';
 import Securities from '@models/investments/securities.model';
 import SecurityPricing from '@models/investments/security-pricing.model';
+import UserExchangeRates from '@models/user-exchange-rates.model';
+import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/fetch-exchange-rates-for-date';
 import * as helpers from '@tests/helpers';
 import { format, subDays } from 'date-fns';
+import { Op } from 'sequelize';
 
 import { CombinedBalanceHistoryItem } from './get-combined-balance-history';
 
@@ -377,6 +381,322 @@ describe('[Stats] Combined balance history', () => {
       const bothEntry = (bothData as CombinedBalanceHistoryItem[]).find((e) => e.date === dayKey);
       expect(bothEntry).toBeDefined();
       expect(bothEntry!.portfoliosBalance).toBe(baselinePortfolio);
+    });
+  });
+
+  describe('Portfolio cross-currency conversion (USD-base ExchangeRates pivot)', () => {
+    // ExchangeRates is preserved across test truncation as seed data (see
+    // `SEED_DATA_TABLES` in `setupIntegrationTests.ts`). Tests in this block
+    // need precise control over which rates exist when the history endpoint
+    // runs, so the cleanup happens BOTH before each test (to clear any prior
+    // describe's leak) and inside `seedHoldingAndPriceHistory` AFTER the
+    // investment-transaction insert (because `calculateRefAmount` lazily
+    // fetches rates and stores them — without that second wipe, every test
+    // would observe an unexpected USD→AED row).
+    const FX_QUOTE_CODES_TOUCHED = ['AED', 'EUR'];
+
+    const wipeFxState = async () => {
+      await ExchangeRates.destroy({
+        where: {
+          baseCode: API_LAYER_BASE_CURRENCY_CODE,
+          quoteCode: { [Op.in]: FX_QUOTE_CODES_TOUCHED },
+        },
+      });
+      await UserExchangeRates.destroy({ where: { userId: 1 } });
+    };
+
+    const seedHoldingAndPriceHistory = async ({
+      portfolioId,
+      securityId,
+      pickedDay,
+      dayKey,
+      price = '100',
+    }: {
+      portfolioId: string;
+      securityId: string;
+      pickedDay: Date;
+      dayKey: string;
+      price?: string;
+    }) => {
+      await helpers.createHolding({ payload: { portfolioId, securityId } });
+      // Drain any background sync from createHolding before clobbering the
+      // single SecurityPricing row this test relies on.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      await SecurityPricing.destroy({ where: { securityId } });
+
+      await SecurityPricing.create({
+        securityId,
+        date: pickedDay,
+        priceClose: price,
+        source: SECURITY_PROVIDER.yahoo,
+      });
+
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId,
+          securityId,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: dayKey,
+          quantity: '1',
+          price,
+          fees: '0',
+        },
+        raw: true,
+      });
+
+      // The transaction-create flow calls `calculateRefAmount`, which lazily
+      // hits the live FX provider and writes a row to `ExchangeRates`. Wipe
+      // that row so each test asserts only against the rates it explicitly
+      // seeds in the lines that follow.
+      await wipeFxState();
+    };
+
+    beforeEach(wipeFxState);
+
+    it('converts USD security holdings into the user base currency via stored USD-pivot rates', async () => {
+      // Regression guard for the case where `ExchangeRates` is queried as
+      // `baseCode = securityCurrency, quoteCode = userBase` — rows are seeded
+      // as `baseCode = USD, quoteCode = X` so that direction never matches and
+      // the lookup silently falls back to 1:1. This test pins both the lookup
+      // direction AND the cross-rate maths by asserting an exact converted
+      // value: with USD→AED = 4 and a USD-denominated holding worth $100, the
+      // portfolio balance must be 400 AED, NOT 100 AED.
+      const pickedDay = subDays(new Date(), 3);
+      pickedDay.setUTCHours(0, 0, 0, 0);
+      const dayKey = format(pickedDay, 'yyyy-MM-dd');
+
+      const portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'USD Stocks' }),
+        raw: true,
+      });
+
+      const usdSecurity = await Securities.create({
+        symbol: 'AAPL',
+        providerSymbol: 'AAPL',
+        currencyCode: 'USD',
+        providerName: SECURITY_PROVIDER.yahoo,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'Apple Inc.',
+      });
+
+      await seedHoldingAndPriceHistory({
+        portfolioId: portfolio.id,
+        securityId: usdSecurity.id,
+        pickedDay,
+        dayKey,
+      });
+
+      // Round-number rate so the assertion is exact: 1 USD = 4 AED.
+      await ExchangeRates.create({
+        baseCode: API_LAYER_BASE_CURRENCY_CODE,
+        quoteCode: 'AED',
+        rate: 4,
+        date: pickedDay,
+      });
+
+      const data = (await helpers.getCombinedBalanceHistory({
+        from: format(subDays(pickedDay, 1), 'yyyy-MM-dd'),
+        to: format(new Date(), 'yyyy-MM-dd'),
+        raw: true,
+      })) as CombinedBalanceHistoryItem[];
+
+      const entry = data.find((e) => e.date === dayKey);
+      expect(entry).toBeDefined();
+      // 1 share * $100 * 4 AED/USD = 400 AED. The API serializer returns
+      // decimals (not cents), so 400 is the expected value over the wire.
+      expect(entry!.portfoliosBalance).toBe(400);
+    });
+
+    it('computes the correct cross-rate when neither security nor user base is USD', async () => {
+      // Security in EUR, user base AED. USD→EUR = 2, USD→AED = 4 -> EUR→AED = 2.
+      // 1 share * €100 * 2 AED/EUR = 200 AED.
+      const pickedDay = subDays(new Date(), 3);
+      pickedDay.setUTCHours(0, 0, 0, 0);
+      const dayKey = format(pickedDay, 'yyyy-MM-dd');
+
+      const portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'EUR Stocks' }),
+        raw: true,
+      });
+
+      const eurSecurity = await Securities.create({
+        symbol: 'ASML',
+        providerSymbol: 'ASML.AS',
+        currencyCode: 'EUR',
+        providerName: SECURITY_PROVIDER.yahoo,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'ASML Holding',
+      });
+
+      await seedHoldingAndPriceHistory({
+        portfolioId: portfolio.id,
+        securityId: eurSecurity.id,
+        pickedDay,
+        dayKey,
+      });
+
+      await ExchangeRates.bulkCreate([
+        { baseCode: API_LAYER_BASE_CURRENCY_CODE, quoteCode: 'EUR', rate: 2, date: pickedDay },
+        { baseCode: API_LAYER_BASE_CURRENCY_CODE, quoteCode: 'AED', rate: 4, date: pickedDay },
+      ]);
+
+      const data = (await helpers.getCombinedBalanceHistory({
+        from: format(subDays(pickedDay, 1), 'yyyy-MM-dd'),
+        to: format(new Date(), 'yyyy-MM-dd'),
+        raw: true,
+      })) as CombinedBalanceHistoryItem[];
+
+      const entry = data.find((e) => e.date === dayKey);
+      expect(entry).toBeDefined();
+      expect(entry!.portfoliosBalance).toBe(200);
+    });
+
+    it('walks back to a prior-date rate when no rate exists for the requested day', async () => {
+      // Seed USD→AED only at day-5; query on pickedDay (day-2). `findLatestUsdRate`
+      // must walk back to the prior rate rather than fall through to 1:1.
+      const pickedDay = subDays(new Date(), 2);
+      pickedDay.setUTCHours(0, 0, 0, 0);
+      const rateSeedDay = subDays(pickedDay, 3);
+      rateSeedDay.setUTCHours(0, 0, 0, 0);
+      const dayKey = format(pickedDay, 'yyyy-MM-dd');
+
+      const portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'Walk-back portfolio' }),
+        raw: true,
+      });
+
+      const usdSecurity = await Securities.create({
+        symbol: 'MSFT',
+        providerSymbol: 'MSFT',
+        currencyCode: 'USD',
+        providerName: SECURITY_PROVIDER.yahoo,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'Microsoft',
+      });
+
+      await seedHoldingAndPriceHistory({
+        portfolioId: portfolio.id,
+        securityId: usdSecurity.id,
+        pickedDay,
+        dayKey,
+      });
+
+      await ExchangeRates.create({
+        baseCode: API_LAYER_BASE_CURRENCY_CODE,
+        quoteCode: 'AED',
+        rate: 4,
+        date: rateSeedDay,
+      });
+
+      const data = (await helpers.getCombinedBalanceHistory({
+        from: format(subDays(pickedDay, 1), 'yyyy-MM-dd'),
+        to: format(new Date(), 'yyyy-MM-dd'),
+        raw: true,
+      })) as CombinedBalanceHistoryItem[];
+
+      const entry = data.find((e) => e.date === dayKey);
+      expect(entry).toBeDefined();
+      // Walk-back must use the seeded rate, not the 1:1 fallback.
+      expect(entry!.portfoliosBalance).toBe(400);
+    });
+
+    it('prefers a UserExchangeRates override over the canonical USD-pivot rate', async () => {
+      // System rate USD→AED = 4. User override (UserExchangeRates baseCode=USD,
+      // quoteCode=AED) = 10. Override must win.
+      const pickedDay = subDays(new Date(), 3);
+      pickedDay.setUTCHours(0, 0, 0, 0);
+      const dayKey = format(pickedDay, 'yyyy-MM-dd');
+
+      const portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'Override portfolio' }),
+        raw: true,
+      });
+
+      const usdSecurity = await Securities.create({
+        symbol: 'GOOG',
+        providerSymbol: 'GOOG',
+        currencyCode: 'USD',
+        providerName: SECURITY_PROVIDER.yahoo,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'Alphabet',
+      });
+
+      await seedHoldingAndPriceHistory({
+        portfolioId: portfolio.id,
+        securityId: usdSecurity.id,
+        pickedDay,
+        dayKey,
+      });
+
+      await ExchangeRates.create({
+        baseCode: API_LAYER_BASE_CURRENCY_CODE,
+        quoteCode: 'AED',
+        rate: 4,
+        date: pickedDay,
+      });
+      // UserExchangeRates is keyed on the global default user (userId=1 in the
+      // integration setup). Insert directly so the test doesn't depend on the
+      // edit-rate HTTP flow.
+      await UserExchangeRates.create({
+        userId: 1,
+        baseCode: 'USD',
+        quoteCode: 'AED',
+        rate: 10,
+        date: pickedDay,
+      });
+
+      const data = (await helpers.getCombinedBalanceHistory({
+        from: format(subDays(pickedDay, 1), 'yyyy-MM-dd'),
+        to: format(new Date(), 'yyyy-MM-dd'),
+        raw: true,
+      })) as CombinedBalanceHistoryItem[];
+
+      const entry = data.find((e) => e.date === dayKey);
+      expect(entry).toBeDefined();
+      // Override rate 10 wins -> 1 * 100 * 10 = 1000 AED.
+      expect(entry!.portfoliosBalance).toBe(1000);
+    });
+
+    it('falls back to 1:1 (security-currency value) when no rate of any kind exists', async () => {
+      // No ExchangeRates / UserExchangeRates seeded. The endpoint must not
+      // crash — it returns the security-currency value as-is (1:1) and the
+      // dispatcher emits a single trailing warn. This pins the documented
+      // graceful-degradation contract.
+      const pickedDay = subDays(new Date(), 3);
+      pickedDay.setUTCHours(0, 0, 0, 0);
+      const dayKey = format(pickedDay, 'yyyy-MM-dd');
+
+      const portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'No-rate portfolio' }),
+        raw: true,
+      });
+
+      const usdSecurity = await Securities.create({
+        symbol: 'AMZN',
+        providerSymbol: 'AMZN',
+        currencyCode: 'USD',
+        providerName: SECURITY_PROVIDER.yahoo,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'Amazon',
+      });
+
+      await seedHoldingAndPriceHistory({
+        portfolioId: portfolio.id,
+        securityId: usdSecurity.id,
+        pickedDay,
+        dayKey,
+      });
+
+      const data = (await helpers.getCombinedBalanceHistory({
+        from: format(subDays(pickedDay, 1), 'yyyy-MM-dd'),
+        to: format(new Date(), 'yyyy-MM-dd'),
+        raw: true,
+      })) as CombinedBalanceHistoryItem[];
+
+      const entry = data.find((e) => e.date === dayKey);
+      expect(entry).toBeDefined();
+      // Rate falls back to 1 -> 1 * 100 * 1 = 100 in user-base units.
+      expect(entry!.portfoliosBalance).toBe(100);
     });
   });
 });

--- a/packages/backend/src/services/stats/get-combined-balance-history.ts
+++ b/packages/backend/src/services/stats/get-combined-balance-history.ts
@@ -8,6 +8,7 @@ import Securities from '@models/investments/securities.model';
 import SecurityPricing from '@models/investments/security-pricing.model';
 import UserExchangeRates from '@models/user-exchange-rates.model';
 import UsersCurrencies from '@models/users-currencies.model';
+import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/fetch-exchange-rates-for-date';
 import { eachDayOfInterval, endOfDay, format, parseISO, startOfDay, subDays } from 'date-fns';
 import { Op } from 'sequelize';
 
@@ -111,6 +112,13 @@ const calculatePortfolioBalanceHistory = async ({
   type SecurityPriceRow = Pick<SecurityPricing, 'securityId' | 'date' | 'priceClose'>;
   type ExchangeRateRow = Pick<UserExchangeRates, 'baseCode' | 'quoteCode' | 'date' | 'rate'>;
 
+  // Currencies we need a `USD → X` rate for: every security currency PLUS the
+  // user's base currency (used as the numerator in the cross-rate). USD itself
+  // is excluded because `findLatestUsdRate` short-circuits to 1 for it.
+  const usdRateQuoteCodes = [...new Set([userBaseCurrency.currencyCode, ...currencyCodes])].filter(
+    (code) => code !== API_LAYER_BASE_CURRENCY_CODE,
+  );
+
   const [securityPrices, userCustomExchangeRates, systemExchangeRates] = await Promise.all([
     SecurityPricing.findAll({
       where: {
@@ -144,18 +152,23 @@ const calculatePortfolioBalanceHistory = async ({
       attributes: ['baseCode', 'quoteCode', 'date', 'rate'],
       raw: true,
     }) as Promise<ExchangeRateRow[]>,
+    // System rates are stored only in one canonical direction:
+    // `baseCode = API_LAYER_BASE_CURRENCY_CODE (USD), quoteCode = X` (1 USD = N X).
+    // Query that direction for every currency we need to convert _from_ AND
+    // for the user's base currency, then compute the actual security→base
+    // cross-rate in `getExchangeRate` below. The cross-rate maths mirrors
+    // `services/user-exchange-rate/get-exchange-rate.service.ts` — keep the
+    // two implementations in sync if you touch either.
     ExchangeRates.findAll({
       where: {
-        baseCode: {
-          [Op.in]: currencyCodes,
-        },
-        quoteCode: userBaseCurrency.currencyCode,
+        baseCode: API_LAYER_BASE_CURRENCY_CODE,
+        quoteCode: { [Op.in]: usdRateQuoteCodes },
         date: {
           [Op.between]: [startOfDay(parseISO(dataFetchMinDate)), endOfDay(parseISO(maxDate))],
         },
       },
       order: [
-        ['baseCode', 'ASC'],
+        ['quoteCode', 'ASC'],
         ['date', 'ASC'],
       ],
       raw: true,
@@ -182,48 +195,87 @@ const calculatePortfolioBalanceHistory = async ({
     pricesBySecurityAndDate.set(`${price.securityId}_${dateStr}`, priceValue);
   }
 
-  const exchangeRateMap = new Map<string, number>();
-
-  // Build user rates map first for O(1) lookup
+  // User-set overrides — these are stored as `currencyCode → userBase` directly,
+  // not via USD pivot, so they short-circuit the cross-rate maths below.
   const userRatesMap = new Map<string, number>();
   for (const r of userCustomExchangeRates) {
     userRatesMap.set(`${r.baseCode}_${formatDate(r.date)}`, r.rate);
   }
 
+  // System rates indexed by `${quoteCode}_${dateStr}` — value is `1 USD = N quoteCode`.
+  // Same currency can be queried under multiple cross-pairs so this stays a single
+  // source of truth instead of one map per pair.
+  const usdRatesMap = new Map<string, number>();
+  // Per-currency sorted date list, ascending — used by `findLatestUsdRate` to walk
+  // backwards from the requested date when an exact match is missing (weekends,
+  // pre-historical-init dates).
+  const usdRateDatesByQuote = new Map<string, string[]>();
   for (const rate of systemExchangeRates) {
-    const key = `${rate.baseCode}_${formatDate(rate.date)}`;
-    // O(1) lookup instead of O(n) find
-    const userRate = userRatesMap.get(key);
-    exchangeRateMap.set(key, userRate ?? rate.rate);
+    const dateStr = formatDate(rate.date);
+    usdRatesMap.set(`${rate.quoteCode}_${dateStr}`, rate.rate);
+
+    const dates = usdRateDatesByQuote.get(rate.quoteCode);
+    if (dates) {
+      dates.push(dateStr);
+    } else {
+      usdRateDatesByQuote.set(rate.quoteCode, [dateStr]);
+    }
   }
 
   const missingRateCurrencies = new Set<string>();
+
+  // Look up `1 USD = ? quoteCode` for `dateStr`, falling back to the most
+  // recent prior rate if the exact day isn't present. Returns `null` if no
+  // rate at all is known for this currency.
+  const findLatestUsdRate = (quoteCode: string, dateStr: string): number | null => {
+    if (quoteCode === API_LAYER_BASE_CURRENCY_CODE) return 1;
+
+    const exact = usdRatesMap.get(`${quoteCode}_${dateStr}`);
+    if (exact !== undefined) return exact;
+
+    const dates = usdRateDatesByQuote.get(quoteCode);
+    if (!dates || dates.length === 0) return null;
+
+    let candidate: number | null = null;
+    for (const d of dates) {
+      if (d <= dateStr) {
+        candidate = usdRatesMap.get(`${quoteCode}_${d}`) ?? candidate;
+      } else {
+        break;
+      }
+    }
+    return candidate;
+  };
 
   const getExchangeRate = (currencyCode: string, dateStr: string): number => {
     if (currencyCode === userBaseCurrency.currencyCode) {
       return 1;
     }
 
-    const key = `${currencyCode}_${dateStr}`;
-    const rate = exchangeRateMap.get(key);
+    // User override (`currencyCode → userBase`) wins over the computed cross-rate.
+    const userOverride = userRatesMap.get(`${currencyCode}_${dateStr}`);
+    if (userOverride !== undefined) return userOverride;
 
-    if (rate) {
-      return rate;
+    // Cross-rate via USD pivot: value_in_userBase = value_in_currencyCode *
+    // (USD→userBase) / (USD→currencyCode).
+    const usdToCurrency = findLatestUsdRate(currencyCode, dateStr);
+    const usdToBase = findLatestUsdRate(userBaseCurrency.currencyCode, dateStr);
+
+    if (usdToCurrency == null || usdToBase == null) {
+      missingRateCurrencies.add(currencyCode);
+      return 1;
     }
 
-    const availableRates = Array.from(exchangeRateMap.entries())
-      .filter(([k]) => {
-        const parts = k.split('_');
-        return k.startsWith(`${currencyCode}_`) && parts[1] && parts[1] <= dateStr;
-      })
-      .toSorted((a, b) => b[0].localeCompare(a[0]));
-
-    if (availableRates.length > 0) {
-      return availableRates[0]![1];
+    // A stored zero rate is data corruption, not a missing-rate gap — only a
+    // bad DB write or an upstream provider bug can produce it. Surface it as
+    // an error (not the missing-rate warn) and refuse to divide by zero.
+    if (usdToCurrency === 0) {
+      logger.error(`Stored exchange rate is zero for USD->${currencyCode} on ${dateStr}; treating as missing.`);
+      missingRateCurrencies.add(currencyCode);
+      return 1;
     }
 
-    missingRateCurrencies.add(currencyCode);
-    return 1;
+    return usdToBase / usdToCurrency;
   };
 
   const findPriceForDate = (securityId: string, targetDate: string): number | null => {


### PR DESCRIPTION
- fixes legacy Yahoo crypto rows were routed to CoinGecko so it failed to fatch the prices
- `CLOSED_SESSION` now treats as "success" when trying to deleteSession