### PR TITLE
perf(mcp): slim MCP read-tool responses to AI-relevant fields

### DIFF
--- a/packages/backend/src/services/mcp/serializers.ts
+++ b/packages/backend/src/services/mcp/serializers.ts
@@ -8,6 +8,11 @@
  * helpers take the already-serialized, already-decimal output and keep only the
  * fields an assistant reasons about. The shared serializers stay untouched.
  */
+import type Accounts from '@models/accounts.model';
+import type Categories from '@models/categories.model';
+import type SubscriptionTransactions from '@models/subscription-transactions.model';
+import type Subscriptions from '@models/subscriptions.model';
+import type { TransactionsAttributes } from '@models/transactions.model';
 import type { AccountApiResponse } from '@root/serializers/accounts.serializer';
 import type { TransactionApiResponse } from '@root/serializers/transactions.serializer';
 
@@ -45,4 +50,65 @@ export function slimTransactionsForMcp(txs: TransactionApiResponse[]) {
     }),
     ...(tx.transactionGroups && { transactionGroups: tx.transactionGroups }),
   }));
+}
+
+/**
+ * Shape of a `getSubscriptionById` result, narrowed to the fields the MCP slimmer
+ * reads. Scalar fields are picked straight from the models so the types track the
+ * schema; only the values the service transforms are overridden — `expectedAmount`
+ * /`amount`/`refAmount` (Money → decimal number), the trimmed `account`/`category`
+ * associations, and the computed `nextExpectedDate`. The service returns a loosely
+ * typed `toJSON()` blob, so the tool casts into this before slimming.
+ */
+export type SubscriptionDetailForMcp = Pick<
+  Subscriptions,
+  'id' | 'name' | 'type' | 'frequency' | 'startDate' | 'endDate' | 'isActive' | 'notes' | 'expectedCurrencyCode'
+> & {
+  expectedAmount: number | null;
+  nextExpectedDate: Date | string | null;
+  account?: Pick<Accounts, 'id' | 'name' | 'currencyCode'> | null;
+  category?: Pick<Categories, 'id' | 'name'> | null;
+  transactions?: Array<
+    Pick<
+      TransactionsAttributes,
+      'id' | 'time' | 'currencyCode' | 'note' | 'transactionType' | 'categoryId' | 'accountId'
+    > & {
+      amount: number;
+      refAmount: number;
+      SubscriptionTransactions?: Pick<SubscriptionTransactions, 'matchSource' | 'matchedAt'> | null;
+    }
+  > | null;
+};
+
+export function slimSubscriptionDetailForMcp(sub: SubscriptionDetailForMcp) {
+  return {
+    id: sub.id,
+    name: sub.name,
+    type: sub.type,
+    expectedAmount: sub.expectedAmount,
+    expectedCurrencyCode: sub.expectedCurrencyCode,
+    frequency: sub.frequency,
+    startDate: sub.startDate,
+    endDate: sub.endDate,
+    isActive: sub.isActive,
+    notes: sub.notes,
+    nextExpectedDate: sub.nextExpectedDate,
+    account: sub.account ?? null,
+    category: sub.category ? { id: sub.category.id, name: sub.category.name } : null,
+    // Embedded transactions arrive as full Transaction models; keep only what
+    // confirms the link, plus the junction's match source/date.
+    transactions: (sub.transactions ?? []).map((tx) => ({
+      id: tx.id,
+      time: tx.time,
+      amount: tx.amount,
+      refAmount: tx.refAmount,
+      currencyCode: tx.currencyCode,
+      note: tx.note,
+      transactionType: tx.transactionType,
+      categoryId: tx.categoryId,
+      accountId: tx.accountId,
+      matchSource: tx.SubscriptionTransactions?.matchSource ?? null,
+      matchedAt: tx.SubscriptionTransactions?.matchedAt ?? null,
+    })),
+  };
 }

--- a/packages/backend/src/services/mcp/serializers.ts
+++ b/packages/backend/src/services/mcp/serializers.ts
@@ -1,0 +1,48 @@
+/**
+ * MCP-specific slimming over the REST serializer output.
+ *
+ * The REST serializers (`serializeAccounts`, `serializeTransactions`) carry
+ * fields the frontend needs — bank-sync metadata, ACL/share context, UI hints,
+ * audit timestamps, near-always-zero fee fields. For an AI client over MCP those
+ * are wasted context tokens (and `externalData` can be kilobytes per row). These
+ * helpers take the already-serialized, already-decimal output and keep only the
+ * fields an assistant reasons about. The shared serializers stay untouched.
+ */
+import type { AccountApiResponse } from '@root/serializers/accounts.serializer';
+import type { TransactionApiResponse } from '@root/serializers/transactions.serializer';
+
+export function slimAccountsForMcp(accounts: AccountApiResponse[]) {
+  return accounts.map((a) => ({
+    id: a.id,
+    name: a.name,
+    type: a.type,
+    accountCategory: a.accountCategory,
+    currencyCode: a.currencyCode,
+    currentBalance: a.currentBalance,
+    refCurrentBalance: a.refCurrentBalance,
+    creditLimit: a.creditLimit,
+    refCreditLimit: a.refCreditLimit,
+    status: a.status,
+    excludeFromStats: a.excludeFromStats,
+  }));
+}
+
+export function slimTransactionsForMcp(txs: TransactionApiResponse[]) {
+  return txs.map((tx) => ({
+    id: tx.id,
+    time: tx.time,
+    amount: tx.amount,
+    refAmount: tx.refAmount,
+    currencyCode: tx.currencyCode,
+    note: tx.note,
+    transactionType: tx.transactionType,
+    transferNature: tx.transferNature,
+    accountId: tx.accountId,
+    categoryId: tx.categoryId,
+    ...(tx.tags && { tags: tx.tags.map((t) => ({ id: t.id, name: t.name })) }),
+    ...(tx.splits && {
+      splits: tx.splits.map((s) => ({ categoryId: s.categoryId, amount: s.amount, note: s.note })),
+    }),
+    ...(tx.transactionGroups && { transactionGroups: tx.transactionGroups }),
+  }));
+}

--- a/packages/backend/src/services/mcp/serializers.unit.ts
+++ b/packages/backend/src/services/mcp/serializers.unit.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from '@jest/globals';
 import type { AccountApiResponse } from '@root/serializers/accounts.serializer';
 import type { TransactionApiResponse } from '@root/serializers/transactions.serializer';
 
-import { slimAccountsForMcp, slimTransactionsForMcp } from './serializers';
+import {
+  type SubscriptionDetailForMcp,
+  slimAccountsForMcp,
+  slimSubscriptionDetailForMcp,
+  slimTransactionsForMcp,
+} from './serializers';
 
 const fullAccount: AccountApiResponse = {
   id: 'acc-1',
@@ -154,6 +159,80 @@ describe('MCP serializers', () => {
       expect(slim).not.toHaveProperty('tags');
       expect(slim).not.toHaveProperty('splits');
       expect(slim).not.toHaveProperty('transactionGroups');
+    });
+  });
+
+  describe('slimSubscriptionDetailForMcp', () => {
+    // Cast mirrors the tool: the service hands back a loosely-typed toJSON blob
+    // carrying matchingRules/userId/timestamps/bare FKs and category color/icon.
+    const fullSubscription = {
+      id: 'sub-1',
+      userId: 42,
+      name: 'Netflix',
+      type: 'subscription',
+      expectedAmount: 15.99,
+      expectedCurrencyCode: 'USD',
+      frequency: 'monthly',
+      startDate: '2026-01-01',
+      endDate: null,
+      accountId: 'acc-1',
+      categoryId: 'cat-1',
+      matchingRules: { merchant: 'NETFLIX', amountTolerance: 0.1 },
+      isActive: true,
+      notes: 'family plan',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      account: { id: 'acc-1', name: 'Checking', currencyCode: 'USD' },
+      category: { id: 'cat-1', name: 'Entertainment', color: '#fff', icon: 'tv' },
+      nextExpectedDate: '2026-02-01',
+      transactions: [
+        {
+          id: 'tx-1',
+          time: '2026-01-05T00:00:00.000Z',
+          amount: 15.99,
+          refAmount: 14.5,
+          commissionRate: 0,
+          cashbackAmount: 0,
+          note: 'Netflix',
+          userId: 42,
+          transactionType: 'expense',
+          paymentType: 'creditCard',
+          accountId: 'acc-1',
+          categoryId: 'cat-1',
+          currencyCode: 'USD',
+          externalData: { raw: 'BLOB' },
+          createdAt: '2026-01-05T00:00:00.000Z',
+          SubscriptionTransactions: { matchSource: 'auto', matchedAt: '2026-01-05T01:00:00.000Z', status: 'active' },
+        },
+      ],
+    } as unknown as SubscriptionDetailForMcp;
+
+    it('drops subscription-level internal fields and category color/icon', () => {
+      const slim = slimSubscriptionDetailForMcp(fullSubscription) as unknown as Record<string, unknown>;
+      for (const dropped of ['userId', 'matchingRules', 'accountId', 'categoryId', 'createdAt', 'updatedAt']) {
+        expect(slim).not.toHaveProperty(dropped);
+      }
+      expect(slim.category).toEqual({ id: 'cat-1', name: 'Entertainment' });
+      expect(slim.account).toEqual({ id: 'acc-1', name: 'Checking', currencyCode: 'USD' });
+    });
+
+    it('slims each linked transaction and surfaces junction match metadata', () => {
+      const slim = slimSubscriptionDetailForMcp(fullSubscription);
+      expect(slim.transactions).toEqual([
+        {
+          id: 'tx-1',
+          time: '2026-01-05T00:00:00.000Z',
+          amount: 15.99,
+          refAmount: 14.5,
+          currencyCode: 'USD',
+          note: 'Netflix',
+          transactionType: 'expense',
+          categoryId: 'cat-1',
+          accountId: 'acc-1',
+          matchSource: 'auto',
+          matchedAt: '2026-01-05T01:00:00.000Z',
+        },
+      ]);
     });
   });
 });

--- a/packages/backend/src/services/mcp/serializers.unit.ts
+++ b/packages/backend/src/services/mcp/serializers.unit.ts
@@ -1,0 +1,159 @@
+import { ACCOUNT_STATUSES, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import type { AccountApiResponse } from '@root/serializers/accounts.serializer';
+import type { TransactionApiResponse } from '@root/serializers/transactions.serializer';
+
+import { slimAccountsForMcp, slimTransactionsForMcp } from './serializers';
+
+const fullAccount: AccountApiResponse = {
+  id: 'acc-1',
+  name: 'Checking',
+  initialBalance: 100,
+  refInitialBalance: 100,
+  currentBalance: 250.5,
+  refCurrentBalance: 230.25,
+  creditLimit: 0,
+  refCreditLimit: 0,
+  type: 'system',
+  accountCategory: 'general',
+  currencyCode: 'USD',
+  userId: 42,
+  externalId: 'ext-abc',
+  externalData: { iban: 'SECRET', owner: 'PII' },
+  status: ACCOUNT_STATUSES.active,
+  excludeFromStats: false,
+  bankDataProviderConnectionId: 'conn-1',
+  bankProviderType: null,
+  needsRelink: true,
+  share: { isOwner: true } as AccountApiResponse['share'],
+};
+
+const fullTransaction: TransactionApiResponse = {
+  id: 'tx-1',
+  amount: 12.34,
+  refAmount: 11.5,
+  commissionRate: 0,
+  refCommissionRate: 0,
+  cashbackAmount: 0,
+  note: 'Coffee',
+  time: new Date('2026-01-01T10:00:00.000Z'),
+  userId: 42,
+  transactionType: TRANSACTION_TYPES.expense,
+  paymentType: 'creditCard',
+  accountId: 'acc-1',
+  categoryId: 'cat-1',
+  currencyCode: 'USD',
+  accountType: 'system',
+  refCurrencyCode: 'EUR',
+  transferNature: TRANSACTION_TRANSFER_NATURE.not_transfer,
+  transferId: null,
+  originalId: 'orig-1',
+  externalData: { raw: 'BANK BLOB' },
+  refundLinked: false,
+  createdAt: new Date('2026-01-01T10:00:00.000Z'),
+  updatedAt: new Date('2026-01-02T10:00:00.000Z'),
+  tags: [{ id: 'tag-1', name: 'food', color: '#fff', icon: 'cup' }],
+  splits: [{ id: 'split-1', categoryId: 'cat-2', amount: 12.34, refAmount: 11.5, note: 'half' }],
+  transactionGroups: [{ id: 'grp-1', name: 'Trip' }],
+};
+
+describe('MCP serializers', () => {
+  describe('slimAccountsForMcp', () => {
+    it('keeps only AI-relevant account fields', () => {
+      const slim = slimAccountsForMcp([fullAccount])[0]!;
+      expect(Object.keys(slim).toSorted()).toEqual(
+        [
+          'accountCategory',
+          'creditLimit',
+          'currencyCode',
+          'currentBalance',
+          'excludeFromStats',
+          'id',
+          'name',
+          'refCreditLimit',
+          'refCurrentBalance',
+          'status',
+          'type',
+        ].toSorted(),
+      );
+    });
+
+    it('drops bank-sync metadata, ACL and audit fields', () => {
+      const slim = (slimAccountsForMcp([fullAccount]) as unknown as Record<string, unknown>[])[0]!;
+      for (const dropped of [
+        'userId',
+        'externalId',
+        'externalData',
+        'bankDataProviderConnectionId',
+        'bankProviderType',
+        'needsRelink',
+        'share',
+        'initialBalance',
+        'refInitialBalance',
+      ]) {
+        expect(slim).not.toHaveProperty(dropped);
+      }
+    });
+  });
+
+  describe('slimTransactionsForMcp', () => {
+    it('keeps only AI-relevant transaction fields', () => {
+      const slim = slimTransactionsForMcp([fullTransaction])[0]!;
+      expect(Object.keys(slim).toSorted()).toEqual(
+        [
+          'accountId',
+          'amount',
+          'categoryId',
+          'currencyCode',
+          'id',
+          'note',
+          'refAmount',
+          'splits',
+          'tags',
+          'time',
+          'transactionGroups',
+          'transactionType',
+          'transferNature',
+        ].toSorted(),
+      );
+    });
+
+    it('drops fee, internal, audit and bank-blob fields', () => {
+      const slim = (slimTransactionsForMcp([fullTransaction]) as unknown as Record<string, unknown>[])[0]!;
+      for (const dropped of [
+        'userId',
+        'paymentType',
+        'accountType',
+        'refCurrencyCode',
+        'transferId',
+        'originalId',
+        'externalData',
+        'commissionRate',
+        'refCommissionRate',
+        'cashbackAmount',
+        'refundLinked',
+        'createdAt',
+        'updatedAt',
+      ]) {
+        expect(slim).not.toHaveProperty(dropped);
+      }
+    });
+
+    it('slims embedded tags to id+name and splits to category/amount/note', () => {
+      const slim = slimTransactionsForMcp([fullTransaction])[0]!;
+      expect(slim.tags).toEqual([{ id: 'tag-1', name: 'food' }]);
+      expect(slim.splits).toEqual([{ categoryId: 'cat-2', amount: 12.34, note: 'half' }]);
+    });
+
+    it('omits embedded collections when absent', () => {
+      const { tags, splits, transactionGroups, ...noCollections } = fullTransaction;
+      void tags;
+      void splits;
+      void transactionGroups;
+      const slim = (slimTransactionsForMcp([noCollections]) as unknown as Record<string, unknown>[])[0]!;
+      expect(slim).not.toHaveProperty('tags');
+      expect(slim).not.toHaveProperty('splits');
+      expect(slim).not.toHaveProperty('transactionGroups');
+    });
+  });
+});

--- a/packages/backend/src/services/mcp/tools/get-accounts.ts
+++ b/packages/backend/src/services/mcp/tools/get-accounts.ts
@@ -2,6 +2,7 @@ import { trackMcpToolUsed } from '@js/utils/posthog';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { serializeAccounts } from '@root/serializers/accounts.serializer';
 import { getAccounts } from '@services/accounts.service';
+import { slimAccountsForMcp } from '@services/mcp/serializers';
 import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
@@ -34,7 +35,7 @@ export function registerGetAccounts(server: McpServer) {
         result = result.filter((a) => !a.excludeFromStats);
       }
 
-      return jsonContent({ data: result });
+      return jsonContent({ data: slimAccountsForMcp(result) });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-budget-spending-stats.ts
+++ b/packages/backend/src/services/mcp/tools/get-budget-spending-stats.ts
@@ -1,6 +1,7 @@
 import { recordId } from '@common/lib/zod/custom-types';
 import { trackMcpToolUsed } from '@js/utils/posthog';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { serializeBudgetSpendingStats } from '@root/serializers';
 import { getBudgetSpendingStats } from '@services/budgets/spending-stats';
 
 import { getUserId, jsonContent } from './helpers';
@@ -10,7 +11,7 @@ export function registerGetBudgetSpendingStats(server: McpServer) {
     'get_budget_spending_stats',
     {
       description:
-        'Get spending statistics for a budget: spending broken down by category and a time-series of expense vs income over the budget period. Granularity is weekly for ranges ≤60 days, monthly otherwise. Amounts are in cents.',
+        'Get spending statistics for a budget: spending broken down by category and a time-series of expense vs income over the budget period. Granularity is weekly for ranges ≤60 days, monthly otherwise. Amounts are decimals.',
       inputSchema: {
         budgetId: recordId().describe('ID of the budget to retrieve spending stats for'),
       },
@@ -21,7 +22,7 @@ export function registerGetBudgetSpendingStats(server: McpServer) {
 
       const stats = await getBudgetSpendingStats({ userId, budgetId: args.budgetId });
 
-      return jsonContent({ data: stats });
+      return jsonContent({ data: serializeBudgetSpendingStats(stats) });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-portfolio-balances.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolio-balances.ts
@@ -30,7 +30,18 @@ export function registerGetPortfolioBalances(server: McpServer) {
         currencyCode: args.currencyCode,
       });
 
-      return jsonContent({ data: balances });
+      // Drop the embedded full Currencies model (redundant with currencyCode)
+      // and audit timestamps. Money fields serialize to plain decimal numbers.
+      const slimmed = balances.map((b) => ({
+        portfolioId: b.portfolioId,
+        currencyCode: b.currencyCode,
+        totalCash: b.totalCash,
+        availableCash: b.availableCash,
+        refTotalCash: b.refTotalCash,
+        refAvailableCash: b.refAvailableCash,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-portfolio-holdings.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolio-holdings.ts
@@ -32,7 +32,18 @@ export function registerGetPortfolioHoldings(server: McpServer) {
         date: args.date ? new Date(args.date) : undefined,
       });
 
-      return jsonContent({ data: holdings });
+      // The shared service embeds the full Securities model (~20 fields, mostly
+      // provider/exchange metadata and nulls) which is wasted context for AI
+      // clients. Keep only what an assistant reasons about. The holding's own
+      // securityId/currencyCode already cover identity and currency.
+      const slimmed = holdings.map(({ security, ...holding }) => ({
+        ...holding,
+        security: security
+          ? { symbol: security.symbol, name: security.name, assetClass: security.assetClass }
+          : undefined,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-portfolios.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolios.ts
@@ -34,7 +34,17 @@ export function registerGetPortfolios(server: McpServer) {
         offset: args.offset,
       });
 
-      return jsonContent({ data: portfolios });
+      // Raw model dump otherwise; drop the caller's own userId and audit fields.
+      const slimmed = portfolios.map((p) => ({
+        id: p.id,
+        name: p.name,
+        portfolioType: p.portfolioType,
+        description: p.description,
+        isEnabled: p.isEnabled,
+        createdAt: p.createdAt,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-subscription-by-id.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscription-by-id.ts
@@ -1,5 +1,6 @@
 import { trackMcpToolUsed } from '@js/utils/posthog';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { slimSubscriptionDetailForMcp } from '@services/mcp/serializers';
 import { getSubscriptionById } from '@services/subscriptions';
 import { z } from 'zod';
 
@@ -21,7 +22,7 @@ export function registerGetSubscriptionById(server: McpServer) {
 
       const result = await getSubscriptionById({ id: args.id, userId });
 
-      return jsonContent({ data: result });
+      return jsonContent({ data: slimSubscriptionDetailForMcp(result) });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-subscriptions.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscriptions.ts
@@ -26,7 +26,25 @@ export function registerGetSubscriptions(server: McpServer) {
 
       const result = await getSubscriptions({ userId, isActive: args.isActive, type: args.type });
 
-      return jsonContent({ data: result });
+      // Drop userId, matchingRules (engine config blob), bare account/category FKs
+      // (the embedded objects already carry them), audit timestamps and category UI hints.
+      const slimmed = result.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: s.type,
+        expectedAmount: s.expectedAmount,
+        expectedCurrencyCode: s.expectedCurrencyCode,
+        frequency: s.frequency,
+        startDate: s.startDate,
+        endDate: s.endDate,
+        isActive: s.isActive,
+        notes: s.notes,
+        linkedTransactionsCount: s.linkedTransactionsCount,
+        account: s.account,
+        category: s.category ? { id: s.category.id, name: s.category.name } : null,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/get-transaction-groups.ts
+++ b/packages/backend/src/services/mcp/tools/get-transaction-groups.ts
@@ -1,6 +1,12 @@
 import { trackMcpToolUsed } from '@js/utils/posthog';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { serializeTransactions } from '@root/serializers/transactions.serializer';
+import { slimTransactionsForMcp } from '@services/mcp/serializers';
 import { getTransactionGroups } from '@services/transaction-groups';
+import type {
+  TransactionGroupWithAggregates,
+  TransactionGroupWithTransactions,
+} from '@services/transaction-groups/get-transaction-groups';
 import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
@@ -24,7 +30,31 @@ export function registerGetTransactionGroups(server: McpServer) {
 
       const result = await getTransactionGroups({ userId, includeTransactions: args.includeTransactions });
 
-      return jsonContent({ data: result });
+      if (args.includeTransactions) {
+        const groups = result as TransactionGroupWithTransactions[];
+        const slimmed = groups.map((group) => ({
+          id: group.id,
+          name: group.name,
+          note: group.note,
+          // Embedded transactions are full models; run through the REST serializer
+          // (Money → decimals) then keep only the AI-relevant fields.
+          transactions: slimTransactionsForMcp(serializeTransactions(group.transactions)),
+        }));
+
+        return jsonContent({ data: slimmed });
+      }
+
+      const groups = result as TransactionGroupWithAggregates[];
+      const slimmed = groups.map((group) => ({
+        id: group.id,
+        name: group.name,
+        note: group.note,
+        transactionCount: group.transactionCount,
+        dateFrom: group.dateFrom,
+        dateTo: group.dateTo,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/search-securities.ts
+++ b/packages/backend/src/services/mcp/tools/search-securities.ts
@@ -32,7 +32,20 @@ export function registerSearchSecurities(server: McpServer) {
         user: { id: userId } as any,
       });
 
-      return jsonContent({ data: results });
+      // Drop provider routing keys (providerName/providerSymbol — not accepted by
+      // any MCP tool), regulatory ids (cusip/isin, usually null), and UI-only hints
+      // (logoUrl, matchType, exchange MIC/acronym).
+      const slimmed = results.map((r) => ({
+        symbol: r.symbol,
+        name: r.name,
+        assetClass: r.assetClass,
+        currencyCode: r.currencyCode,
+        exchangeName: r.exchangeName,
+        marketCapRank: r.marketCapRank,
+        isInPortfolio: r.isInPortfolio,
+      }));
+
+      return jsonContent({ data: slimmed });
     },
   );
 }

--- a/packages/backend/src/services/mcp/tools/search-transactions.ts
+++ b/packages/backend/src/services/mcp/tools/search-transactions.ts
@@ -4,6 +4,7 @@ import { Money } from '@common/types/money';
 import { trackMcpToolUsed } from '@js/utils/posthog';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { serializeTransactions } from '@root/serializers/transactions.serializer';
+import { slimTransactionsForMcp } from '@services/mcp/serializers';
 import { getTransactions } from '@services/transactions/get-transactions';
 import { z } from 'zod';
 
@@ -67,7 +68,7 @@ export function registerSearchTransactions(server: McpServer) {
 
       const transactions = await getTransactions(filterParams);
 
-      const serialized = serializeTransactions(transactions);
+      const serialized = slimTransactionsForMcp(serializeTransactions(transactions));
 
       return jsonContent({
         data: {

--- a/packages/backend/src/services/subscriptions/get-subscriptions.ts
+++ b/packages/backend/src/services/subscriptions/get-subscriptions.ts
@@ -3,8 +3,9 @@ import { Money } from '@common/types/money';
 import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
 import Accounts from '@models/accounts.model';
 import Categories from '@models/categories.model';
+import SubscriptionTransactions from '@models/subscription-transactions.model';
 import Subscriptions from '@models/subscriptions.model';
-import Transactions from '@models/transactions.model';
+import Transactions, { type TransactionsAttributes } from '@models/transactions.model';
 import { fn, literal } from 'sequelize';
 
 import { computeNextExpectedDate } from './subscription-date.utils';
@@ -17,7 +18,68 @@ interface GetSubscriptionsParams {
   type?: string;
 }
 
-export const getSubscriptions = async ({ userId, isActive, type }: GetSubscriptionsParams) => {
+// The included associations are loaded with trimmed attribute sets.
+type SubscriptionAccount = Pick<Accounts, 'id' | 'name' | 'currencyCode'>;
+type SubscriptionCategory = Pick<Categories, 'id' | 'name' | 'color' | 'icon'>;
+
+/**
+ * Subscription scalar columns plus its trimmed account/category associations.
+ * `expectedAmount` is a BIGINT (cents) on the model but is surfaced here as a
+ * decimal number — the type stays `number | null`, only the value changes.
+ */
+interface SubscriptionBase extends Pick<
+  Subscriptions,
+  | 'id'
+  | 'userId'
+  | 'name'
+  | 'type'
+  | 'expectedAmount'
+  | 'expectedCurrencyCode'
+  | 'frequency'
+  | 'startDate'
+  | 'endDate'
+  | 'accountId'
+  | 'categoryId'
+  | 'matchingRules'
+  | 'isActive'
+  | 'notes'
+  | 'createdAt'
+  | 'updatedAt'
+> {
+  account: SubscriptionAccount | null;
+  category: SubscriptionCategory | null;
+}
+
+interface SubscriptionListItem extends SubscriptionBase {
+  linkedTransactionsCount: number;
+}
+
+/**
+ * A linked transaction: the full transaction columns with Money fields surfaced
+ * as decimal numbers, plus the join-table match metadata.
+ */
+interface SubscriptionLinkedTransaction extends Omit<
+  TransactionsAttributes,
+  'amount' | 'refAmount' | 'commissionRate' | 'refCommissionRate' | 'cashbackAmount'
+> {
+  amount: number;
+  refAmount: number;
+  commissionRate: number;
+  refCommissionRate: number;
+  cashbackAmount: number;
+  SubscriptionTransactions: Pick<SubscriptionTransactions, 'matchSource' | 'matchedAt' | 'status'>;
+}
+
+interface SubscriptionDetail extends SubscriptionBase {
+  transactions: SubscriptionLinkedTransaction[];
+  nextExpectedDate: string | null;
+}
+
+export const getSubscriptions = async ({
+  userId,
+  isActive,
+  type,
+}: GetSubscriptionsParams): Promise<SubscriptionListItem[]> => {
   const where: Record<string, unknown> = { userId };
   if (isActive !== undefined) where.isActive = isActive;
   if (type) where.type = type;
@@ -52,16 +114,22 @@ export const getSubscriptions = async ({ userId, isActive, type }: GetSubscripti
   });
 
   return subscriptions.map((s) => {
-    const plain = s.toJSON();
+    const plain = s.toJSON() as unknown as SubscriptionBase & { linkedTransactionsCount: number | string | null };
     return {
       ...plain,
       expectedAmount: plain.expectedAmount !== null ? Money.fromCents(plain.expectedAmount).toNumber() : null,
-      linkedTransactionsCount: Number((plain as Record<string, unknown>).linkedTransactionsCount ?? 0),
+      linkedTransactionsCount: Number(plain.linkedTransactionsCount ?? 0),
     };
   });
 };
 
-export const getSubscriptionById = async ({ id, userId }: { id: string; userId: number }) => {
+export const getSubscriptionById = async ({
+  id,
+  userId,
+}: {
+  id: string;
+  userId: number;
+}): Promise<SubscriptionDetail> => {
   const subscription = await findOrThrowNotFound({
     query: Subscriptions.findOne({
       where: { id, userId },
@@ -80,26 +148,35 @@ export const getSubscriptionById = async ({ id, userId }: { id: string; userId: 
     message: 'Subscription not found.',
   });
 
-  const raw = subscription.toJSON();
-  const plain = {
-    ...raw,
-    expectedAmount: raw.expectedAmount !== null ? Money.fromCents(raw.expectedAmount).toNumber() : null,
+  // toJSON() is untyped; describe the loaded shape (Money fields still boxed,
+  // join-table metadata nested under SubscriptionTransactions) so the rest is typed.
+  const raw = subscription.toJSON() as unknown as SubscriptionBase & {
+    transactions?: Array<
+      TransactionsAttributes & {
+        SubscriptionTransactions: Pick<SubscriptionTransactions, 'matchSource' | 'matchedAt' | 'status'>;
+      }
+    >;
   };
-  const nextExpectedDate = computeNextExpectedDate({
-    startDate: plain.startDate,
-    frequency: plain.frequency,
-    transactions: plain.transactions,
-  });
 
-  // Convert transaction Money instances to numbers for API response
-  const serializedTransactions = (plain.transactions ?? []).map((tx: Record<string, unknown>) => ({
+  const transactions: SubscriptionLinkedTransaction[] = (raw.transactions ?? []).map((tx) => ({
     ...tx,
-    amount: (tx.amount as Money).toNumber(),
-    refAmount: (tx.refAmount as Money).toNumber(),
-    commissionRate: (tx.commissionRate as Money).toNumber(),
-    refCommissionRate: (tx.refCommissionRate as Money).toNumber(),
-    cashbackAmount: (tx.cashbackAmount as Money).toNumber(),
+    amount: tx.amount.toNumber(),
+    refAmount: tx.refAmount.toNumber(),
+    commissionRate: tx.commissionRate.toNumber(),
+    refCommissionRate: tx.refCommissionRate.toNumber(),
+    cashbackAmount: tx.cashbackAmount.toNumber(),
   }));
 
-  return { ...plain, transactions: serializedTransactions, nextExpectedDate };
+  const nextExpectedDate = computeNextExpectedDate({
+    startDate: raw.startDate,
+    frequency: raw.frequency,
+    transactions,
+  });
+
+  return {
+    ...raw,
+    expectedAmount: raw.expectedAmount !== null ? Money.fromCents(raw.expectedAmount).toNumber() : null,
+    transactions,
+    nextExpectedDate,
+  };
 };

--- a/packages/backend/src/services/subscriptions/subscriptions.e2e.ts
+++ b/packages/backend/src/services/subscriptions/subscriptions.e2e.ts
@@ -364,7 +364,7 @@ describe('Subscriptions', () => {
 
       const list = await helpers.getSubscriptions({ raw: true });
       const found = list.find((s: { id: string }) => s.id === sub.id);
-      expect((found as Record<string, unknown>).linkedTransactionsCount).toBe(1);
+      expect(found?.linkedTransactionsCount).toBe(1);
     });
   });
 


### PR DESCRIPTION
MCP read tools returned raw Sequelize models and the full REST serializer output, spending context tokens on fields an AI client never uses – bank-sync metadata, externalData blobs, ACL/share context, provider routing keys, embedded currency models, matching-rule config, audit timestamps and redundant ids. Each tool now slims its payload (via a small mcp/serializers module for the reused account/transaction shapes, inline picks elsewhere) while the shared services stay untouched so REST and the frontend are unaffected

Also fixes `get_budget_spending_stats`, which returned amounts in cents instead of decimals, diverging from the REST endpoint and the money convention. As a side effect, getSubscriptions/getSubscriptionById gained model-derived return types in place of their previous untyped toJSON blobs