### PR TITLE
Investment calculator based on holdings

### DIFF
--- a/packages/backend/src/controllers/investments/portfolios/get-portfolios-annualized-returns.controller.ts
+++ b/packages/backend/src/controllers/investments/portfolios/get-portfolios-annualized-returns.controller.ts
@@ -1,0 +1,10 @@
+import { createController } from '@controllers/helpers/controller-factory';
+import { getPortfoliosAnnualizedReturns } from '@services/investments/portfolios/get-portfolios-annualized-returns.service';
+import { z } from 'zod';
+
+const schema = z.object({});
+
+export default createController(schema, async ({ user }) => {
+  const data = await getPortfoliosAnnualizedReturns({ userId: user.id });
+  return { data };
+});

--- a/packages/backend/src/routes/investments.route.ts
+++ b/packages/backend/src/routes/investments.route.ts
@@ -18,6 +18,7 @@ import exchangeCurrencyController from '@controllers/investments/portfolios/exch
 import getPortfolioController from '@controllers/investments/portfolios/get-portfolio';
 import getPortfolioBalanceController from '@controllers/investments/portfolios/get-portfolio-balance';
 import getPortfolioSummaryController from '@controllers/investments/portfolios/get-portfolio-summary.controller';
+import getPortfoliosAnnualizedReturnsController from '@controllers/investments/portfolios/get-portfolios-annualized-returns.controller';
 import listPortfolioTransfersController from '@controllers/investments/portfolios/list-portfolio-transfers';
 import listPortfoliosController from '@controllers/investments/portfolios/list-portfolios';
 import portfolioToAccountTransferController from '@controllers/investments/portfolios/portfolio-to-account-transfer';
@@ -51,6 +52,14 @@ router.use(authenticateSession);
 
 // Portfolio routes
 router.get('/portfolios', validateEndpoint(listPortfoliosController.schema), listPortfoliosController.handler);
+
+// Static path — must be registered before `/portfolios/:id` so it isn't
+// swallowed as `:id = "annualized-returns"`.
+router.get(
+  '/portfolios/annualized-returns',
+  validateEndpoint(getPortfoliosAnnualizedReturnsController.schema),
+  getPortfoliosAnnualizedReturnsController.handler,
+);
 
 router.get('/portfolios/:id', validateEndpoint(getPortfolioController.schema), getPortfolioController.handler);
 

--- a/packages/backend/src/services/investments/portfolios/fast-format-date.unit.ts
+++ b/packages/backend/src/services/investments/portfolios/fast-format-date.unit.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { fastFormatDate } from './get-portfolios-annualized-returns.service';
+
+describe('fastFormatDate', () => {
+  describe('Date input', () => {
+    it('formats a standard mid-year UTC date', () => {
+      expect(fastFormatDate(new Date('2025-06-15T12:34:56Z'))).toBe('2025-06-15');
+    });
+
+    it('zero-pads single-digit months', () => {
+      expect(fastFormatDate(new Date('2025-01-15T00:00:00Z'))).toBe('2025-01-15');
+      expect(fastFormatDate(new Date('2025-09-15T00:00:00Z'))).toBe('2025-09-15');
+    });
+
+    it('zero-pads single-digit days', () => {
+      expect(fastFormatDate(new Date('2025-06-01T00:00:00Z'))).toBe('2025-06-01');
+      expect(fastFormatDate(new Date('2025-06-09T00:00:00Z'))).toBe('2025-06-09');
+    });
+
+    it('zero-pads single-digit month AND day together', () => {
+      expect(fastFormatDate(new Date('2025-01-01T00:00:00Z'))).toBe('2025-01-01');
+      expect(fastFormatDate(new Date('2025-09-09T00:00:00Z'))).toBe('2025-09-09');
+    });
+
+    it('uses UTC, not local timezone', () => {
+      // 2025-01-15 at 23:30 UTC is 2025-01-16 in tz=+02:00 (and 2025-01-15 in
+      // tz=-05:00). The helper must return the UTC calendar day regardless of
+      // the host TZ — otherwise rate/price keys disagree across deploys.
+      expect(fastFormatDate(new Date('2025-01-15T23:30:00Z'))).toBe('2025-01-15');
+      expect(fastFormatDate(new Date('2025-01-16T00:30:00Z'))).toBe('2025-01-16');
+    });
+
+    it('handles the last day of the year', () => {
+      expect(fastFormatDate(new Date('2025-12-31T23:59:59Z'))).toBe('2025-12-31');
+    });
+
+    it('handles the first day of the year', () => {
+      expect(fastFormatDate(new Date('2025-01-01T00:00:00Z'))).toBe('2025-01-01');
+    });
+
+    it('handles a leap-day', () => {
+      expect(fastFormatDate(new Date('2024-02-29T00:00:00Z'))).toBe('2024-02-29');
+    });
+
+    it('handles a four-digit year far in the past', () => {
+      expect(fastFormatDate(new Date('1999-12-31T00:00:00Z'))).toBe('1999-12-31');
+    });
+
+    it('handles a four-digit year far in the future', () => {
+      expect(fastFormatDate(new Date('2999-07-04T00:00:00Z'))).toBe('2999-07-04');
+    });
+  });
+
+  describe('string input', () => {
+    it('slices an ISO timestamp to YYYY-MM-DD', () => {
+      expect(fastFormatDate('2025-01-15T00:00:00.000Z')).toBe('2025-01-15');
+      expect(fastFormatDate('2025-12-31T23:59:59Z')).toBe('2025-12-31');
+    });
+
+    it('returns an already-formatted YYYY-MM-DD string unchanged', () => {
+      expect(fastFormatDate('2025-06-15')).toBe('2025-06-15');
+    });
+
+    it('slices any string at least 10 chars long', () => {
+      // The helper does not validate format — it trusts the caller passes
+      // either an ISO-shaped timestamp or a YYYY-MM-DD value (both start with
+      // 10 chars of date). Anything longer is sliced to the first 10 chars.
+      expect(fastFormatDate('2025-06-15extra')).toBe('2025-06-15');
+    });
+
+    it('returns a short string unchanged (defensive edge case)', () => {
+      expect(fastFormatDate('')).toBe('');
+      expect(fastFormatDate('2025-06')).toBe('2025-06');
+    });
+  });
+
+  describe('parity with format(date, "yyyy-MM-dd")', () => {
+    // Sanity check that the fast path matches the previous `date-fns` output
+    // for UTC-aligned inputs (the production case). Spot-checks across the
+    // boundaries that single-digit padding logic touches.
+    const cases: Array<{ iso: string; expected: string }> = [
+      { iso: '2025-01-01T00:00:00Z', expected: '2025-01-01' },
+      { iso: '2025-01-15T00:00:00Z', expected: '2025-01-15' },
+      { iso: '2025-10-15T00:00:00Z', expected: '2025-10-15' },
+      { iso: '2025-10-09T00:00:00Z', expected: '2025-10-09' },
+      { iso: '2025-12-31T00:00:00Z', expected: '2025-12-31' },
+    ];
+
+    it.each(cases)('formats $iso as $expected', ({ iso, expected }) => {
+      expect(fastFormatDate(new Date(iso))).toBe(expected);
+    });
+  });
+});

--- a/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.e2e.ts
+++ b/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.e2e.ts
@@ -1,0 +1,352 @@
+import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY, SECURITY_PROVIDER } from '@bt/shared/types';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import Portfolios from '@models/investments/portfolios.model';
+import Securities from '@models/investments/securities.model';
+import SecurityPricing from '@models/investments/security-pricing.model';
+import * as helpers from '@tests/helpers';
+import { format, parseISO, subDays } from 'date-fns';
+
+const today = () => format(new Date(), 'yyyy-MM-dd');
+const daysAgo = ({ days }: { days: number }) => format(subDays(new Date(), days), 'yyyy-MM-dd');
+
+/**
+ * Creates a stock security denominated in the test base currency (AED) so that
+ * the FX rate is 1:1 and the time-weighted return is driven purely by the
+ * seeded prices — keeping the assertions deterministic.
+ */
+const createBaseCurrencySecurity = async ({ symbol }: { symbol: string }) =>
+  Securities.create({
+    symbol,
+    providerSymbol: symbol,
+    currencyCode: global.BASE_CURRENCY_CODE,
+    providerName: SECURITY_PROVIDER.fmp,
+    assetClass: ASSET_CLASS.stocks,
+    name: `${symbol} Test Security`,
+  });
+
+const seedPrices = async ({
+  securityId,
+  points,
+}: {
+  securityId: string;
+  points: Array<{ date: string; price: string }>;
+}) => {
+  // Drain the background price sync triggered by createHolding, then replace the
+  // pricing rows with exactly the points we control.
+  await helpers.sleep(200);
+  await SecurityPricing.destroy({ where: { securityId } });
+  for (const point of points) {
+    await SecurityPricing.create({
+      securityId,
+      date: parseISO(point.date),
+      priceClose: point.price,
+      source: SECURITY_PROVIDER.fmp,
+    });
+  }
+};
+
+describe('GET /investments/portfolios/annualized-returns', () => {
+  it('returns an empty array when the user has no portfolios', async () => {
+    const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+    expect(result).toEqual([]);
+  });
+
+  describe('with portfolios', () => {
+    let portfolio: Portfolios;
+
+    beforeEach(async () => {
+      portfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'Returns Test Portfolio' }),
+        raw: true,
+      });
+    });
+
+    it('reports not-enough-history for a portfolio with no transactions', async () => {
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+      expect(entry).toBeDefined();
+      expect(entry.annualizedReturn).toBeNull();
+      expect(entry.hasEnoughHistory).toBe(false);
+      expect(entry.startDate).toBeNull();
+      expect(entry.periodDays).toBe(0);
+      expect(entry.currencyCode).toBe(global.BASE_CURRENCY_CODE);
+    });
+
+    it('reports not-enough-history when the history is shorter than the minimum', async () => {
+      const security = await createBaseCurrencySecurity({ symbol: 'SHORT' });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: security.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 30 }),
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: security.id,
+        points: [
+          { date: daysAgo({ days: 30 }), price: '100' },
+          { date: today(), price: '150' },
+        ],
+      });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      expect(entry.annualizedReturn).toBeNull();
+      expect(entry.hasEnoughHistory).toBe(false);
+      expect(entry.startDate).toBe(daysAgo({ days: 30 }));
+      expect(entry.periodDays).toBeGreaterThan(0);
+    });
+
+    it('computes the annualized time-weighted return over a full year', async () => {
+      const security = await createBaseCurrencySecurity({ symbol: 'YEAR' });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: security.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 365 }),
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      // Bought at 100, worth 120 today → +20% over exactly 365 days → ~20%/yr.
+      await seedPrices({
+        securityId: security.id,
+        points: [
+          { date: daysAgo({ days: 365 }), price: '100' },
+          { date: today(), price: '120' },
+        ],
+      });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      expect(entry.hasEnoughHistory).toBe(true);
+      expect(entry.startDate).toBe(daysAgo({ days: 365 }));
+      expect(entry.periodDays).toBe(365);
+      expect(entry.annualizedReturn).toBeCloseTo(20, 1);
+      expect(entry.currencyCode).toBe(global.BASE_CURRENCY_CODE);
+    });
+
+    it('chains sub-period returns and excludes mid-period contributions', async () => {
+      // Two buys at different prices. TWR must measure the holdings' performance
+      // only, treating the second buy as new capital (not a return) — otherwise
+      // the contribution would leak into the figure.
+      const security = await createBaseCurrencySecurity({ symbol: 'CHAIN' });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: security.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 365 }),
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 182 }),
+          quantity: '1',
+          price: '110',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: security.id,
+        points: [
+          { date: daysAgo({ days: 365 }), price: '100' },
+          { date: daysAgo({ days: 182 }), price: '110' },
+          { date: today(), price: '121' },
+        ],
+      });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      // Sub-period 1: 100 → 110 (+10%). Sub-period 2: 220 → 242 on 2 shares
+      // (+10%). Chained: 1.1 × 1.1 = 1.21 → ~21%/yr. A naive total-return metric
+      // that counted the +110 contribution as growth would land near ~15%, so
+      // the 21% result proves the contribution is excluded.
+      expect(entry.hasEnoughHistory).toBe(true);
+      expect(entry.annualizedReturn).toBeCloseTo(21, 0);
+    });
+
+    it('does not treat a partial sell as a loss', async () => {
+      // Selling shares is a withdrawal of capital, not a negative return. The
+      // sub-period spanning the sell must stay flat (price unchanged), so the
+      // whole return comes from the pre-sell appreciation.
+      const security = await createBaseCurrencySecurity({ symbol: 'PSELL' });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: security.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 365 }),
+          quantity: '2',
+          price: '100',
+        },
+        raw: true,
+      });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.sell,
+          date: daysAgo({ days: 182 }),
+          quantity: '1',
+          price: '150',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: security.id,
+        points: [
+          { date: daysAgo({ days: 365 }), price: '100' },
+          { date: daysAgo({ days: 182 }), price: '150' },
+          { date: today(), price: '150' },
+        ],
+      });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      // Sub-period 1: 200 → 300 on 2 shares (+50%). Sub-period 2: 1 share held
+      // flat at 150 (0%). Chained: 1.5 × 1.0 = 1.5 → ~50%/yr. The sell itself
+      // must not register as a drop.
+      expect(entry.hasEnoughHistory).toBe(true);
+      expect(entry.annualizedReturn).toBeCloseTo(50, 0);
+    });
+
+    it('reports each portfolio independently, including negative returns', async () => {
+      // `portfolio` (from beforeEach) gains; a second portfolio loses. Both must
+      // appear in one response with their own independent figures — proving the
+      // per-portfolio grouping doesn't leak transactions across portfolios.
+      const gainSecurity = await createBaseCurrencySecurity({ symbol: 'GAIN' });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: gainSecurity.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: gainSecurity.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 365 }),
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: gainSecurity.id,
+        points: [
+          { date: daysAgo({ days: 365 }), price: '100' },
+          { date: today(), price: '120' },
+        ],
+      });
+
+      const losingPortfolio = await helpers.createPortfolio({
+        payload: helpers.buildPortfolioPayload({ name: 'Losing Portfolio' }),
+        raw: true,
+      });
+      const loseSecurity = await createBaseCurrencySecurity({ symbol: 'LOSE' });
+      await helpers.createHolding({ payload: { portfolioId: losingPortfolio.id, securityId: loseSecurity.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: losingPortfolio.id,
+          securityId: loseSecurity.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: daysAgo({ days: 365 }),
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: loseSecurity.id,
+        points: [
+          { date: daysAgo({ days: 365 }), price: '100' },
+          { date: today(), price: '80' },
+        ],
+      });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const gain = result.find((r) => r.portfolioId === portfolio.id)!;
+      const lose = result.find((r) => r.portfolioId === losingPortfolio.id)!;
+
+      // 100 → 120 over a year ≈ +20%/yr; 100 → 80 ≈ -20%/yr.
+      expect(gain.annualizedReturn).toBeCloseTo(20, 0);
+      expect(lose.annualizedReturn).toBeCloseTo(-20, 0);
+    });
+
+    it('does not inflate the return when a holding is unpriced at its buy date', async () => {
+      // Reproduces the real-world case: a security whose price history does not
+      // reach back to the (back-dated) buy. The unpriced holding must fall back
+      // to its cost basis at the buy boundary — otherwise it is valued at 0 when
+      // bought and at full price later, injecting a phantom return.
+      const buyDay = daysAgo({ days: 300 });
+
+      const priced = await createBaseCurrencySecurity({ symbol: 'PRICED' });
+      const latePriced = await createBaseCurrencySecurity({ symbol: 'LATEPRICE' });
+
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: priced.id } });
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: latePriced.id } });
+
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: priced.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: buyDay,
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: latePriced.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: buyDay,
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+
+      // PRICED has a price at the buy date; LATEPRICE only gets a price today
+      // (none at or before the buy). Both end flat-ish, so the true return is
+      // small: cost basis 200 → value 210 over 300 days ≈ 6%/yr.
+      await seedPrices({
+        securityId: priced.id,
+        points: [
+          { date: buyDay, price: '100' },
+          { date: today(), price: '110' },
+        ],
+      });
+      await seedPrices({ securityId: latePriced.id, points: [{ date: today(), price: '100' }] });
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      expect(entry.hasEnoughHistory).toBe(true);
+      // Must be the real ~6%/yr, NOT the phantom ~140%/yr the skip-when-unpriced
+      // bug produced.
+      expect(entry.annualizedReturn).toBeLessThan(20);
+      expect(entry.annualizedReturn).toBeCloseTo(6.1, 0);
+    });
+  });
+});

--- a/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.e2e.ts
+++ b/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.e2e.ts
@@ -1,8 +1,11 @@
 import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY, SECURITY_PROVIDER } from '@bt/shared/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
+import ExchangeRates from '@models/exchange-rates.model';
 import Portfolios from '@models/investments/portfolios.model';
 import Securities from '@models/investments/securities.model';
 import SecurityPricing from '@models/investments/security-pricing.model';
+import UserExchangeRates from '@models/user-exchange-rates.model';
+import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/fetch-exchange-rates-for-date';
 import * as helpers from '@tests/helpers';
 import { format, parseISO, subDays } from 'date-fns';
 
@@ -289,6 +292,74 @@ describe('GET /investments/portfolios/annualized-returns', () => {
       // 100 → 120 over a year ≈ +20%/yr; 100 → 80 ≈ -20%/yr.
       expect(gain.annualizedReturn).toBeCloseTo(20, 0);
       expect(lose.annualizedReturn).toBeCloseTo(-20, 0);
+    });
+
+    it('applies FX conversion for a non-base-currency (USD) security', async () => {
+      // Base currency is AED; this security is in USD, so a real USD→AED
+      // cross-rate is applied at each valuation boundary (the other tests use
+      // AED securities, where the 1:1 rate hides any FX bug). The rate DIFFERS
+      // between the start and end of the period so the FX move is baked into
+      // the return: a 1:1 fallback would yield ~20%/yr (raw price move), but
+      // the real answer is higher because the dollar also rose against AED.
+      //
+      // valueHoldings values a USD holding as quantity * price * USD→AED rate:
+      //   start: 1 * $100 * 3 = 300 AED
+      //   today: 1 * $120 * 4 = 480 AED
+      //   TWR factor = 480 / 300 = 1.6 over exactly 365 days → ~60%/yr.
+      const startDate = daysAgo({ days: 365 });
+
+      const security = await Securities.create({
+        symbol: 'USDFX',
+        providerSymbol: 'USDFX',
+        currencyCode: 'USD',
+        providerName: SECURITY_PROVIDER.fmp,
+        assetClass: ASSET_CLASS.stocks,
+        name: 'USD FX Test Security',
+      });
+
+      await helpers.createHolding({ payload: { portfolioId: portfolio.id, securityId: security.id } });
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: portfolio.id,
+          securityId: security.id,
+          category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+          date: startDate,
+          quantity: '1',
+          price: '100',
+        },
+        raw: true,
+      });
+      await seedPrices({
+        securityId: security.id,
+        points: [
+          { date: startDate, price: '100' },
+          { date: today(), price: '120' },
+        ],
+      });
+
+      // ExchangeRates survives test truncation (it is seed data), and the
+      // investment-transaction create flow lazily writes a USD→AED row via
+      // calculateRefAmount. Wipe both so only the two deterministic rates we
+      // seed below exist for this pair.
+      await ExchangeRates.destroy({ where: { baseCode: API_LAYER_BASE_CURRENCY_CODE, quoteCode: 'AED' } });
+      await UserExchangeRates.destroy({ where: { userId: 1, baseCode: 'USD', quoteCode: 'AED' } });
+
+      // `date` is a DATE column; seed JS Dates the service normalizes to
+      // yyyy-MM-dd. USD→AED = 3 at the buy, 4 today.
+      await ExchangeRates.bulkCreate([
+        { baseCode: API_LAYER_BASE_CURRENCY_CODE, quoteCode: 'AED', rate: 3, date: parseISO(startDate) },
+        { baseCode: API_LAYER_BASE_CURRENCY_CODE, quoteCode: 'AED', rate: 4, date: parseISO(today()) },
+      ]);
+
+      const result = await helpers.getPortfoliosAnnualizedReturns({ raw: true });
+      const entry = result.find((r) => r.portfolioId === portfolio.id)!;
+
+      expect(entry.hasEnoughHistory).toBe(true);
+      expect(entry.periodDays).toBe(365);
+      // 300 AED → 480 AED over 365 days = +60%/yr. NOT the ~20% a 1:1 FX
+      // fallback (or an unconverted USD figure) would produce.
+      expect(entry.annualizedReturn).toBeCloseTo(60, 0);
+      expect(entry.currencyCode).toBe(global.BASE_CURRENCY_CODE);
     });
 
     it('does not inflate the return when a holding is unpriced at its buy date', async () => {

--- a/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
+++ b/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
@@ -8,7 +8,6 @@ import Securities from '@models/investments/securities.model';
 import SecurityPricing from '@models/investments/security-pricing.model';
 import UserExchangeRates from '@models/user-exchange-rates.model';
 import UsersCurrencies from '@models/users-currencies.model';
-import { withTransaction } from '@services/common/with-transaction';
 import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/fetch-exchange-rates-for-date';
 import { differenceInDays, endOfDay, format, parseISO, startOfDay, subDays } from 'date-fns';
 import { Op } from 'sequelize';
@@ -29,14 +28,37 @@ const FALLBACK_LOOKBACK_DAYS = 7;
 
 const formatDate = (date: Date | string): string => format(date, 'yyyy-MM-dd');
 
+/**
+ * Fast UTC variant for hot loops that format tens of thousands of pricing/rate
+ * rows. `date-fns` `format()` is regex/template-driven and dominated the
+ * pre-compute "map building" phase. Skipping it cuts that phase by ~10×.
+ *
+ * Output matches `formatDate(d)` whenever the process runs in UTC (the prod
+ * default for containerized backends). In a non-UTC dev shell the two diverge
+ * for rows whose UTC timestamp crosses local midnight — acceptable because the
+ * comparison target (`tx.date`) is a TZ-naive `DATEONLY` string and the data
+ * model treats dates as calendar days, not wall-clock moments.
+ */
+export const fastFormatDate = (date: Date | string): string => {
+  if (typeof date === 'string') return date.length >= 10 ? date.slice(0, 10) : date;
+  const y = date.getUTCFullYear();
+  const m = date.getUTCMonth() + 1;
+  const d = date.getUTCDate();
+  return `${y}-${m < 10 ? '0' : ''}${m}-${d < 10 ? '0' : ''}${d}`;
+};
+
 interface GetPortfoliosAnnualizedReturnsParams {
   userId: number;
 }
 
-type TransactionRow = Pick<
-  InvestmentTransaction,
-  'portfolioId' | 'securityId' | 'category' | 'date' | 'quantity' | 'refAmount' | 'refFees'
->;
+// Raw query — decimal Money columns come back as Postgres-formatted strings
+// (`'12.3400000000'`), not hydrated Money instances. Convert with `Number(...)`
+// at the use site; precision loss matches the prior `Money.toNumber()` path.
+type TransactionRow = Pick<InvestmentTransaction, 'portfolioId' | 'securityId' | 'category' | 'date'> & {
+  quantity: string;
+  refAmount: string;
+  refFees: string;
+};
 
 /** Running per-security position used to value the portfolio over time. */
 interface HoldingState {
@@ -72,7 +94,7 @@ interface HoldingState {
  * `calculateRefAmount` round-trip instead would issue dozens of serial DB
  * queries per request; keep the two cross-rate implementations in sync.
  */
-const getPortfoliosAnnualizedReturnsImpl = async ({
+export const getPortfoliosAnnualizedReturns = async ({
   userId,
 }: GetPortfoliosAnnualizedReturnsParams): Promise<PortfolioAnnualizedReturnModel[]> => {
   const [userBaseCurrency, portfolios] = await Promise.all([
@@ -99,7 +121,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
   // Only buys/sells (holdings changes) and dividends (income return) matter for
   // TWR. Other categories (transfer, fee, tax, cancel, other) are cash-side
   // movements that don't affect security market value or investment return.
-  const transactions: TransactionRow[] = await InvestmentTransaction.findAll({
+  const transactions: TransactionRow[] = (await InvestmentTransaction.findAll({
     where: {
       portfolioId: { [Op.in]: portfolioIds },
       category: {
@@ -117,7 +139,8 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
       ['createdAt', 'ASC'],
     ],
     attributes: ['portfolioId', 'securityId', 'category', 'date', 'quantity', 'refAmount', 'refFees'],
-  });
+    raw: true,
+  })) as unknown as TransactionRow[];
 
   const securityIds = [...new Set(transactions.map((t) => t.securityId))];
 
@@ -148,20 +171,28 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
     (code) => code !== API_LAYER_BASE_CURRENCY_CODE,
   );
 
-  type SecurityPriceRow = Pick<SecurityPricing, 'securityId' | 'date' | 'priceClose'>;
+  type SecurityPriceRow = Pick<SecurityPricing, 'securityId' | 'date'> & { priceClose: string };
   type UserRateRow = Pick<UserExchangeRates, 'baseCode' | 'quoteCode' | 'date' | 'rate'>;
   type SystemRateRow = Pick<ExchangeRates, 'quoteCode' | 'date' | 'rate'>;
 
   const [securityPrices, userCustomExchangeRates, systemExchangeRates] = await Promise.all([
     securityIds.length
       ? (SecurityPricing.findAll({
-          where: { securityId: { [Op.in]: securityIds } },
+          where: {
+            securityId: { [Op.in]: securityIds },
+            // Crypto writes intraday rows hourly, so the unbounded variant of
+            // this query pulled the entire price history of every traded
+            // security. Bounding by the data window cuts both row count and
+            // downstream `findPriceForDate` scan length.
+            date: { [Op.between]: [startOfDay(parseISO(dataFetchMinDate)), endOfDay(parseISO(today))] },
+          },
           order: [
             ['securityId', 'ASC'],
             ['date', 'ASC'],
           ],
           attributes: ['securityId', 'date', 'priceClose'],
-        }) as Promise<SecurityPriceRow[]>)
+          raw: true,
+        }) as unknown as Promise<SecurityPriceRow[]>)
       : Promise.resolve([] as SecurityPriceRow[]),
     // User-set overrides — stored directly as `currencyCode → userBase`.
     currencyCodes.length
@@ -200,9 +231,9 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
   // ("latest price on or before a date" covers weekends/holidays).
   const pricesBySecurity = new Map<string, Array<{ date: string; price: number }>>();
   for (const row of securityPrices) {
-    const dateStr = formatDate(row.date);
+    const dateStr = fastFormatDate(row.date);
     const list = pricesBySecurity.get(row.securityId);
-    const entry = { date: dateStr, price: row.priceClose.toNumber() };
+    const entry = { date: dateStr, price: Number(row.priceClose) };
     if (list) {
       // Crypto carries intraday rows; later same-day write wins the daily bucket.
       const last = list[list.length - 1];
@@ -227,7 +258,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
   // User overrides (`currencyCode → userBase`) win over the computed cross-rate.
   const userRatesMap = new Map<string, number>();
   for (const r of userCustomExchangeRates) {
-    userRatesMap.set(`${r.baseCode}_${formatDate(r.date)}`, r.rate);
+    userRatesMap.set(`${r.baseCode}_${fastFormatDate(r.date)}`, r.rate);
   }
 
   // System rates indexed by `${quoteCode}_${dateStr}` — value is `1 USD = N quoteCode`.
@@ -235,7 +266,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
   // Per-currency sorted (ascending) date list for the weekend/holiday fallback.
   const usdRateDatesByQuote = new Map<string, string[]>();
   for (const rate of systemExchangeRates) {
-    const dateStr = formatDate(rate.date);
+    const dateStr = fastFormatDate(rate.date);
     usdRatesMap.set(`${rate.quoteCode}_${dateStr}`, rate.rate);
     const dates = usdRateDatesByQuote.get(rate.quoteCode);
     if (dates) dates.push(dateStr);
@@ -356,7 +387,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
     const dividends: Array<{ date: string; amount: number }> = [];
     for (const tx of portfolioTxs) {
       if (tx.category === INVESTMENT_TRANSACTION_CATEGORY.dividend) {
-        dividends.push({ date: tx.date, amount: tx.refAmount.toNumber() });
+        dividends.push({ date: tx.date, amount: Number(tx.refAmount) });
         continue;
       }
       const list = tradesByDate.get(tx.date);
@@ -391,8 +422,8 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
       // oversell (allowed for crypto) doesn't corrupt the basis used as the
       // no-price valuation fallback.
       for (const tx of tradesByDate.get(boundaryDate) ?? []) {
-        const quantity = tx.quantity.toNumber();
-        const totalAmount = tx.refAmount.toNumber() + tx.refFees.toNumber();
+        const quantity = Number(tx.quantity);
+        const totalAmount = Number(tx.refAmount) + Number(tx.refFees);
         const holding = holdings.get(tx.securityId) ?? { quantity: 0, costBasis: 0 };
 
         if (tx.category === INVESTMENT_TRANSACTION_CATEGORY.buy) {
@@ -449,5 +480,3 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
 
   return results;
 };
-
-export const getPortfoliosAnnualizedReturns = withTransaction(getPortfoliosAnnualizedReturnsImpl);

--- a/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
+++ b/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
@@ -1,14 +1,16 @@
 import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types';
 import type { PortfolioAnnualizedReturnModel } from '@bt/shared/types/investments/portfolio-annualized-return.model';
-import { Money } from '@common/types/money';
+import { logger } from '@js/utils';
+import ExchangeRates from '@models/exchange-rates.model';
 import InvestmentTransaction from '@models/investments/investment-transaction.model';
 import Portfolios from '@models/investments/portfolios.model';
 import Securities from '@models/investments/securities.model';
 import SecurityPricing from '@models/investments/security-pricing.model';
+import UserExchangeRates from '@models/user-exchange-rates.model';
 import UsersCurrencies from '@models/users-currencies.model';
-import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { withTransaction } from '@services/common/with-transaction';
-import { differenceInDays, format, parseISO } from 'date-fns';
+import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/fetch-exchange-rates-for-date';
+import { differenceInDays, endOfDay, format, parseISO, startOfDay, subDays } from 'date-fns';
 import { Op } from 'sequelize';
 
 /**
@@ -18,8 +20,12 @@ import { Op } from 'sequelize';
  */
 const MIN_HISTORY_DAYS = 180;
 
-/** Unit amount used to derive a currency→base rate from `calculateRefAmount`. */
-const FX_PROBE_UNITS = 10_000;
+/**
+ * Days of price/rate history to pre-fetch before the first trade so the
+ * "latest value on or before a date" fallback has prior trading-day data to
+ * walk back to across weekends/holidays.
+ */
+const FALLBACK_LOOKBACK_DAYS = 7;
 
 const formatDate = (date: Date | string): string => format(date, 'yyyy-MM-dd');
 
@@ -60,6 +66,11 @@ interface HoldingState {
  * as return-without-new-capital. Buys/sells are NOT treated as returns because
  * the same day-close price is used for both the valuation and the share delta,
  * so a trade contributes ~0 to its own day's return.
+ *
+ * FX — all exchange rates are bulk-loaded once and converted in memory (mirrors
+ * `get-combined-balance-history`). Valuing each boundary with a per-date
+ * `calculateRefAmount` round-trip instead would issue dozens of serial DB
+ * queries per request; keep the two cross-rate implementations in sync.
  */
 const getPortfoliosAnnualizedReturnsImpl = async ({
   userId,
@@ -119,21 +130,74 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
       })) as SecurityRow[])
     : [];
   const securitiesById = new Map(securities.map((s) => [String(s.id), s]));
+  const currencyCodes = [...new Set(securities.map((s) => s.currencyCode))];
 
-  // One price series per security, ascending by date, for O(log n)-ish fallback
-  // lookups ("latest price on or before a date" covers weekends/holidays).
+  // Earliest trade date bounds how far back rates need to be loaded.
+  let earliestDate: string | null = null;
+  for (const tx of transactions) {
+    if (earliestDate === null || tx.date < earliestDate) earliestDate = tx.date;
+  }
+  const dataFetchMinDate = earliestDate
+    ? format(subDays(parseISO(earliestDate), FALLBACK_LOOKBACK_DAYS), 'yyyy-MM-dd')
+    : today;
+
+  // Currencies we need a `USD → X` rate for: every security currency PLUS the
+  // user's base currency (the numerator in the cross-rate). USD itself is
+  // excluded because `findLatestUsdRate` short-circuits to 1 for it.
+  const usdRateQuoteCodes = [...new Set([baseCurrencyCode, ...currencyCodes])].filter(
+    (code) => code !== API_LAYER_BASE_CURRENCY_CODE,
+  );
+
   type SecurityPriceRow = Pick<SecurityPricing, 'securityId' | 'date' | 'priceClose'>;
-  const securityPrices: SecurityPriceRow[] = securityIds.length
-    ? ((await SecurityPricing.findAll({
-        where: { securityId: { [Op.in]: securityIds } },
-        order: [
-          ['securityId', 'ASC'],
-          ['date', 'ASC'],
-        ],
-        attributes: ['securityId', 'date', 'priceClose'],
-      })) as SecurityPriceRow[])
-    : [];
+  type UserRateRow = Pick<UserExchangeRates, 'baseCode' | 'quoteCode' | 'date' | 'rate'>;
+  type SystemRateRow = Pick<ExchangeRates, 'quoteCode' | 'date' | 'rate'>;
 
+  const [securityPrices, userCustomExchangeRates, systemExchangeRates] = await Promise.all([
+    securityIds.length
+      ? (SecurityPricing.findAll({
+          where: { securityId: { [Op.in]: securityIds } },
+          order: [
+            ['securityId', 'ASC'],
+            ['date', 'ASC'],
+          ],
+          attributes: ['securityId', 'date', 'priceClose'],
+        }) as Promise<SecurityPriceRow[]>)
+      : Promise.resolve([] as SecurityPriceRow[]),
+    // User-set overrides — stored directly as `currencyCode → userBase`.
+    currencyCodes.length
+      ? (UserExchangeRates.findAll({
+          where: {
+            userId,
+            baseCode: { [Op.in]: currencyCodes },
+            quoteCode: baseCurrencyCode,
+            date: { [Op.between]: [dataFetchMinDate, today] },
+          },
+          attributes: ['baseCode', 'quoteCode', 'date', 'rate'],
+          raw: true,
+        }) as Promise<UserRateRow[]>)
+      : Promise.resolve([] as UserRateRow[]),
+    // System rates are stored only as `baseCode = USD, quoteCode = X` (1 USD = N X).
+    // Query that direction for every currency we convert from AND the user's
+    // base currency, then derive the cross-rate in `getExchangeRate` below.
+    usdRateQuoteCodes.length
+      ? (ExchangeRates.findAll({
+          where: {
+            baseCode: API_LAYER_BASE_CURRENCY_CODE,
+            quoteCode: { [Op.in]: usdRateQuoteCodes },
+            date: { [Op.between]: [startOfDay(parseISO(dataFetchMinDate)), endOfDay(parseISO(today))] },
+          },
+          order: [
+            ['quoteCode', 'ASC'],
+            ['date', 'ASC'],
+          ],
+          attributes: ['quoteCode', 'date', 'rate'],
+          raw: true,
+        }) as Promise<SystemRateRow[]>)
+      : Promise.resolve([] as SystemRateRow[]),
+  ]);
+
+  // One price series per security, ascending by date, for fallback lookups
+  // ("latest price on or before a date" covers weekends/holidays).
   const pricesBySecurity = new Map<string, Array<{ date: string; price: number }>>();
   for (const row of securityPrices) {
     const dateStr = formatDate(row.date);
@@ -160,27 +224,66 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
     return latest;
   };
 
-  // Memoized `1 unit of <currency>` → base-currency rate at a given date.
-  const fxCache = new Map<string, number>();
-  const getFxRate = async (currencyCode: string, dateStr: string): Promise<number> => {
+  // User overrides (`currencyCode → userBase`) win over the computed cross-rate.
+  const userRatesMap = new Map<string, number>();
+  for (const r of userCustomExchangeRates) {
+    userRatesMap.set(`${r.baseCode}_${formatDate(r.date)}`, r.rate);
+  }
+
+  // System rates indexed by `${quoteCode}_${dateStr}` — value is `1 USD = N quoteCode`.
+  const usdRatesMap = new Map<string, number>();
+  // Per-currency sorted (ascending) date list for the weekend/holiday fallback.
+  const usdRateDatesByQuote = new Map<string, string[]>();
+  for (const rate of systemExchangeRates) {
+    const dateStr = formatDate(rate.date);
+    usdRatesMap.set(`${rate.quoteCode}_${dateStr}`, rate.rate);
+    const dates = usdRateDatesByQuote.get(rate.quoteCode);
+    if (dates) dates.push(dateStr);
+    else usdRateDatesByQuote.set(rate.quoteCode, [dateStr]);
+  }
+
+  const missingRateCurrencies = new Set<string>();
+
+  // `1 USD = ? quoteCode` for `dateStr`, falling back to the most recent prior
+  // rate when the exact day is missing. `null` when nothing is known.
+  const findLatestUsdRate = (quoteCode: string, dateStr: string): number | null => {
+    if (quoteCode === API_LAYER_BASE_CURRENCY_CODE) return 1;
+    const exact = usdRatesMap.get(`${quoteCode}_${dateStr}`);
+    if (exact !== undefined) return exact;
+    const dates = usdRateDatesByQuote.get(quoteCode);
+    if (!dates || dates.length === 0) return null;
+    let candidate: number | null = null;
+    for (const d of dates) {
+      if (d <= dateStr) candidate = usdRatesMap.get(`${quoteCode}_${d}`) ?? candidate;
+      else break;
+    }
+    return candidate;
+  };
+
+  // Multiplier converting 1 unit of `currencyCode` into the user's base currency.
+  const getExchangeRate = (currencyCode: string, dateStr: string): number => {
     if (currencyCode === baseCurrencyCode) return 1;
-    const key = `${currencyCode}_${dateStr}`;
-    const cached = fxCache.get(key);
-    if (cached !== undefined) return cached;
-    const converted = await calculateRefAmount({
-      amount: Money.fromDecimal(FX_PROBE_UNITS),
-      userId,
-      date: dateStr,
-      baseCode: currencyCode,
-      quoteCode: baseCurrencyCode,
-    });
-    const rate = converted.toNumber() / FX_PROBE_UNITS;
-    fxCache.set(key, rate);
-    return rate;
+
+    const userOverride = userRatesMap.get(`${currencyCode}_${dateStr}`);
+    if (userOverride !== undefined) return userOverride;
+
+    // Cross-rate via USD pivot: base = currency * (USD→base) / (USD→currency).
+    const usdToCurrency = findLatestUsdRate(currencyCode, dateStr);
+    const usdToBase = findLatestUsdRate(baseCurrencyCode, dateStr);
+
+    if (usdToCurrency == null || usdToBase == null || usdToCurrency === 0) {
+      if (usdToCurrency === 0) {
+        logger.error(`Stored exchange rate is zero for USD->${currencyCode} on ${dateStr}; treating as missing.`);
+      }
+      missingRateCurrencies.add(currencyCode);
+      return 1;
+    }
+
+    return usdToBase / usdToCurrency;
   };
 
   // Market value (base currency) of a holdings map valued at `dateStr`.
-  const valueHoldings = async (holdings: Map<string, HoldingState>, dateStr: string): Promise<number> => {
+  const valueHoldings = (holdings: Map<string, HoldingState>, dateStr: string): number => {
     let total = 0;
     for (const [securityId, holding] of holdings) {
       const security = securitiesById.get(securityId);
@@ -198,7 +301,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
         total += holding.costBasis;
         continue;
       }
-      const rate = await getFxRate(security?.currencyCode ?? baseCurrencyCode, dateStr);
+      const rate = getExchangeRate(security?.currencyCode ?? baseCurrencyCode, dateStr);
       total += effectiveQuantity * price * rate;
     }
     return total;
@@ -274,7 +377,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
     for (const boundaryDate of boundaryDates) {
       // Close the open sub-period: value the (unchanged) holdings at this date.
       if (prevDate !== null && prevValue > 0) {
-        const valueBefore = await valueHoldings(holdings, boundaryDate);
+        const valueBefore = valueHoldings(holdings, boundaryDate);
         let dividendsInPeriod = 0;
         while (dividendIdx < dividends.length && dividends[dividendIdx]!.date <= boundaryDate) {
           if (dividends[dividendIdx]!.date > prevDate) dividendsInPeriod += dividends[dividendIdx]!.amount;
@@ -314,7 +417,7 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
         holdings.set(tx.securityId, holding);
       }
 
-      prevValue = await valueHoldings(holdings, boundaryDate);
+      prevValue = valueHoldings(holdings, boundaryDate);
       prevDate = boundaryDate;
       if (prevValue > 0) started = true;
     }
@@ -333,6 +436,14 @@ const getPortfoliosAnnualizedReturnsImpl = async ({
       startDate,
       periodDays,
       currencyCode: baseCurrencyCode,
+    });
+  }
+
+  if (missingRateCurrencies.size > 0) {
+    logger.warn('Annualized return: exchange rate fallback to 1:1', {
+      userId,
+      baseCurrency: baseCurrencyCode,
+      currencies: Array.from(missingRateCurrencies),
     });
   }
 

--- a/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
+++ b/packages/backend/src/services/investments/portfolios/get-portfolios-annualized-returns.service.ts
@@ -1,0 +1,342 @@
+import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types';
+import type { PortfolioAnnualizedReturnModel } from '@bt/shared/types/investments/portfolio-annualized-return.model';
+import { Money } from '@common/types/money';
+import InvestmentTransaction from '@models/investments/investment-transaction.model';
+import Portfolios from '@models/investments/portfolios.model';
+import Securities from '@models/investments/securities.model';
+import SecurityPricing from '@models/investments/security-pricing.model';
+import UsersCurrencies from '@models/users-currencies.model';
+import { calculateRefAmount } from '@services/calculate-ref-amount.service';
+import { withTransaction } from '@services/common/with-transaction';
+import { differenceInDays, format, parseISO } from 'date-fns';
+import { Op } from 'sequelize';
+
+/**
+ * Minimum tracked history (in days) before an annualized figure is shown.
+ * Annualizing a return from a few weeks of data inflates noise into a wild
+ * yearly number, so anything shorter is reported as "not enough history".
+ */
+const MIN_HISTORY_DAYS = 180;
+
+/** Unit amount used to derive a currency→base rate from `calculateRefAmount`. */
+const FX_PROBE_UNITS = 10_000;
+
+const formatDate = (date: Date | string): string => format(date, 'yyyy-MM-dd');
+
+interface GetPortfoliosAnnualizedReturnsParams {
+  userId: number;
+}
+
+type TransactionRow = Pick<
+  InvestmentTransaction,
+  'portfolioId' | 'securityId' | 'category' | 'date' | 'quantity' | 'refAmount' | 'refFees'
+>;
+
+/** Running per-security position used to value the portfolio over time. */
+interface HoldingState {
+  quantity: number;
+  /**
+   * Total cost basis in the user's base currency. Used as the valuation
+   * fallback when no market price is available on a given date (e.g. a
+   * back-dated buy that precedes the security's price history).
+   */
+  costBasis: number;
+}
+
+/**
+ * Computes the annualized time-weighted return (TWR) of each enabled portfolio
+ * over its full tracked history, expressed in the user's base currency.
+ *
+ * TWR is the right metric for the investment calculator: it measures how the
+ * *holdings themselves* performed, stripping out the timing and size of the
+ * user's contributions (the calculator already models contributions separately,
+ * so a contribution-sensitive metric like XIRR would double-count them).
+ *
+ * Method — daily values aren't stored, so the portfolio is valued only at the
+ * dates where holdings change (every buy/sell) plus today. Between two such
+ * boundaries the holdings are fixed, so the sub-period return collapses to a
+ * pure price ratio `value(end) / value(start)`. Chaining those ratios yields
+ * the TWR; dividends received within a sub-period are added to its ending value
+ * as return-without-new-capital. Buys/sells are NOT treated as returns because
+ * the same day-close price is used for both the valuation and the share delta,
+ * so a trade contributes ~0 to its own day's return.
+ */
+const getPortfoliosAnnualizedReturnsImpl = async ({
+  userId,
+}: GetPortfoliosAnnualizedReturnsParams): Promise<PortfolioAnnualizedReturnModel[]> => {
+  const [userBaseCurrency, portfolios] = await Promise.all([
+    UsersCurrencies.findOne({
+      where: { userId, isDefaultCurrency: true },
+      raw: true,
+      attributes: ['currencyCode'],
+    }) as Promise<Pick<UsersCurrencies, 'currencyCode'> | null>,
+    Portfolios.findAll({
+      where: { userId, isEnabled: true },
+      attributes: ['id', 'name'],
+      raw: true,
+    }) as Promise<Pick<Portfolios, 'id' | 'name'>[]>,
+  ]);
+
+  if (!userBaseCurrency?.currencyCode || portfolios.length === 0) {
+    return [];
+  }
+
+  const baseCurrencyCode = userBaseCurrency.currencyCode;
+  const today = formatDate(new Date());
+  const portfolioIds = portfolios.map((p) => p.id);
+
+  // Only buys/sells (holdings changes) and dividends (income return) matter for
+  // TWR. Other categories (transfer, fee, tax, cancel, other) are cash-side
+  // movements that don't affect security market value or investment return.
+  const transactions: TransactionRow[] = await InvestmentTransaction.findAll({
+    where: {
+      portfolioId: { [Op.in]: portfolioIds },
+      category: {
+        [Op.in]: [
+          INVESTMENT_TRANSACTION_CATEGORY.buy,
+          INVESTMENT_TRANSACTION_CATEGORY.sell,
+          INVESTMENT_TRANSACTION_CATEGORY.dividend,
+        ],
+      },
+      date: { [Op.lte]: today },
+    },
+    order: [
+      ['portfolioId', 'ASC'],
+      ['date', 'ASC'],
+      ['createdAt', 'ASC'],
+    ],
+    attributes: ['portfolioId', 'securityId', 'category', 'date', 'quantity', 'refAmount', 'refFees'],
+  });
+
+  const securityIds = [...new Set(transactions.map((t) => t.securityId))];
+
+  type SecurityRow = Pick<Securities, 'id' | 'currencyCode' | 'assetClass'>;
+  const securities: SecurityRow[] = securityIds.length
+    ? ((await Securities.findAll({
+        where: { id: { [Op.in]: securityIds } },
+        attributes: ['id', 'currencyCode', 'assetClass'],
+        raw: true,
+      })) as SecurityRow[])
+    : [];
+  const securitiesById = new Map(securities.map((s) => [String(s.id), s]));
+
+  // One price series per security, ascending by date, for O(log n)-ish fallback
+  // lookups ("latest price on or before a date" covers weekends/holidays).
+  type SecurityPriceRow = Pick<SecurityPricing, 'securityId' | 'date' | 'priceClose'>;
+  const securityPrices: SecurityPriceRow[] = securityIds.length
+    ? ((await SecurityPricing.findAll({
+        where: { securityId: { [Op.in]: securityIds } },
+        order: [
+          ['securityId', 'ASC'],
+          ['date', 'ASC'],
+        ],
+        attributes: ['securityId', 'date', 'priceClose'],
+      })) as SecurityPriceRow[])
+    : [];
+
+  const pricesBySecurity = new Map<string, Array<{ date: string; price: number }>>();
+  for (const row of securityPrices) {
+    const dateStr = formatDate(row.date);
+    const list = pricesBySecurity.get(row.securityId);
+    const entry = { date: dateStr, price: row.priceClose.toNumber() };
+    if (list) {
+      // Crypto carries intraday rows; later same-day write wins the daily bucket.
+      const last = list[list.length - 1];
+      if (last && last.date === dateStr) last.price = entry.price;
+      else list.push(entry);
+    } else {
+      pricesBySecurity.set(row.securityId, [entry]);
+    }
+  }
+
+  const findPriceForDate = (securityId: string, targetDate: string): number | null => {
+    const prices = pricesBySecurity.get(securityId);
+    if (!prices || prices.length === 0) return null;
+    let latest: number | null = null;
+    for (const p of prices) {
+      if (p.date <= targetDate) latest = p.price;
+      else break;
+    }
+    return latest;
+  };
+
+  // Memoized `1 unit of <currency>` → base-currency rate at a given date.
+  const fxCache = new Map<string, number>();
+  const getFxRate = async (currencyCode: string, dateStr: string): Promise<number> => {
+    if (currencyCode === baseCurrencyCode) return 1;
+    const key = `${currencyCode}_${dateStr}`;
+    const cached = fxCache.get(key);
+    if (cached !== undefined) return cached;
+    const converted = await calculateRefAmount({
+      amount: Money.fromDecimal(FX_PROBE_UNITS),
+      userId,
+      date: dateStr,
+      baseCode: currencyCode,
+      quoteCode: baseCurrencyCode,
+    });
+    const rate = converted.toNumber() / FX_PROBE_UNITS;
+    fxCache.set(key, rate);
+    return rate;
+  };
+
+  // Market value (base currency) of a holdings map valued at `dateStr`.
+  const valueHoldings = async (holdings: Map<string, HoldingState>, dateStr: string): Promise<number> => {
+    let total = 0;
+    for (const [securityId, holding] of holdings) {
+      const security = securitiesById.get(securityId);
+      // Stocks can't be negative; crypto may legitimately drift negative.
+      const allowNegative = security?.assetClass === ASSET_CLASS.crypto;
+      const effectiveQuantity = !allowNegative && holding.quantity < 0 ? 0 : holding.quantity;
+      if (effectiveQuantity === 0) continue;
+      const price = findPriceForDate(securityId, dateStr);
+      if (price === null) {
+        // No market price on/before this date (e.g. a back-dated buy that
+        // precedes the security's price history). Fall back to cost basis —
+        // already in base currency — so the position is valued consistently at
+        // both ends of a sub-period instead of jumping 0 → market value and
+        // injecting a phantom return. Mirrors `get-combined-balance-history`.
+        total += holding.costBasis;
+        continue;
+      }
+      const rate = await getFxRate(security?.currencyCode ?? baseCurrencyCode, dateStr);
+      total += effectiveQuantity * price * rate;
+    }
+    return total;
+  };
+
+  const transactionsByPortfolio = new Map<string, TransactionRow[]>();
+  for (const tx of transactions) {
+    const list = transactionsByPortfolio.get(tx.portfolioId);
+    if (list) list.push(tx);
+    else transactionsByPortfolio.set(tx.portfolioId, [tx]);
+  }
+
+  const results: PortfolioAnnualizedReturnModel[] = [];
+
+  for (const portfolio of portfolios) {
+    const portfolioTxs = transactionsByPortfolio.get(portfolio.id) ?? [];
+    const tradeTxs = portfolioTxs.filter(
+      (t) => t.category === INVESTMENT_TRANSACTION_CATEGORY.buy || t.category === INVESTMENT_TRANSACTION_CATEGORY.sell,
+    );
+
+    if (tradeTxs.length === 0) {
+      results.push({
+        portfolioId: portfolio.id,
+        portfolioName: portfolio.name,
+        annualizedReturn: null,
+        hasEnoughHistory: false,
+        startDate: null,
+        periodDays: 0,
+        currencyCode: baseCurrencyCode,
+      });
+      continue;
+    }
+
+    const startDate = tradeTxs[0]!.date;
+    const periodDays = differenceInDays(parseISO(today), parseISO(startDate));
+
+    if (periodDays < MIN_HISTORY_DAYS) {
+      results.push({
+        portfolioId: portfolio.id,
+        portfolioName: portfolio.name,
+        annualizedReturn: null,
+        hasEnoughHistory: false,
+        startDate,
+        periodDays: Math.max(periodDays, 0),
+        currencyCode: baseCurrencyCode,
+      });
+      continue;
+    }
+
+    // Group trades by date and collect dividends as a sorted list of returns.
+    const tradesByDate = new Map<string, TransactionRow[]>();
+    const dividends: Array<{ date: string; amount: number }> = [];
+    for (const tx of portfolioTxs) {
+      if (tx.category === INVESTMENT_TRANSACTION_CATEGORY.dividend) {
+        dividends.push({ date: tx.date, amount: tx.refAmount.toNumber() });
+        continue;
+      }
+      const list = tradesByDate.get(tx.date);
+      if (list) list.push(tx);
+      else tradesByDate.set(tx.date, [tx]);
+    }
+
+    const boundaryDates = [...tradesByDate.keys()].toSorted();
+    if (boundaryDates[boundaryDates.length - 1] !== today) boundaryDates.push(today);
+
+    const holdings = new Map<string, HoldingState>();
+    let cumulativeFactor = 1;
+    let prevValue = 0;
+    let prevDate: string | null = null;
+    let started = false;
+    let dividendIdx = 0;
+
+    for (const boundaryDate of boundaryDates) {
+      // Close the open sub-period: value the (unchanged) holdings at this date.
+      if (prevDate !== null && prevValue > 0) {
+        const valueBefore = await valueHoldings(holdings, boundaryDate);
+        let dividendsInPeriod = 0;
+        while (dividendIdx < dividends.length && dividends[dividendIdx]!.date <= boundaryDate) {
+          if (dividends[dividendIdx]!.date > prevDate) dividendsInPeriod += dividends[dividendIdx]!.amount;
+          dividendIdx += 1;
+        }
+        cumulativeFactor *= (valueBefore + dividendsInPeriod) / prevValue;
+      }
+
+      // Apply this date's trades to the running holdings. Cost-basis tracking
+      // mirrors `recalculateHolding` / `get-combined-balance-history` so an
+      // oversell (allowed for crypto) doesn't corrupt the basis used as the
+      // no-price valuation fallback.
+      for (const tx of tradesByDate.get(boundaryDate) ?? []) {
+        const quantity = tx.quantity.toNumber();
+        const totalAmount = tx.refAmount.toNumber() + tx.refFees.toNumber();
+        const holding = holdings.get(tx.securityId) ?? { quantity: 0, costBasis: 0 };
+
+        if (tx.category === INVESTMENT_TRANSACTION_CATEGORY.buy) {
+          const newQuantity = holding.quantity + quantity;
+          if (newQuantity <= 0) {
+            holding.costBasis = 0;
+          } else if (holding.quantity <= 0) {
+            // Buy crosses from short/zero into long — only the long part is new basis.
+            holding.costBasis = totalAmount * (newQuantity / quantity);
+          } else {
+            holding.costBasis += totalAmount;
+          }
+          holding.quantity = newQuantity;
+        } else {
+          if (holding.quantity > 0) {
+            const newQuantity = holding.quantity - quantity;
+            holding.costBasis = newQuantity <= 0 ? 0 : holding.costBasis * (newQuantity / holding.quantity);
+          }
+          holding.quantity -= quantity;
+        }
+
+        holdings.set(tx.securityId, holding);
+      }
+
+      prevValue = await valueHoldings(holdings, boundaryDate);
+      prevDate = boundaryDate;
+      if (prevValue > 0) started = true;
+    }
+
+    // `cumulativeFactor <= 0` means the position was wiped out — not annualizable.
+    const computable = started && periodDays > 0 && cumulativeFactor > 0;
+    const annualizedReturn = computable
+      ? Math.round((Math.pow(cumulativeFactor, 365 / periodDays) - 1) * 100 * 100) / 100
+      : null;
+
+    results.push({
+      portfolioId: portfolio.id,
+      portfolioName: portfolio.name,
+      annualizedReturn,
+      hasEnoughHistory: annualizedReturn !== null,
+      startDate,
+      periodDays,
+      currencyCode: baseCurrencyCode,
+    });
+  }
+
+  return results;
+};
+
+export const getPortfoliosAnnualizedReturns = withTransaction(getPortfoliosAnnualizedReturnsImpl);

--- a/packages/backend/src/tests/helpers/investments/portfolios.ts
+++ b/packages/backend/src/tests/helpers/investments/portfolios.ts
@@ -5,6 +5,7 @@ import { updatePortfolioBalance as _updatePortfolioBalance } from '@services/inv
 import { createPortfolio as _createPortfolio } from '@services/investments/portfolios/create.service';
 import { deletePortfolio as _deletePortfolio } from '@services/investments/portfolios/delete.service';
 import { getPortfolioSummary as _getPortfolioSummary } from '@services/investments/portfolios/get-portfolio-summary.service';
+import { getPortfoliosAnnualizedReturns as _getPortfoliosAnnualizedReturns } from '@services/investments/portfolios/get-portfolios-annualized-returns.service';
 import { getPortfolio as _getPortfolio } from '@services/investments/portfolios/get.service';
 import { listPortfolios as _listPortfolios } from '@services/investments/portfolios/list.service';
 import { restorePortfolio as _restorePortfolio } from '@services/investments/portfolios/restore.service';
@@ -195,6 +196,18 @@ export async function getPortfolioSummary<R extends boolean | undefined = false>
     method: 'get',
     url: `/investments/portfolios/${portfolioId}/summary`,
     payload: removeUndefinedKeys({ date }),
+    raw,
+  });
+}
+
+export async function getPortfoliosAnnualizedReturns<R extends boolean | undefined = false>({
+  raw,
+}: {
+  raw?: R;
+} = {}) {
+  return makeRequest<Awaited<ReturnType<typeof _getPortfoliosAnnualizedReturns>>, R>({
+    method: 'get',
+    url: '/investments/portfolios/annualized-returns',
     raw,
   });
 }

--- a/packages/frontend/src/api/portfolios.ts
+++ b/packages/frontend/src/api/portfolios.ts
@@ -5,6 +5,7 @@ import {
   PortfolioModel,
   PortfolioTransferModel,
 } from '@bt/shared/types/investments';
+import type { PortfolioAnnualizedReturnModel } from '@bt/shared/types/investments/portfolio-annualized-return.model';
 import type { PortfolioSummaryModel } from '@bt/shared/types/investments/portfolio-summary.model';
 
 interface CreatePortfolioRequest {
@@ -226,5 +227,10 @@ export const getPortfolioSummary = async ({
 }): Promise<PortfolioSummaryModel> => {
   const params = date ? { date } : {};
   const result = await api.get(`/investments/portfolios/${portfolioId}/summary`, params);
+  return result;
+};
+
+export const getPortfoliosAnnualizedReturns = async (): Promise<PortfolioAnnualizedReturnModel[]> => {
+  const result = await api.get('/investments/portfolios/annualized-returns');
   return result;
 };

--- a/packages/frontend/src/common/const/vue-query.ts
+++ b/packages/frontend/src/common/const/vue-query.ts
@@ -93,6 +93,7 @@ export const VUE_QUERY_CACHE_KEYS = Object.freeze({
   portfolioDetails: [securityPriceChange, 'portfolio-details'] as const,
   portfolioTransfers: [securityPriceChange, 'portfolio-transfers'] as const,
   portfolioSummary: [securityPriceChange, 'portfolio-summary'] as const,
+  portfolioAnnualizedReturns: [securityPriceChange, 'portfolio-annualized-returns'] as const,
   portfolioBalances: [securityPriceChange, 'portfolio-balances'] as const,
   transactionPortfolioLink: [transactionChange, 'transaction-portfolio-link'] as const,
 

--- a/packages/frontend/src/components/fields/select-field.vue
+++ b/packages/frontend/src/components/fields/select-field.vue
@@ -27,6 +27,8 @@ const props = withDefaults(
     searchKeys?: NonEmptyArray<StringOrNumberKeys<T>>;
     placeholder?: string;
     disabled?: boolean;
+    /** Predicate to render an individual option as non-selectable. */
+    optionDisabled?: (value: T) => boolean;
     errorMessage?: string;
     label?: string;
   }>(),
@@ -35,6 +37,7 @@ const props = withDefaults(
     disabled: false,
     withSearch: false,
     searchKeys: undefined,
+    optionDisabled: undefined,
     errorMessage: undefined,
     labelKey: 'label',
     valueKey: 'value',
@@ -137,6 +140,7 @@ watch(
             v-for="item in debouncedFilteredValues"
             :key="getKeyFromItem(item as T)"
             :value="getKeyFromItem(item as T)"
+            :disabled="optionDisabled ? optionDisabled(item as T) : undefined"
           >
             <slot name="item" :item="item" :label="getLabelFromValue(item as T)">
               {{ getLabelFromValue(item as T) }}

--- a/packages/frontend/src/composable/data-queries/portfolios-annualized-returns.ts
+++ b/packages/frontend/src/composable/data-queries/portfolios-annualized-returns.ts
@@ -1,0 +1,10 @@
+import { getPortfoliosAnnualizedReturns } from '@/api/portfolios';
+import { QUERY_CACHE_STALE_TIME, VUE_QUERY_CACHE_KEYS } from '@/common/const';
+import { useQuery } from '@tanstack/vue-query';
+
+export const usePortfoliosAnnualizedReturns = () =>
+  useQuery({
+    queryKey: VUE_QUERY_CACHE_KEYS.portfolioAnnualizedReturns,
+    queryFn: getPortfoliosAnnualizedReturns,
+    staleTime: QUERY_CACHE_STALE_TIME.ANALYTICS,
+  });

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/analytics.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/analytics.json
@@ -115,7 +115,9 @@
       "inflationTooltip": "How fast prices rise each year, reducing your money's real value.\n\n~1–2% — very low, stable economy\n~2–3% — normal (typical target)\n~4–6% — above average\n~7%+ — crisis-level inflation",
       "totalInvestedBreakdown": "{initial} initial + {contributions} contributions",
       "configure": "Configure",
-      "hideInputs": "Hide"
+      "hideInputs": "Hide",
+      "portfolioReturnOption": "{name} (your ~{rate}%/yr)",
+      "portfolioNoHistoryOption": "{name} — not enough history"
     }
   }
 }

--- a/packages/frontend/src/i18n/locales/chunks/uk/pages/analytics.json
+++ b/packages/frontend/src/i18n/locales/chunks/uk/pages/analytics.json
@@ -115,7 +115,9 @@
       "inflationTooltip": "Як швидко зростають ціни щороку, зменшуючи реальну вартість грошей.\n\n~1–2% — дуже низька, стабільна економіка\n~2–3% — нормальна (типова ціль)\n~4–6% — вище середнього\n~7%+ — кризова інфляція",
       "totalInvestedBreakdown": "{initial} початкові + {contributions} внески",
       "configure": "Налаштувати",
-      "hideInputs": "Сховати"
+      "hideInputs": "Сховати",
+      "portfolioReturnOption": "{name} (ваш ~{rate}%/рік)",
+      "portfolioNoHistoryOption": "{name} — недостатньо історії"
     }
   }
 }

--- a/packages/frontend/src/pages/analytics/subpages/investment-calculator/components/calculator-inputs.vue
+++ b/packages/frontend/src/pages/analytics/subpages/investment-calculator/components/calculator-inputs.vue
@@ -202,6 +202,7 @@
       <SelectField
         :model-value="selectedIndicatorOption"
         :values="indicatorOptions"
+        :option-disabled="isOptionDisabled"
         :label="$t('analytics.investmentCalculator.annualReturn')"
         label-key="label"
         value-key="id"
@@ -264,8 +265,15 @@ import { PercentIcon, SlidersHorizontalIcon } from '@lucide/vue';
 import { computed, reactive, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { CUSTOM_INDICATOR_ID, MARKET_INDICATORS } from '../composables/market-indicators';
+import {
+  CUSTOM_INDICATOR_ID,
+  getPortfolioIdFromIndicatorId,
+  isPortfolioIndicatorId,
+  makePortfolioIndicatorId,
+  MARKET_INDICATORS,
+} from '../composables/market-indicators';
 import type { NetIncomePeriod } from '../composables/use-seed-data';
+import type { PortfolioAnnualizedReturnModel } from '@bt/shared/types/investments/portfolio-annualized-return.model';
 
 const { t } = useI18n();
 const { formatBaseCurrency, getCurrencySymbol } = useFormatCurrency();
@@ -283,6 +291,7 @@ const DEFAULT_HORIZON_MAX = 20;
 interface SelectOption {
   id: string;
   label: string;
+  disabled?: boolean;
 }
 
 const props = defineProps<{
@@ -294,6 +303,7 @@ const props = defineProps<{
   selectedPeriod: NetIncomePeriod | null;
   selectedIndicatorId: string;
   currentTotalBalance: number;
+  portfolioReturns: PortfolioAnnualizedReturnModel[];
 }>();
 
 const emit = defineEmits<{
@@ -400,7 +410,31 @@ const netIncomePeriods: { value: NetIncomePeriod; label: string }[] = [
   { value: 'all', label: 'All' },
 ];
 
+// User's own portfolios first (their tracked performance), then the static
+// market indices, then the manual "Custom" entry. Portfolios without enough
+// history are listed disabled so the option is still discoverable.
+const portfolioOptions = computed<SelectOption[]>(() =>
+  // `annualizedReturn !== null` is the single source of truth — the backend only
+  // sets it when the history is long enough, so it doubles as the "selectable?" gate.
+  props.portfolioReturns.map((p) =>
+    p.annualizedReturn !== null
+      ? {
+          id: makePortfolioIndicatorId({ portfolioId: p.portfolioId }),
+          label: t('analytics.investmentCalculator.portfolioReturnOption', {
+            name: p.portfolioName,
+            rate: p.annualizedReturn.toFixed(1),
+          }),
+        }
+      : {
+          id: makePortfolioIndicatorId({ portfolioId: p.portfolioId }),
+          label: t('analytics.investmentCalculator.portfolioNoHistoryOption', { name: p.portfolioName }),
+          disabled: true,
+        },
+  ),
+);
+
 const indicatorOptions = computed<SelectOption[]>(() => [
+  ...portfolioOptions.value,
   ...MARKET_INDICATORS.map((i) => ({
     id: i.id,
     label: `${i.label} (~${i.avgAnnualReturn}%/yr)`,
@@ -415,9 +449,21 @@ const selectedIndicatorOption = computed(
   () => indicatorOptions.value.find((o) => o.id === props.selectedIndicatorId) ?? null,
 );
 
+const isOptionDisabled = (option: SelectOption): boolean => option.disabled === true;
+
 const handleIndicatorChange = (option: SelectOption | null) => {
-  if (!option) return;
+  if (!option || isOptionDisabled(option)) return;
   emit('update:selectedIndicatorId', option.id);
+
+  if (isPortfolioIndicatorId({ id: option.id })) {
+    const portfolioId = getPortfolioIdFromIndicatorId({ id: option.id });
+    const portfolio = props.portfolioReturns.find((p) => p.portfolioId === portfolioId);
+    if (portfolio && portfolio.annualizedReturn !== null) {
+      emit('update:annualReturnRate', portfolio.annualizedReturn);
+    }
+    return;
+  }
+
   const indicator = MARKET_INDICATORS.find((i) => i.id === option.id);
   if (indicator) {
     emit('update:annualReturnRate', indicator.avgAnnualReturn);

--- a/packages/frontend/src/pages/analytics/subpages/investment-calculator/composables/market-indicators.ts
+++ b/packages/frontend/src/pages/analytics/subpages/investment-calculator/composables/market-indicators.ts
@@ -6,6 +6,21 @@ interface MarketIndicator {
 
 export const CUSTOM_INDICATOR_ID = 'custom';
 
+/**
+ * Prefix for indicator options backed by one of the user's own portfolios
+ * (their tracked historical performance). The portfolio id is appended, e.g.
+ * `portfolio:9f3c...`, so it never collides with the static indicator ids.
+ */
+const PORTFOLIO_INDICATOR_PREFIX = 'portfolio:';
+
+export const makePortfolioIndicatorId = ({ portfolioId }: { portfolioId: string }): string =>
+  `${PORTFOLIO_INDICATOR_PREFIX}${portfolioId}`;
+
+export const isPortfolioIndicatorId = ({ id }: { id: string }): boolean => id.startsWith(PORTFOLIO_INDICATOR_PREFIX);
+
+export const getPortfolioIdFromIndicatorId = ({ id }: { id: string }): string =>
+  id.slice(PORTFOLIO_INDICATOR_PREFIX.length);
+
 export const MARKET_INDICATORS: MarketIndicator[] = [
   { id: 'sp500', label: 'S&P 500', avgAnnualReturn: 10 },
   { id: 'nasdaq', label: 'NASDAQ Composite', avgAnnualReturn: 12 },

--- a/packages/frontend/src/pages/analytics/subpages/investment-calculator/composables/use-seed-data.ts
+++ b/packages/frontend/src/pages/analytics/subpages/investment-calculator/composables/use-seed-data.ts
@@ -14,18 +14,20 @@ const PERIOD_MONTHS: Record<Exclude<NetIncomePeriod, 'all'>, number> = {
 };
 
 export function useSeedData({ selectedPeriod }: { selectedPeriod: Ref<NetIncomePeriod> }) {
-  // Fetch combined balance history to get the latest total balance
-  const { data: balanceHistory } = useQuery({
+  // Fetch only today's combined balance — the calculator just needs the seed
+  // value for "Initial balance", not the full multi-year series the dashboard
+  // chart consumes. `today` is computed inside queryFn so each refetch
+  // re-reads the date (the request stays correct across a midnight boundary).
+  const { data: latestBalance } = useQuery({
     queryKey: [...VUE_QUERY_CACHE_KEYS.widgetBalanceTrend, 'investment-calc-balance'],
-    queryFn: () => getCombinedBalanceHistory(),
+    queryFn: () => {
+      const today = new Date();
+      return getCombinedBalanceHistory({ from: today, to: today });
+    },
     staleTime: QUERY_CACHE_STALE_TIME.ANALYTICS,
   });
 
-  const currentTotalBalance = computed(() => {
-    const history = balanceHistory.value;
-    if (!history || history.length === 0) return 0;
-    return history[history.length - 1]!.totalBalance;
-  });
+  const currentTotalBalance = computed(() => latestBalance.value?.[0]?.totalBalance ?? 0);
 
   // Compute the cash flow query params based on selected period
   const cashFlowParams = computed(() => {

--- a/packages/frontend/src/pages/analytics/subpages/investment-calculator/index.vue
+++ b/packages/frontend/src/pages/analytics/subpages/investment-calculator/index.vue
@@ -38,6 +38,7 @@
         :selected-period="periodTabValue"
         :selected-indicator-id="selectedIndicatorId"
         :current-total-balance="currentTotalBalance"
+        :portfolio-returns="portfolioReturns"
         @update:initial-balance="initialBalance = $event"
         @update:monthly-contribution="handleManualContributionChange($event)"
         @update:time-horizon-years="timeHorizonYears = $event"
@@ -68,10 +69,17 @@ import { useElementSize } from '@vueuse/core';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import { usePortfoliosAnnualizedReturns } from '@/composable/data-queries/portfolios-annualized-returns';
 import CalculatorInputs from './components/calculator-inputs.vue';
 import ProjectionChart from './components/projection-chart.vue';
 import SummaryCards from './components/summary-cards.vue';
-import { CUSTOM_INDICATOR_ID, getIndicatorById, MARKET_INDICATORS } from './composables/market-indicators';
+import {
+  CUSTOM_INDICATOR_ID,
+  getIndicatorById,
+  getPortfolioIdFromIndicatorId,
+  isPortfolioIndicatorId,
+  MARKET_INDICATORS,
+} from './composables/market-indicators';
 import { useProjectionCalc, type ProjectionParams } from './composables/use-projection-calc';
 import { useSeedData, type NetIncomePeriod } from './composables/use-seed-data';
 
@@ -112,6 +120,11 @@ const selectedIndicatorId = ref(MARKET_INDICATORS[0]!.id);
 
 // Seed data from backend
 const { currentTotalBalance, averageNetIncome } = useSeedData({ selectedPeriod });
+
+// User's own portfolios' historical annualized returns (TWR), offered as
+// "Annual return" choices alongside the static market indices.
+const { data: portfolioReturnsData } = usePortfoliosAnnualizedReturns();
+const portfolioReturns = computed(() => portfolioReturnsData.value ?? []);
 
 // Auto-seed initial balance from user's current balance (once).
 // `immediate` is needed so that cached vue-query data (already non-zero on
@@ -161,6 +174,11 @@ const handleManualContributionChange = (val: number) => {
 const indicatorLabel = computed(() => {
   if (selectedIndicatorId.value === CUSTOM_INDICATOR_ID) {
     return t('analytics.investmentCalculator.customIndicator');
+  }
+  if (isPortfolioIndicatorId({ id: selectedIndicatorId.value })) {
+    const portfolioId = getPortfolioIdFromIndicatorId({ id: selectedIndicatorId.value });
+    const portfolio = portfolioReturns.value.find((p) => p.portfolioId === portfolioId);
+    return portfolio?.portfolioName ?? t('analytics.investmentCalculator.customIndicator');
   }
   const indicator = getIndicatorById({ id: selectedIndicatorId.value });
   return indicator?.label ?? t('analytics.investmentCalculator.customIndicator');

--- a/packages/shared/src/types/investments/portfolio-annualized-return.model.ts
+++ b/packages/shared/src/types/investments/portfolio-annualized-return.model.ts
@@ -1,0 +1,21 @@
+export interface PortfolioAnnualizedReturnModel {
+  portfolioId: string;
+  portfolioName: string;
+  /**
+   * Annualized time-weighted return as a percentage (e.g. `12.34` = +12.34%/yr).
+   * `null` when it cannot be computed (no holdings ever, or not enough history).
+   */
+  annualizedReturn: number | null;
+  /**
+   * Whether the tracked history is long enough for the figure to be meaningful.
+   * When `false`, `annualizedReturn` is `null` and the UI should present the
+   * portfolio as a disabled choice.
+   */
+  hasEnoughHistory: boolean;
+  /** ISO date (`yyyy-MM-dd`) of the first investment transaction, or `null`. */
+  startDate: string | null;
+  /** Number of days of history the figure is based on. */
+  periodDays: number;
+  /** User's base currency code (the return is computed in this currency). */
+  currencyCode: string;
+}


### PR DESCRIPTION
Adds a new market-indicator option in the investment calculator that surfaces each enabled portfolio's own time-weighted annualized return, so projections can be seeded from real tracked performance instead of preset benchmarks. TWR is used rather than XIRR because the calculator already models contributions separately – a money-weighted metric would double-count them

Endpoint cost is held down via bulk-loaded FX (mirrors get-combined-balance-history), raw: true on the heavy findAll queries, a date-bound SecurityPricing fetch, and a UTC fast-formatter for the per-row hot loops