### PR TITLE
Investments: Collapse closed positions in holdings table

### DIFF
--- a/packages/frontend/src/components/holdings/holdings-table.vue
+++ b/packages/frontend/src/components/holdings/holdings-table.vue
@@ -14,6 +14,7 @@ import { useCurrenciesStore } from '@/stores/currencies';
 import type { HoldingModel } from '@bt/shared/types/investments';
 import {
   AlertCircleIcon,
+  ArchiveIcon,
   ArrowDownIcon,
   ArrowUpIcon,
   ChevronDownIcon,
@@ -30,8 +31,24 @@ import SecurityLogo from '@/components/common/security-logo.vue';
 
 import HoldingTransactionsSection from './holding-transactions-section.vue';
 import { useHoldingRowExpansion } from './composables/use-holding-row-expansion';
+import {
+  type HoldingSortKey,
+  getAverageCost,
+  getPrice,
+  getTotalCost,
+  groupHoldings,
+  sortHoldings,
+} from './utils/sort-holdings';
 
-const props = defineProps<{ holdings: HoldingModel[]; loading?: boolean; error?: boolean; portfolioId: string }>();
+const props = defineProps<{
+  holdings: HoldingModel[];
+  loading?: boolean;
+  error?: boolean;
+  portfolioId: string;
+  // When the user is filtering via search, closed positions are shown inline
+  // alongside active ones (no collapsible section).
+  isFiltering?: boolean;
+}>();
 const emit = defineEmits<{ (e: 'addSymbol'): void; (e: 'importTransactions'): void }>();
 
 const { t } = useI18n();
@@ -45,9 +62,7 @@ const openTransactionModal = (holding: HoldingModel | null = null) => {
   isTransactionModalOpen.value = true;
 };
 
-const sortKey = ref<'symbol' | 'quantity' | 'value' | 'avgCost' | 'totalCost' | 'unrealizedGain' | 'realizedGain'>(
-  'totalCost',
-);
+const sortKey = ref<HoldingSortKey>('totalCost');
 const sortDir = ref<'asc' | 'desc'>('desc');
 
 const { formatAmountByCurrencyCode } = useFormatCurrency();
@@ -63,9 +78,7 @@ const formatCurrency = (amount: number, currencyCode: string) => {
   return formatAmountByCurrencyCode(amount, userCurrency.currencyCode);
 };
 
-const toggleSort = (
-  key: 'symbol' | 'quantity' | 'value' | 'avgCost' | 'totalCost' | 'unrealizedGain' | 'realizedGain',
-) => {
+const toggleSort = (key: HoldingSortKey) => {
   if (sortKey.value === key) {
     sortDir.value = sortDir.value === 'asc' ? 'desc' : 'asc';
   } else {
@@ -74,66 +87,39 @@ const toggleSort = (
   }
 };
 
-const sortedHoldings = computed(() => {
-  if (!props.holdings) return [];
-  return [...props.holdings].sort((a, b) => {
-    let av: string | number;
-    let bv: string | number;
+// Collapsible "Closed positions" section, collapsed by default.
+const closedExpanded = ref(false);
 
-    switch (sortKey.value) {
-      case 'symbol':
-        av = a.security?.symbol ?? '';
-        bv = b.security?.symbol ?? '';
-        break;
-      case 'quantity':
-        av = Number(a.quantity);
-        bv = Number(b.quantity);
-        break;
-      case 'value':
-        av = Number(a.marketValue || 0);
-        bv = Number(b.marketValue || 0);
-        break;
-      case 'avgCost':
-        av = getAverageCost(a);
-        bv = getAverageCost(b);
-        break;
-      case 'totalCost':
-        av = getTotalCost(a);
-        bv = getTotalCost(b);
-        break;
-      case 'unrealizedGain':
-        av = Number(a.unrealizedGainValue || 0);
-        bv = Number(b.unrealizedGainValue || 0);
-        break;
-      case 'realizedGain':
-        av = Number(a.realizedGainValue || 0);
-        bv = Number(b.realizedGainValue || 0);
-        break;
-    }
-    if (typeof av === 'string') av = av.toLocaleLowerCase();
-    if (typeof bv === 'string') bv = bv.toLocaleLowerCase();
-    return sortDir.value === 'asc' ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
-  });
-});
+const groupedHoldings = computed(() =>
+  groupHoldings({ holdings: props.holdings ?? [], sortKey: sortKey.value, sortDir: sortDir.value }),
+);
 
-const getPrice = (holding: HoldingModel) => {
-  if (holding.latestPrice) {
-    return Number(holding.latestPrice);
+type DisplayRow = { kind: 'holding'; holding: HoldingModel } | { kind: 'closedToggle'; count: number };
+
+/**
+ * Flat list of rows to render. While filtering we show every match in one
+ * combined sorted list; otherwise active positions come first, followed by a
+ * collapsible "Closed positions" toggle and (when expanded) the closed ones.
+ */
+const displayRows = computed<DisplayRow[]>(() => {
+  if (props.isFiltering) {
+    return sortHoldings({ holdings: props.holdings ?? [], sortKey: sortKey.value, sortDir: sortDir.value }).map(
+      (holding) => ({ kind: 'holding', holding }),
+    );
   }
-  const quantity = Number(holding.quantity);
-  const marketValue = Number(holding.marketValue || 0);
-  return quantity > 0 && marketValue > 0 ? marketValue / quantity : 0;
-};
 
-const getAverageCost = (holding: HoldingModel) => {
-  const quantity = Number(holding.quantity);
-  const costBasis = Number(holding.costBasis);
-  return quantity > 0 && costBasis > 0 ? costBasis / quantity : 0;
-};
+  const { active, closed } = groupedHoldings.value;
+  const rows: DisplayRow[] = active.map((holding) => ({ kind: 'holding', holding }));
 
-const getTotalCost = (holding: HoldingModel) => {
-  return Number(holding.costBasis);
-};
+  if (closed.length > 0) {
+    rows.push({ kind: 'closedToggle', count: closed.length });
+    if (closedExpanded.value) {
+      rows.push(...closed.map((holding) => ({ kind: 'holding', holding }) as const));
+    }
+  }
+
+  return rows;
+});
 
 const getUnrealizedGain = (holding: HoldingModel) => {
   return {
@@ -345,72 +331,108 @@ const theadBgStyles = 'bg-muted';
           </tr>
         </thead>
         <tbody class="divide-border divide-y">
-          <template v-for="h in sortedHoldings" :key="h.securityId">
-            <tr class="hover:bg-muted/30 text-sm transition-colors">
+          <template
+            v-for="row in displayRows"
+            :key="row.kind === 'closedToggle' ? 'closed-positions-toggle' : row.holding.securityId"
+          >
+            <!-- Inline collapsible "Closed positions" section header -->
+            <tr
+              v-if="row.kind === 'closedToggle'"
+              class="bg-muted/40 hover:bg-muted/70 cursor-pointer text-sm transition-colors"
+              @click="closedExpanded = !closedExpanded"
+            >
               <td :class="[cellStyles, 'py-1']">
-                <Button variant="ghost" size="icon" class="size-8" @click="toggleExpand(h.securityId)">
-                  <ChevronDownIcon v-if="isExpanded(h.securityId)" class="size-4" />
+                <Button variant="ghost" size="icon" class="size-8" @click.stop="closedExpanded = !closedExpanded">
+                  <ChevronDownIcon v-if="closedExpanded" class="size-4" />
                   <ChevronRightIcon v-else class="size-4" />
                 </Button>
               </td>
-              <td :class="[cellStyles, 'px-3 font-semibold']">
-                <div class="flex items-center gap-2">
-                  <SecurityLogo v-if="h.security" :security="h.security" />
-                  <span>{{ h.security?.symbol }}</span>
+              <td colspan="10" :class="[cellStyles, 'px-3']">
+                <div class="text-muted-foreground flex items-center gap-2 font-medium">
+                  <ArchiveIcon class="size-4" />
+                  {{ $t('portfolioDetail.holdingsTable.closedPositions', { count: row.count }) }}
                 </div>
               </td>
-              <td :class="[cellStyles, 'text-muted-foreground max-w-50 truncate px-3']">
-                {{ h.security?.name }}
-              </td>
-              <td :class="[cellStyles, 'px-3 text-right tabular-nums']">{{ Number(h.quantity).toLocaleString() }}</td>
-              <td :class="[cellStyles, 'px-3 text-right tabular-nums']">
-                {{ formatCurrency(getPrice(h), h.currencyCode) }}
-              </td>
-              <td :class="[cellStyles, 'text-muted-foreground px-3 text-right tabular-nums']">
-                {{ formatCurrency(getAverageCost(h), h.currencyCode) }}
-              </td>
-              <td :class="[cellStyles, 'px-3 text-right tabular-nums']">
-                {{ formatCurrency(getTotalCost(h), h.currencyCode) }}
-              </td>
-              <td :class="[cellStyles, 'px-3 text-right font-medium tabular-nums']">
-                {{ formatCurrency(Number(h.marketValue || 0), h.currencyCode) }}
-              </td>
-              <td :class="[cellStyles, 'px-3 text-right']">
-                <div :class="getGainColorClass({ gainValue: getUnrealizedGain(h).value })" class="tabular-nums">
-                  <div class="font-semibold">{{ formatCurrency(getUnrealizedGain(h).value, h.currencyCode) }}</div>
-                  <div class="text-xs">{{ getUnrealizedGain(h).percent.toFixed(2) }}%</div>
-                </div>
-              </td>
-              <td :class="[cellStyles, 'px-3 text-right']">
-                <div :class="getGainColorClass({ gainValue: getRealizedGain(h).value })" class="tabular-nums">
-                  <div class="font-semibold">{{ formatCurrency(getRealizedGain(h).value, h.currencyCode) }}</div>
-                  <div class="text-xs">{{ getRealizedGain(h).percent.toFixed(2) }}%</div>
-                </div>
-              </td>
-              <td :class="[cellStyles, 'py-1 pr-2 text-right']">
-                <DesktopOnlyTooltip :content="$t('portfolioDetail.holdingsTable.deleteHolding.ariaLabel')">
-                  <Button
-                    variant="ghost-destructive"
-                    size="icon"
-                    class="size-8"
-                    :aria-label="$t('portfolioDetail.holdingsTable.deleteHolding.ariaLabel')"
-                    @click="openDeleteConfirm(h)"
-                  >
-                    <Trash2Icon class="size-4" />
+            </tr>
+            <template v-else>
+              <tr class="hover:bg-muted/30 text-sm transition-colors">
+                <td :class="[cellStyles, 'py-1']">
+                  <Button variant="ghost" size="icon" class="size-8" @click="toggleExpand(row.holding.securityId)">
+                    <ChevronDownIcon v-if="isExpanded(row.holding.securityId)" class="size-4" />
+                    <ChevronRightIcon v-else class="size-4" />
                   </Button>
-                </DesktopOnlyTooltip>
-              </td>
-            </tr>
-            <!-- Expanded transactions section -->
-            <tr v-if="isExpanded(h.securityId)" class="bg-muted/20">
-              <td colspan="11" class="p-0">
-                <HoldingTransactionsSection
-                  :portfolio-id="portfolioId"
-                  :security-id="h.securityId"
-                  @add-transaction="openTransactionModal(h)"
-                />
-              </td>
-            </tr>
+                </td>
+                <td :class="[cellStyles, 'px-3 font-semibold']">
+                  <div class="flex items-center gap-2">
+                    <SecurityLogo v-if="row.holding.security" :security="row.holding.security" />
+                    <span>{{ row.holding.security?.symbol }}</span>
+                  </div>
+                </td>
+                <td :class="[cellStyles, 'text-muted-foreground max-w-50 truncate px-3']">
+                  {{ row.holding.security?.name }}
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right tabular-nums']">
+                  {{ Number(row.holding.quantity).toLocaleString() }}
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right tabular-nums']">
+                  {{ formatCurrency(getPrice(row.holding), row.holding.currencyCode) }}
+                </td>
+                <td :class="[cellStyles, 'text-muted-foreground px-3 text-right tabular-nums']">
+                  {{ formatCurrency(getAverageCost(row.holding), row.holding.currencyCode) }}
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right tabular-nums']">
+                  {{ formatCurrency(getTotalCost(row.holding), row.holding.currencyCode) }}
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right font-medium tabular-nums']">
+                  {{ formatCurrency(Number(row.holding.marketValue || 0), row.holding.currencyCode) }}
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right']">
+                  <div
+                    :class="getGainColorClass({ gainValue: getUnrealizedGain(row.holding).value })"
+                    class="tabular-nums"
+                  >
+                    <div class="font-semibold">
+                      {{ formatCurrency(getUnrealizedGain(row.holding).value, row.holding.currencyCode) }}
+                    </div>
+                    <div class="text-xs">{{ getUnrealizedGain(row.holding).percent.toFixed(2) }}%</div>
+                  </div>
+                </td>
+                <td :class="[cellStyles, 'px-3 text-right']">
+                  <div
+                    :class="getGainColorClass({ gainValue: getRealizedGain(row.holding).value })"
+                    class="tabular-nums"
+                  >
+                    <div class="font-semibold">
+                      {{ formatCurrency(getRealizedGain(row.holding).value, row.holding.currencyCode) }}
+                    </div>
+                    <div class="text-xs">{{ getRealizedGain(row.holding).percent.toFixed(2) }}%</div>
+                  </div>
+                </td>
+                <td :class="[cellStyles, 'py-1 pr-2 text-right']">
+                  <DesktopOnlyTooltip :content="$t('portfolioDetail.holdingsTable.deleteHolding.ariaLabel')">
+                    <Button
+                      variant="ghost-destructive"
+                      size="icon"
+                      class="size-8"
+                      :aria-label="$t('portfolioDetail.holdingsTable.deleteHolding.ariaLabel')"
+                      @click="openDeleteConfirm(row.holding)"
+                    >
+                      <Trash2Icon class="size-4" />
+                    </Button>
+                  </DesktopOnlyTooltip>
+                </td>
+              </tr>
+              <!-- Expanded transactions section -->
+              <tr v-if="isExpanded(row.holding.securityId)" class="bg-muted/20">
+                <td colspan="11" class="p-0">
+                  <HoldingTransactionsSection
+                    :portfolio-id="portfolioId"
+                    :security-id="row.holding.securityId"
+                    @add-transaction="openTransactionModal(row.holding)"
+                  />
+                </td>
+              </tr>
+            </template>
           </template>
         </tbody>
       </table>

--- a/packages/frontend/src/components/holdings/utils/sort-holdings.test.ts
+++ b/packages/frontend/src/components/holdings/utils/sort-holdings.test.ts
@@ -1,0 +1,93 @@
+import type { HoldingModel } from '@bt/shared/types/investments';
+
+import { groupHoldings, isClosedPosition, sortHoldings } from './sort-holdings';
+
+const makeHolding = (overrides: Partial<HoldingModel> & { symbol?: string }): HoldingModel => {
+  const { symbol, ...rest } = overrides;
+  return {
+    portfolioId: 'p1',
+    securityId: symbol ?? 'sec',
+    quantity: '0',
+    costBasis: '0',
+    refCostBasis: '0',
+    currencyCode: 'USD',
+    excluded: false,
+    security: symbol ? ({ symbol, name: symbol } as HoldingModel['security']) : undefined,
+    ...rest,
+  };
+};
+
+describe('isClosedPosition', () => {
+  it('treats a zero quantity as closed', () => {
+    expect(isClosedPosition(makeHolding({ quantity: '0' }))).toBe(true);
+  });
+
+  it('treats any non-zero quantity as active', () => {
+    expect(isClosedPosition(makeHolding({ quantity: '10' }))).toBe(false);
+    expect(isClosedPosition(makeHolding({ quantity: '0.5' }))).toBe(false);
+  });
+});
+
+describe('sortHoldings', () => {
+  it('sorts by symbol ascending and descending', () => {
+    const holdings = [
+      makeHolding({ symbol: 'SONY', quantity: '1' }),
+      makeHolding({ symbol: 'BAC', quantity: '1' }),
+      makeHolding({ symbol: 'FIG', quantity: '1' }),
+    ];
+
+    expect(sortHoldings({ holdings, sortKey: 'symbol', sortDir: 'asc' }).map((h) => h.security?.symbol)).toEqual([
+      'BAC',
+      'FIG',
+      'SONY',
+    ]);
+    expect(sortHoldings({ holdings, sortKey: 'symbol', sortDir: 'desc' }).map((h) => h.security?.symbol)).toEqual([
+      'SONY',
+      'FIG',
+      'BAC',
+    ]);
+  });
+
+  it('sorts numerically by market value', () => {
+    const holdings = [
+      makeHolding({ symbol: 'A', quantity: '1', marketValue: '100' }),
+      makeHolding({ symbol: 'B', quantity: '1', marketValue: '2000' }),
+      makeHolding({ symbol: 'C', quantity: '1', marketValue: '50' }),
+    ];
+
+    expect(sortHoldings({ holdings, sortKey: 'value', sortDir: 'asc' }).map((h) => h.security?.symbol)).toEqual([
+      'C',
+      'A',
+      'B',
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const holdings = [makeHolding({ symbol: 'B', quantity: '1' }), makeHolding({ symbol: 'A', quantity: '1' })];
+    sortHoldings({ holdings, sortKey: 'symbol', sortDir: 'asc' });
+    expect(holdings.map((h) => h.security?.symbol)).toEqual(['B', 'A']);
+  });
+});
+
+describe('groupHoldings', () => {
+  it('separates active from closed positions, each sorted independently', () => {
+    const holdings = [
+      makeHolding({ symbol: 'SONY', quantity: '20', marketValue: '434' }),
+      makeHolding({ symbol: 'BAC', quantity: '0', marketValue: '0' }),
+      makeHolding({ symbol: 'FIG', quantity: '14', marketValue: '328' }),
+      makeHolding({ symbol: 'VST', quantity: '0', marketValue: '0' }),
+    ];
+
+    const { active, closed } = groupHoldings({ holdings, sortKey: 'symbol', sortDir: 'asc' });
+
+    expect(active.map((h) => h.security?.symbol)).toEqual(['FIG', 'SONY']);
+    expect(closed.map((h) => h.security?.symbol)).toEqual(['BAC', 'VST']);
+  });
+
+  it('returns empty closed group when no positions are closed', () => {
+    const holdings = [makeHolding({ symbol: 'A', quantity: '1' }), makeHolding({ symbol: 'B', quantity: '2' })];
+    const { active, closed } = groupHoldings({ holdings, sortKey: 'symbol', sortDir: 'asc' });
+    expect(active).toHaveLength(2);
+    expect(closed).toHaveLength(0);
+  });
+});

--- a/packages/frontend/src/components/holdings/utils/sort-holdings.ts
+++ b/packages/frontend/src/components/holdings/utils/sort-holdings.ts
@@ -1,0 +1,120 @@
+import type { HoldingModel } from '@bt/shared/types/investments';
+
+export type HoldingSortKey =
+  | 'symbol'
+  | 'quantity'
+  | 'value'
+  | 'avgCost'
+  | 'totalCost'
+  | 'unrealizedGain'
+  | 'realizedGain';
+
+type SortDirection = 'asc' | 'desc';
+
+export const getPrice = (holding: HoldingModel) => {
+  if (holding.latestPrice) {
+    return Number(holding.latestPrice);
+  }
+  const quantity = Number(holding.quantity);
+  const marketValue = Number(holding.marketValue || 0);
+  return quantity > 0 && marketValue > 0 ? marketValue / quantity : 0;
+};
+
+export const getAverageCost = (holding: HoldingModel) => {
+  const quantity = Number(holding.quantity);
+  const costBasis = Number(holding.costBasis);
+  return quantity > 0 && costBasis > 0 ? costBasis / quantity : 0;
+};
+
+export const getTotalCost = (holding: HoldingModel) => Number(holding.costBasis);
+
+/**
+ * A position is considered "closed" once its quantity reaches zero — the user
+ * has fully divested but the holding row is kept around for its realized gains.
+ */
+export const isClosedPosition = (holding: HoldingModel) => Number(holding.quantity) === 0;
+
+const compareHoldings = ({
+  a,
+  b,
+  sortKey,
+  sortDir,
+}: {
+  a: HoldingModel;
+  b: HoldingModel;
+  sortKey: HoldingSortKey;
+  sortDir: SortDirection;
+}) => {
+  let av: string | number;
+  let bv: string | number;
+
+  switch (sortKey) {
+    case 'symbol':
+      av = a.security?.symbol ?? '';
+      bv = b.security?.symbol ?? '';
+      break;
+    case 'quantity':
+      av = Number(a.quantity);
+      bv = Number(b.quantity);
+      break;
+    case 'value':
+      av = Number(a.marketValue || 0);
+      bv = Number(b.marketValue || 0);
+      break;
+    case 'avgCost':
+      av = getAverageCost(a);
+      bv = getAverageCost(b);
+      break;
+    case 'totalCost':
+      av = getTotalCost(a);
+      bv = getTotalCost(b);
+      break;
+    case 'unrealizedGain':
+      av = Number(a.unrealizedGainValue || 0);
+      bv = Number(b.unrealizedGainValue || 0);
+      break;
+    case 'realizedGain':
+      av = Number(a.realizedGainValue || 0);
+      bv = Number(b.realizedGainValue || 0);
+      break;
+  }
+
+  if (typeof av === 'string') av = av.toLocaleLowerCase();
+  if (typeof bv === 'string') bv = bv.toLocaleLowerCase();
+  return sortDir === 'asc' ? (av > bv ? 1 : -1) : av < bv ? 1 : -1;
+};
+
+export const sortHoldings = ({
+  holdings,
+  sortKey,
+  sortDir,
+}: {
+  holdings: HoldingModel[];
+  sortKey: HoldingSortKey;
+  sortDir: SortDirection;
+}) => [...holdings].sort((a, b) => compareHoldings({ a, b, sortKey, sortDir }));
+
+/**
+ * Split holdings into active vs. closed groups, each independently sorted with
+ * the same key/direction. Used to keep closed (zero-quantity) positions tucked
+ * under their own collapsible section instead of intermixed with active ones.
+ */
+export const groupHoldings = ({
+  holdings,
+  sortKey,
+  sortDir,
+}: {
+  holdings: HoldingModel[];
+  sortKey: HoldingSortKey;
+  sortDir: SortDirection;
+}) => {
+  const active: HoldingModel[] = [];
+  const closed: HoldingModel[] = [];
+  for (const holding of holdings) {
+    (isClosedPosition(holding) ? closed : active).push(holding);
+  }
+  return {
+    active: sortHoldings({ holdings: active, sortKey, sortDir }),
+    closed: sortHoldings({ holdings: closed, sortKey, sortDir }),
+  };
+};

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/portfolio-detail.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/portfolio-detail.json
@@ -79,6 +79,7 @@
         "empty": "No transactions found.",
         "addFirstButton": "Add first Transaction"
       },
+      "closedPositions": "Closed positions ({count})",
       "deleteHolding": {
         "ariaLabel": "Delete holding",
         "title": "Delete holding",

--- a/packages/frontend/src/i18n/locales/chunks/uk/pages/portfolio-detail.json
+++ b/packages/frontend/src/i18n/locales/chunks/uk/pages/portfolio-detail.json
@@ -79,6 +79,7 @@
         "empty": "Транзакцій не знайдено.",
         "addFirstButton": "Додати першу транзакцію"
       },
+      "closedPositions": "Закриті позиції ({count})",
       "deleteHolding": {
         "ariaLabel": "Видалити актив",
         "title": "Видалити актив",

--- a/packages/frontend/src/pages/portfolios/components/holdings-summary.vue
+++ b/packages/frontend/src/pages/portfolios/components/holdings-summary.vue
@@ -56,6 +56,7 @@
         :loading="isLoading"
         :error="!!error"
         :portfolio-id="portfolioId"
+        :is-filtering="isFiltering"
         @add-symbol="isAddSymbolsOpen = true"
         @import-transactions="goToImport"
       />
@@ -87,9 +88,11 @@ function goToImport() {
   router.push({ name: ROUTES_NAMES.portfolioTransactionsImport, params: { portfolioId: portfolioId.value } });
 }
 
+const isFiltering = computed(() => !!filterText.value.trim());
+
 const filteredHoldings = computed(() => {
   if (!holdings.value) return null;
-  if (!filterText.value.trim()) return holdings.value;
+  if (!isFiltering.value) return holdings.value;
 
   const searchTerm = filterText.value.toLowerCase().trim();
   return holdings.value.filter((holding) => {


### PR DESCRIPTION
Zero-quantity holdings now sit under an expandable "Closed positions" section instead of cluttering the active list