### PR TITLE
Merge exchange-rate providers to refresh full currency coverage

### DIFF
--- a/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.e2e.ts
+++ b/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.e2e.ts
@@ -1,7 +1,12 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { logger } from '@js/utils';
 import { connection } from '@models/index';
 import * as helpers from '@tests/helpers';
-import { getCurrencyRatesApiResponseMock, getFrankfurterResponseMock } from '@tests/mocks/exchange-rates/data';
+import {
+  getApiLayerResposeMock,
+  getCurrencyRatesApiResponseMock,
+  getFrankfurterResponseMock,
+} from '@tests/mocks/exchange-rates/data';
 import { createCallsCounter, createOverride } from '@tests/mocks/helpers';
 import { format, startOfDay } from 'date-fns';
 
@@ -45,7 +50,18 @@ describe('Exchange Rates Functionality', () => {
     currencyRatesApiCounter.reset();
     frankfurterCounter.reset();
     apiLayerCounter.reset();
+    // Drop any logger spies installed by degradation-signal tests
+    jest.restoreAllMocks();
   });
+
+  // logger.error is an overloaded fn, so jest infers its call args as `never`.
+  // Read the recorded calls through a widened tuple type for assertions.
+  const loggerErrorCalls = (errorSpy: ReturnType<typeof jest.spyOn>): Array<[unknown, Record<string, unknown>?]> =>
+    errorSpy.mock.calls as unknown as Array<[unknown, Record<string, unknown>?]>;
+
+  // Returns true if logger.error was called with a message containing `substring`.
+  const loggerErrorCalledWith = (errorSpy: ReturnType<typeof jest.spyOn>, substring: string): boolean =>
+    loggerErrorCalls(errorSpy).some(([arg]) => typeof arg === 'string' && arg.includes(substring));
 
   it('should successfully fetch and store exchange rates using modular provider system', async () => {
     const date = format(new Date(), 'yyyy-MM-dd');
@@ -66,6 +82,100 @@ describe('Exchange Rates Functionality', () => {
       expect(item.source).not.toBe(EXCHANGE_RATE_PROVIDER_TYPE.UNKNOWN);
       expect(Object.values(EXCHANGE_RATE_PROVIDER_TYPE)).toContain(item.source);
     });
+  });
+
+  it('should fill currencies missing from the primary provider using lower-priority fallbacks', async () => {
+    // Real-world bug: Currency Rates API (priority 1) only covers ~38 currencies
+    // and succeeds every day, so the chain used to stop there and never reach
+    // ApiLayer. Exotic currencies (ETB, HNL, PEN, RSD, TZS, XAF) that ONLY
+    // ApiLayer provides were therefore never refreshed. The fallback must MERGE
+    // providers — filling gaps left by higher-priority ones — instead of
+    // returning on first success.
+    const date = format(new Date(), 'yyyy-MM-dd');
+
+    // All providers available with their default mocks (no overrides).
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    const byQuote = new Map(response.map((row) => [row.quoteCode, row]));
+
+    // Present in ApiLayer's mock but absent from Currency Rates API's mock.
+    for (const exotic of ['ETB', 'HNL', 'PEN', 'RSD', 'TZS', 'XAF']) {
+      const row = byQuote.get(exotic);
+      expect(row).toBeTruthy();
+      expect(row!.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER);
+    }
+
+    // Currencies the primary provider covers must keep its (higher-priority) source.
+    expect(byQuote.get('EUR')?.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
+    expect(byQuote.get('UAH')?.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
+  });
+
+  it('keeps the higher-priority provider value when two providers supply the same currency', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+    const primaryEur = getCurrencyRatesApiResponseMock(date).rates.EUR;
+
+    // ApiLayer (priority 3) returns a DIFFERENT EUR value. The primary must win on
+    // the VALUE, not just the source label — guards the dedup precedence path.
+    apiLayerOverride.setOverride({
+      body: { ...getApiLayerResposeMock(date), rates: { ...getApiLayerResposeMock(date).rates, EUR: 0.123456 } },
+    });
+
+    await helpers.syncExchangeRates();
+
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    const eur = response.find((r) => r.quoteCode === 'EUR')!;
+    expect(eur.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
+    expect(eur.rate).toBeCloseTo(primaryEur, 6);
+  });
+
+  it('never stores the base currency as a quote (no USD->USD self-rate)', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+
+    await helpers.syncExchangeRates();
+
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    expect(response.find((r) => r.quoteCode === 'USD')).toBeUndefined();
+  });
+
+  it('reports a Sentry event (logger.error) when the primary provider is unavailable', async () => {
+    const errorSpy = jest.spyOn(logger, 'error');
+    // 500 fails the health check too → primary is filtered out before the fetch loop,
+    // the exact path that previously slipped through without an alert.
+    currencyRatesApiOverride.setOverride({ status: 500 });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    expect(loggerErrorCalledWith(errorSpy, 'CURRENCY_RATES_API_FAILED')).toBe(true);
+  });
+
+  it('reports a Sentry event (logger.error) when a fallback provider is degraded', async () => {
+    const errorSpy = jest.spyOn(logger, 'error');
+    // Primary stays healthy; a lower-priority provider is down.
+    frankfurterOverride.setOverride({ status: 500 });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    expect(loggerErrorCalledWith(errorSpy, 'Degraded sync')).toBe(true);
+  });
+
+  it('reports a Sentry event (logger.error) listing enabled currencies missing from the result', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+    const errorSpy = jest.spyOn(logger, 'error');
+    // Starve the comprehensive provider so the exotic long tail is uncovered.
+    apiLayerOverride.setOverride({ body: { base: 'USD', date, success: true, timestamp: 1, rates: { EUR: 0.9 } } });
+
+    await helpers.syncExchangeRates();
+
+    const coverageCall = loggerErrorCalls(errorSpy).find(
+      ([arg]) => typeof arg === 'string' && arg.includes('Enabled currencies missing'),
+    );
+    expect(coverageCall).toBeTruthy();
+    // Starving the comprehensive provider leaves the whole exotic long tail
+    // uncovered — far more than a healthy run would ever miss.
+    const { missingCurrencies } = (coverageCall![1] ?? {}) as { missingCurrencies?: string[] };
+    expect(Array.isArray(missingCurrencies)).toBe(true);
+    expect(missingCurrencies!.length).toBeGreaterThan(50);
   });
 
   it('should successfully resolve when trying to sync data for the date with existing rates', async () => {

--- a/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.ts
+++ b/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.ts
@@ -23,9 +23,18 @@ export const API_LAYER_BASE_CURRENCY_CODE = 'USD';
  * 3. ApiLayer (comprehensive, paid)
  *
  * Includes deduplication to prevent concurrent calls for the same date.
+ *
+ * `force` bypasses the "already comprehensive" short-circuit. Callers that
+ * have detected a SPECIFIC missing rate (e.g. the lazy gap-fill in
+ * `getExchangeRate`) must set it: a date can hold 50+ rates yet still be
+ * missing the exact currency that was just requested (a currency added after
+ * the date was first synced, or one a caller explicitly cleared). Skipping on
+ * raw count alone would strand that currency permanently, so when the caller
+ * knows the rate it needs is absent we fetch regardless of how many other
+ * rates the date already has.
  */
 export const fetchExchangeRatesForDate = withDeduplication(
-  async (date: Date): Promise<void> => {
+  async (date: Date, { force = false }: { force?: boolean } = {}): Promise<void> => {
     const normalizedDate = startOfDay(date);
     const formattedDate = format(normalizedDate, API_LAYER_DATE_FORMAT);
 
@@ -36,8 +45,9 @@ export const fetchExchangeRatesForDate = withDeduplication(
       });
 
       // If we have a substantial number of rates, skip to avoid redundant API calls
-      // 50+ rates indicates a comprehensive provider (ApiLayer) was already used
-      if (existingRatesCount > 50) {
+      // 50+ rates indicates a comprehensive provider (ApiLayer) was already used.
+      // `force` callers opt out: they already know a specific rate is missing.
+      if (!force && existingRatesCount > 50) {
         logger.info(
           `Found ${existingRatesCount} rates for ${formattedDate}, skipping sync to avoid redundant API calls`,
         );
@@ -101,7 +111,9 @@ export const fetchExchangeRatesForDate = withDeduplication(
     }
   },
   {
-    keyGenerator: (date: Date) => format(date, 'yyyy-MM-dd'),
+    // Dedup by date only — a forced and an unforced call for the same date
+    // are the same fetch; the in-flight one serves both.
+    keyGenerator: (date: Date, _options?: { force?: boolean }) => format(date, 'yyyy-MM-dd'),
     ttl: 30000, // Keep cache for 30 seconds after completion
   },
 );

--- a/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.ts
+++ b/packages/backend/src/services/exchange-rates/fetch-exchange-rates-for-date.ts
@@ -56,22 +56,23 @@ export const fetchExchangeRatesForDate = withDeduplication(
         baseCurrency: API_LAYER_BASE_CURRENCY_CODE,
       });
 
-      if (!fetchResult || Object.keys(fetchResult.result.rates).length === 0) {
+      if (!fetchResult || Object.keys(fetchResult.merged.rates).length === 0) {
         throw new BadGateway({
           code: API_ERROR_CODES.currencyProviderUnavailable,
           message: 'Failed to load exchange rates from all providers',
         });
       }
 
-      const { result, providerName, providerType } = fetchResult;
+      const { merged, providersUsed } = fetchResult;
 
-      // Convert rates to database format
-      const rateEntries = Object.entries(result.rates).map(([quoteCode, rate]) => ({
-        baseCode: result.baseCurrency,
+      // Convert rates to database format. Each rate carries its own source — the
+      // provider that actually supplied it (rates are merged across providers).
+      const rateEntries = Object.entries(merged.rates).map(([quoteCode, { rate, source }]) => ({
+        baseCode: merged.baseCurrency,
         quoteCode,
         rate,
         date: normalizedDate,
-        source: providerType,
+        source,
       }));
 
       // Bulk insert with duplicate handling
@@ -79,9 +80,10 @@ export const fetchExchangeRatesForDate = withDeduplication(
         ignoreDuplicates: true,
       });
 
+      const providerSummary = providersUsed.map((p) => `${p.name}(${p.ratesContributed})`).join(', ');
       logger.info(
-        `[Exchange Rates: ${providerName}] Rates for ${formattedDate} successfully processed. ` +
-          `Fetched ${rateEntries.length} rates. (Duplicates automatically ignored)`,
+        `[Exchange Rates] Rates for ${formattedDate} successfully processed. ` +
+          `Fetched ${rateEntries.length} rates from: ${providerSummary}. (Duplicates automatically ignored)`,
       );
     } catch (error) {
       if (error instanceof CustomError) {

--- a/packages/backend/src/services/exchange-rates/initialize-historical-rates.e2e.ts
+++ b/packages/backend/src/services/exchange-rates/initialize-historical-rates.e2e.ts
@@ -1,4 +1,5 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { logger } from '@js/utils';
 import ExchangeRates from '@models/exchange-rates.model';
 import { createOverride } from '@tests/mocks/helpers';
 import { format } from 'date-fns';
@@ -7,6 +8,13 @@ import { CURRENCY_RATES_API_ENDPOINT_REGEX, FRANKFURTER_ENDPOINT_REGEX } from '.
 import { initializeHistoricalRates, providerAvailabilityConfig } from './initialize-historical-rates.service';
 import { exchangeRateProviderRegistry } from './providers';
 import { EXCHANGE_RATE_PROVIDER_TYPE } from './providers/types';
+
+// logger.error is an overloaded fn, so jest infers its call args as `never`.
+// Read the recorded calls through a widened tuple type for assertions.
+const loggerErrorCalledWith = (errorSpy: ReturnType<typeof jest.spyOn>, substring: string): boolean =>
+  (errorSpy.mock.calls as unknown as Array<[unknown, Record<string, unknown>?]>).some(
+    ([arg]) => typeof arg === 'string' && arg.includes(substring),
+  );
 
 describe('Initialize Historical Rates Service', () => {
   let currencyRatesApiOverride: ReturnType<typeof createOverride>;
@@ -48,6 +56,9 @@ describe('Initialize Historical Rates Service', () => {
         ignoreDuplicates: true,
       });
     }
+
+    // Drop any logger spies installed by degradation-signal tests
+    jest.restoreAllMocks();
   });
 
   afterAll(() => {
@@ -171,6 +182,35 @@ describe('Initialize Historical Rates Service', () => {
     // the insert path in a future refactor.
     expect(sampleRate!.source).not.toBe(EXCHANGE_RATE_PROVIDER_TYPE.UNKNOWN);
     expect(Object.values(EXCHANGE_RATE_PROVIDER_TYPE)).toContain(sampleRate!.source);
+  });
+
+  it('attributes backfilled rates to the highest-priority provider that supplied them', async () => {
+    // Both historical providers (Currency Rates API p1, Frankfurter p2) are healthy.
+    // The primary's mock is a superset of Frankfurter's, so the per-date merge must
+    // attribute EVERY row to the primary — proving priority precedence holds in the
+    // historical path (a lower-priority value never overwrites a higher-priority one).
+    await ExchangeRates.destroy({ where: {} });
+
+    await initializeHistoricalRates();
+
+    const rates = await ExchangeRates.findAll({ raw: true });
+    expect(rates.length).toBeGreaterThan(0);
+    rates.forEach((rate) => {
+      expect(rate.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
+    });
+  });
+
+  it('reports a Sentry event (logger.error) when a historical provider is unavailable', async () => {
+    const errorSpy = jest.spyOn(logger, 'error');
+    // Primary stays healthy and backfills the data; the secondary provider fails its
+    // health check (500), so it is skipped by isAvailable(). That degradation used to
+    // go unreported on the historical path (only `failed`, never `unavailable`, was
+    // signalled) — the exact asymmetry this guards against.
+    frankfurterOverride.setOverride({ status: 500 });
+
+    await initializeHistoricalRates();
+
+    expect(loggerErrorCalledWith(errorSpy, 'Historical backfill degraded')).toBe(true);
   });
 
   it('should work as a fire-and-forget operation (non-blocking startup pattern)', async () => {

--- a/packages/backend/src/services/exchange-rates/initialize-historical-rates.service.ts
+++ b/packages/backend/src/services/exchange-rates/initialize-historical-rates.service.ts
@@ -5,7 +5,7 @@ import { addYears, format, min, startOfDay } from 'date-fns';
 import chunk from 'lodash/chunk';
 
 import { exchangeRateProviderRegistry } from './providers';
-import { EXCHANGE_RATE_PROVIDER_TYPE, ExchangeRateResult } from './providers/types';
+import { EXCHANGE_RATE_PROVIDER_TYPE, MergedRatesForDate } from './providers/types';
 
 // Fallback date if no providers are registered (should not happen in practice)
 const FALLBACK_START_DATE = new Date('1999-01-04');
@@ -49,16 +49,17 @@ async function waitForProviderAvailability(): Promise<boolean> {
 }
 
 /**
- * Process and insert rates from a single fetch result
+ * Process and insert merged rates from a fetch result.
+ *
+ * Rates are merged per-date across providers, so each rate carries its own
+ * source — there is no single provider for the whole chunk.
  */
 async function insertRatesChunk({
   results,
   validCurrencyCodes,
-  providerType,
 }: {
-  results: ExchangeRateResult[];
+  results: MergedRatesForDate[];
   validCurrencyCodes: Set<string>;
-  providerType: EXCHANGE_RATE_PROVIDER_TYPE;
 }): Promise<{ totalRates: number; insertedRates: number }> {
   // Convert provider results to rate entries, filtering as we go to reduce memory.
   // `source` is part of the intermediate shape so a future refactor cannot drop
@@ -73,14 +74,14 @@ async function insertRatesChunk({
 
   for (const result of results) {
     const rateDate = startOfDay(new Date(result.date));
-    for (const [quoteCode, rate] of Object.entries(result.rates)) {
+    for (const [quoteCode, { rate, source }] of Object.entries(result.rates)) {
       if (validCurrencyCodes.has(result.baseCurrency) && validCurrencyCodes.has(quoteCode)) {
         validRates.push({
           baseCode: result.baseCurrency,
           quoteCode,
           rate,
           date: rateDate,
-          source: providerType,
+          source,
         });
       }
     }
@@ -174,12 +175,11 @@ export async function initializeHistoricalRates(): Promise<void> {
           `No provider available for range ${format(currentStartDate, 'yyyy-MM-dd')} to ${format(currentEndDate, 'yyyy-MM-dd')}, skipping`,
         );
       } else {
-        providerName = fetchResult.providerName;
+        providerName = fetchResult.providersUsed.map((p) => p.name).join(', ') || null;
 
         const { insertedRates } = await insertRatesChunk({
           results: fetchResult.results,
           validCurrencyCodes,
-          providerType: fetchResult.providerType,
         });
 
         totalInserted += insertedRates;

--- a/packages/backend/src/services/exchange-rates/providers/merge-provider-rates.ts
+++ b/packages/backend/src/services/exchange-rates/providers/merge-provider-rates.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure merge logic for combining exchange rates from multiple providers.
+ *
+ * Kept free of I/O so the priority/gap-fill rules can be unit-tested directly,
+ * instead of only through the full HTTP-mocked sync. Both the daily and the
+ * historical fallback paths in the registry delegate here so they share one
+ * definition of "merge by priority".
+ */
+import { EXCHANGE_RATE_PROVIDER_TYPE } from '@bt/shared/types';
+
+/** A single quote currency's rate together with the provider that supplied it. */
+export interface AttributedRate {
+  rate: number;
+  source: EXCHANGE_RATE_PROVIDER_TYPE;
+}
+
+/** Rates returned by one provider for one date, awaiting merge. */
+export interface ProviderRatesInput {
+  type: EXCHANGE_RATE_PROVIDER_TYPE;
+  name: string;
+  rates: Record<string, number>;
+}
+
+/** How many new rates each provider supplied to the merged result. */
+export interface ProviderContribution {
+  name: string;
+  type: EXCHANGE_RATE_PROVIDER_TYPE;
+  ratesContributed: number;
+}
+
+interface MergeResult {
+  /** quoteCode -> { rate, source }. Rate and source always travel together. */
+  rates: Record<string, AttributedRate>;
+  /** Providers that supplied at least one rate, in the order they were given. */
+  providersUsed: ProviderContribution[];
+}
+
+/**
+ * An exchange rate is only usable if it is finite and strictly positive. A 0,
+ * negative, NaN or Infinity value is treated as "not supplied" so a healthy
+ * lower-priority provider can fill the slot instead of the bad value winning it
+ * and being persisted — otherwise a currency could silently freeze on garbage.
+ */
+function isUsableRate(rate: number): boolean {
+  return Number.isFinite(rate) && rate > 0;
+}
+
+/**
+ * Merge provider rates given in PRIORITY ORDER (highest priority first).
+ *
+ * A lower-priority provider only fills currencies a higher-priority one didn't
+ * already supply — so both the rate value AND its source come from the highest
+ * priority provider that had it. The base currency is never emitted as a quote
+ * (no `USD -> USD = 1` self-rate row).
+ */
+export function mergeProviderRates({
+  providerRates,
+  baseCurrency,
+}: {
+  providerRates: ProviderRatesInput[];
+  baseCurrency: string;
+}): MergeResult {
+  const rates: Record<string, AttributedRate> = {};
+  const providersUsed: ProviderContribution[] = [];
+
+  for (const provider of providerRates) {
+    let ratesContributed = 0;
+
+    for (const [quoteCode, rate] of Object.entries(provider.rates)) {
+      if (quoteCode === baseCurrency) continue;
+      // Skip invalid values so they neither persist nor block a fallback fill.
+      if (!isUsableRate(rate)) continue;
+      if (rates[quoteCode] === undefined) {
+        rates[quoteCode] = { rate, source: provider.type };
+        ratesContributed += 1;
+      }
+    }
+
+    // A provider whose currencies were all already covered contributed nothing
+    // and is deliberately omitted, so the summary reflects real coverage.
+    if (ratesContributed > 0) {
+      providersUsed.push({ name: provider.name, type: provider.type, ratesContributed });
+    }
+  }
+
+  return { rates, providersUsed };
+}
+
+/**
+ * Currencies expected but absent from the merged result, excluding the base
+ * currency (which is never a quote). Used to surface coverage gaps.
+ */
+export function findMissingCurrencies({
+  expected,
+  covered,
+  baseCurrency,
+}: {
+  expected: string[];
+  covered: string[];
+  baseCurrency: string;
+}): string[] {
+  const have = new Set(covered);
+  return expected.filter((code) => code !== baseCurrency && !have.has(code));
+}

--- a/packages/backend/src/services/exchange-rates/providers/merge-provider-rates.unit.ts
+++ b/packages/backend/src/services/exchange-rates/providers/merge-provider-rates.unit.ts
@@ -1,0 +1,137 @@
+import { EXCHANGE_RATE_PROVIDER_TYPE } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+
+import { findMissingCurrencies, mergeProviderRates, ProviderRatesInput } from './merge-provider-rates';
+
+const { CURRENCY_RATES_API, FRANKFURTER, API_LAYER } = EXCHANGE_RATE_PROVIDER_TYPE;
+
+describe('mergeProviderRates', () => {
+  it('attributes every rate from a single provider to that provider', () => {
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: 0.9, UAH: 41 } },
+    ];
+
+    const { rates, providersUsed } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates).toEqual({
+      EUR: { rate: 0.9, source: CURRENCY_RATES_API },
+      UAH: { rate: 41, source: CURRENCY_RATES_API },
+    });
+    expect(providersUsed).toEqual([{ name: 'Currency Rates API', type: CURRENCY_RATES_API, ratesContributed: 2 }]);
+  });
+
+  it('keeps the higher-priority value AND source when providers overlap', () => {
+    // Same currency from two providers with DIFFERENT values — proves precedence
+    // applies to the value, not just the source label.
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: 0.9 } },
+      { type: API_LAYER, name: 'ApiLayer', rates: { EUR: 0.95 } },
+    ];
+
+    const { rates } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates.EUR).toEqual({ rate: 0.9, source: CURRENCY_RATES_API });
+  });
+
+  it('lets a lower-priority provider fill only the currencies higher ones omitted', () => {
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: 0.9 } },
+      { type: API_LAYER, name: 'ApiLayer', rates: { EUR: 0.95, ETB: 121 } },
+    ];
+
+    const { rates, providersUsed } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates).toEqual({
+      EUR: { rate: 0.9, source: CURRENCY_RATES_API },
+      ETB: { rate: 121, source: API_LAYER },
+    });
+    expect(providersUsed).toEqual([
+      { name: 'Currency Rates API', type: CURRENCY_RATES_API, ratesContributed: 1 },
+      { name: 'ApiLayer', type: API_LAYER, ratesContributed: 1 },
+    ]);
+  });
+
+  it('never emits the base currency as a quote', () => {
+    const providerRates: ProviderRatesInput[] = [{ type: API_LAYER, name: 'ApiLayer', rates: { USD: 1, EUR: 0.9 } }];
+
+    const { rates } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates.USD).toBeUndefined();
+    expect(rates.EUR).toEqual({ rate: 0.9, source: API_LAYER });
+  });
+
+  it('omits a provider that contributed no new rates from providersUsed', () => {
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: 0.9, UAH: 41 } },
+      // Fully redundant: every currency already covered by the primary.
+      { type: FRANKFURTER, name: 'Frankfurter', rates: { EUR: 0.95, UAH: 42 } },
+    ];
+
+    const { providersUsed } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(providersUsed).toEqual([{ name: 'Currency Rates API', type: CURRENCY_RATES_API, ratesContributed: 2 }]);
+  });
+
+  it('returns empty result when no providers supplied rates', () => {
+    expect(mergeProviderRates({ providerRates: [], baseCurrency: 'USD' })).toEqual({ rates: {}, providersUsed: [] });
+  });
+
+  it('skips an invalid rate so a lower-priority provider can fill it', () => {
+    // A higher-priority provider supplying a garbage value (NaN, 0, negative,
+    // Infinity) must NOT block a healthy fallback. Otherwise the bad value would
+    // win the slot and persist — the same silent-staleness failure this merge
+    // exists to prevent, just relocated from "missing" to "bad value wins".
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: NaN, GBP: 0, JPY: -5, CHF: Infinity } },
+      { type: API_LAYER, name: 'ApiLayer', rates: { EUR: 0.95, GBP: 0.8, JPY: 150, CHF: 1.1 } },
+    ];
+
+    const { rates, providersUsed } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates).toEqual({
+      EUR: { rate: 0.95, source: API_LAYER },
+      GBP: { rate: 0.8, source: API_LAYER },
+      JPY: { rate: 150, source: API_LAYER },
+      CHF: { rate: 1.1, source: API_LAYER },
+    });
+    // The primary contributed nothing valid, so it must not appear as a contributor.
+    expect(providersUsed).toEqual([{ name: 'ApiLayer', type: API_LAYER, ratesContributed: 4 }]);
+  });
+
+  it('drops an invalid rate entirely when no provider supplies a valid one', () => {
+    // If every provider's value for a currency is invalid, that currency is left
+    // uncovered rather than persisted with garbage — surfaced later as a coverage gap.
+    const providerRates: ProviderRatesInput[] = [
+      { type: CURRENCY_RATES_API, name: 'Currency Rates API', rates: { EUR: 0.9, BAD: NaN } },
+    ];
+
+    const { rates } = mergeProviderRates({ providerRates, baseCurrency: 'USD' });
+
+    expect(rates.BAD).toBeUndefined();
+    expect(rates.EUR).toEqual({ rate: 0.9, source: CURRENCY_RATES_API });
+  });
+});
+
+describe('findMissingCurrencies', () => {
+  it('returns expected currencies absent from the covered set', () => {
+    const missing = findMissingCurrencies({
+      expected: ['USD', 'EUR', 'ETB', 'XAF'],
+      covered: ['EUR'],
+      baseCurrency: 'USD',
+    });
+
+    expect(missing).toEqual(['ETB', 'XAF']);
+  });
+
+  it('excludes the base currency even when uncovered', () => {
+    const missing = findMissingCurrencies({ expected: ['USD', 'EUR'], covered: ['EUR'], baseCurrency: 'USD' });
+
+    expect(missing).toEqual([]);
+  });
+
+  it('returns empty when everything expected is covered', () => {
+    const missing = findMissingCurrencies({ expected: ['EUR', 'ETB'], covered: ['EUR', 'ETB'], baseCurrency: 'USD' });
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/backend/src/services/exchange-rates/providers/registry.ts
+++ b/packages/backend/src/services/exchange-rates/providers/registry.ts
@@ -8,16 +8,32 @@
  *   - Fetch with fallback: registry.fetchRatesWithFallback({ date: new Date() })
  */
 import { logger } from '@js/utils';
+import { getAllCurrencies } from '@models/currencies.model';
 
 import { BaseExchangeRateProvider } from './base-provider';
 import {
+  findMissingCurrencies,
+  mergeProviderRates,
+  ProviderContribution,
+  ProviderRatesInput,
+} from './merge-provider-rates';
+import {
+  DEFAULT_BASE_CURRENCY,
   EXCHANGE_RATE_PROVIDER_TYPE,
   ExchangeRateProviderMetadata,
   FetchHistoricalRatesWithFallbackResult,
   FetchRatesParams,
   FetchRatesRangeParams,
   FetchRatesWithFallbackResult,
+  MergedRatesForDate,
 } from './types';
+
+/** A provider that was registered but did not contribute rates this run. */
+interface ProviderFailure {
+  name: string;
+  type: EXCHANGE_RATE_PROVIDER_TYPE;
+  reason: string;
+}
 
 class ExchangeRateProviderRegistry {
   private providers = new Map<EXCHANGE_RATE_PROVIDER_TYPE, BaseExchangeRateProvider>();
@@ -120,78 +136,142 @@ class ExchangeRateProviderRegistry {
   }
 
   /**
-   * Fetch exchange rates with automatic fallback through providers by priority.
-   * Tries each provider in order until one succeeds.
+   * Fetch exchange rates by merging across providers in priority order.
+   *
+   * Each provider is queried and its rates are merged into the result, but a
+   * lower-priority provider only fills currencies the higher-priority ones did
+   * NOT supply. This is a gap-filling merge, not first-success-wins: the primary
+   * provider (currency-rates-api) covers ~38 currencies, so the chain MUST
+   * continue to the comprehensive fallback (ApiLayer) to refresh the long tail
+   * of exotic currencies — otherwise those rates go permanently stale.
+   *
    * @param params - Fetch parameters
-   * @returns Exchange rate result with provider info, or null if all providers fail
+   * @returns Merged exchange rates with per-currency attribution, or null if
+   *          every provider failed to return any rates.
    */
   async fetchRatesWithFallback(params: FetchRatesParams): Promise<FetchRatesWithFallbackResult | null> {
-    const providers = await this.getByPriority();
+    const registered = Array.from(this.providers.values());
+    const available = await this.getByPriority();
 
-    if (providers.length === 0) {
-      logger.error('No exchange rate providers are available');
+    // A registered provider missing from `available` was skipped by isAvailable()
+    // (e.g. the primary's health check failed). That degradation never enters the
+    // fetch loop, so it must be tracked separately or it would go unreported.
+    const unavailable: ProviderFailure[] = registered
+      .filter((p) => !available.includes(p))
+      .map((p) => ({
+        name: p.metadata.name,
+        type: p.metadata.type,
+        reason: 'Unavailable (isAvailable() returned false)',
+      }));
+
+    if (available.length === 0) {
+      logger.error('No exchange rate providers are available', { unavailable, date: params.date.toISOString() });
       return null;
     }
 
-    const failedProviders: { name: string; type: EXCHANGE_RATE_PROVIDER_TYPE; error?: string }[] = [];
+    const baseCurrency = params.baseCurrency ?? DEFAULT_BASE_CURRENCY;
+    const providerRates: ProviderRatesInput[] = [];
+    const failed: ProviderFailure[] = [];
+    let resultDate: string | undefined;
 
-    for (const provider of providers) {
+    for (const provider of available) {
       try {
         logger.info(`Attempting to fetch rates from ${provider.metadata.name}`);
         const result = await provider.fetchRatesForDate(params);
 
-        if (result && Object.keys(result.rates).length > 0) {
-          logger.info(`Successfully fetched ${Object.keys(result.rates).length} rates from ${provider.metadata.name}`);
-
-          // Alert: Frankfurter was used (ideally should never happen if currency-rates-api works)
-          if (provider.metadata.type === EXCHANGE_RATE_PROVIDER_TYPE.FRANKFURTER) {
-            logger.warn(`[ALERT:FRANKFURTER_USED] Frankfurter fallback was triggered`, {
-              failedProviders: failedProviders.map((p) => p.name),
-              date: params.date.toISOString(),
-            });
-          }
-
-          // Alert: Currency Rates API failed but another provider succeeded
-          const currencyRatesApiFailed = failedProviders.some(
-            (p) => p.type === EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API,
-          );
-          if (currencyRatesApiFailed) {
-            const failedProvider = failedProviders.find(
-              (p) => p.type === EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API,
-            );
-            logger.warn(`[ALERT:CURRENCY_RATES_API_FAILED] Primary provider failed`, {
-              error: failedProvider?.error,
-              fallbackProvider: provider.metadata.name,
-              date: params.date.toISOString(),
-            });
-          }
-
-          return {
-            result,
-            providerName: provider.metadata.name,
-            providerType: provider.metadata.type,
-          };
+        if (!result || Object.keys(result.rates).length === 0) {
+          logger.warn(`${provider.metadata.name} returned no rates, continuing to next provider`);
+          failed.push({ name: provider.metadata.name, type: provider.metadata.type, reason: 'No rates returned' });
+          continue;
         }
 
-        logger.warn(`${provider.metadata.name} returned no rates, trying next provider`);
-        failedProviders.push({
-          name: provider.metadata.name,
-          type: provider.metadata.type,
-          error: 'No rates returned',
-        });
+        resultDate ??= result.date;
+        providerRates.push({ type: provider.metadata.type, name: provider.metadata.name, rates: result.rates });
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        logger.warn(`${provider.metadata.name} failed, trying next provider`, { error: errorMessage });
-        failedProviders.push({
-          name: provider.metadata.name,
-          type: provider.metadata.type,
-          error: errorMessage,
-        });
+        const reason = error instanceof Error ? error.message : String(error);
+        logger.warn(`${provider.metadata.name} failed, continuing to next provider`, { error: reason });
+        failed.push({ name: provider.metadata.name, type: provider.metadata.type, reason });
       }
     }
 
-    logger.error('All exchange rate providers failed to fetch rates');
-    return null;
+    const { rates, providersUsed } = mergeProviderRates({ providerRates, baseCurrency });
+
+    if (Object.keys(rates).length === 0) {
+      logger.error('All exchange rate providers failed to fetch rates', {
+        failed,
+        unavailable,
+        date: params.date.toISOString(),
+      });
+      return null;
+    }
+
+    const merged: MergedRatesForDate = {
+      date: resultDate ?? params.date.toISOString().slice(0, 10),
+      baseCurrency,
+      rates,
+    };
+
+    await this.reportDegradedSync({ failed, unavailable, providersUsed, merged });
+
+    return { merged, providersUsed };
+  }
+
+  /**
+   * Surface a degraded sync to Sentry (via logger.error). Two independent signals:
+   *  1. Provider degradation — a registered provider failed, returned nothing, or
+   *     was unavailable, even if others covered the gap (the long-tail-staleness
+   *     risk this whole path exists to prevent).
+   *  2. Coverage gap — an enabled currency is absent from the merged result.
+   * Both are reported because either can leave a user's currency without a fresh
+   * rate while the sync still "succeeds".
+   */
+  private async reportDegradedSync({
+    failed,
+    unavailable,
+    providersUsed,
+    merged,
+  }: {
+    failed: ProviderFailure[];
+    unavailable: ProviderFailure[];
+    providersUsed: ProviderContribution[];
+    merged: MergedRatesForDate;
+  }): Promise<void> {
+    const degradedProviders = [...failed, ...unavailable];
+
+    if (degradedProviders.length > 0) {
+      const primaryDegraded = degradedProviders.some((p) => p.type === EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
+      // Preserve the [ALERT:CURRENCY_RATES_API_FAILED] keyword for the primary so
+      // existing monitoring keyed off it keeps firing.
+      const message = primaryDegraded
+        ? '[ALERT:CURRENCY_RATES_API_FAILED] Primary provider degraded; rates served by fallbacks'
+        : '[exchange-rates] Degraded sync: fallback provider(s) failed or unavailable';
+      logger.error(message, {
+        degradedProviders,
+        contributingProviders: providersUsed.map((p) => p.name),
+        date: merged.date,
+      });
+    }
+
+    // Compare against the currencies users can actually select.
+    try {
+      const enabled = (await getAllCurrencies()).map((c) => c.code);
+      const missingCurrencies = findMissingCurrencies({
+        expected: enabled,
+        covered: Object.keys(merged.rates),
+        baseCurrency: merged.baseCurrency,
+      });
+      if (missingCurrencies.length > 0) {
+        logger.error('[exchange-rates] Enabled currencies missing from sync result', {
+          missingCurrencies,
+          missingCount: missingCurrencies.length,
+          date: merged.date,
+        });
+      }
+    } catch (error) {
+      logger.warn('Could not check currency coverage for sync result', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   /**
@@ -205,45 +285,106 @@ class ExchangeRateProviderRegistry {
   }
 
   /**
-   * Fetch historical exchange rates for a date range with automatic fallback.
-   * Only tries providers that support efficient historical data loading.
+   * Fetch historical exchange rates for a date range, merging across providers
+   * by priority — the SAME gap-filling semantics as the daily path, applied
+   * per-date. Each lower-priority provider only fills currencies a higher one
+   * didn't supply for that date, so the exotic long tail (covered only by the
+   * comprehensive provider) is backfilled instead of dropped.
+   * Only providers that support efficient historical data loading are queried.
    * @param params - Fetch parameters including date range
-   * @returns Historical rate results with provider info, or null if no provider supports it
+   * @returns Merged historical rates per date, or null if no provider returned data
    */
   async fetchHistoricalRatesWithFallback(
     params: FetchRatesRangeParams,
   ): Promise<FetchHistoricalRatesWithFallbackResult | null> {
+    const registeredHistorical = Array.from(this.providers.values()).filter(
+      (p) => p.metadata.supportsHistoricalDataLoading === true,
+    );
     const providers = await this.getHistoricalDataProviders();
 
+    // A registered historical provider missing from `providers` was skipped by
+    // isAvailable(). The daily path tracks this; the historical path must too,
+    // or a provider silently dropping out of the backfill goes unreported.
+    const unavailable: ProviderFailure[] = registeredHistorical
+      .filter((p) => !providers.includes(p))
+      .map((p) => ({
+        name: p.metadata.name,
+        type: p.metadata.type,
+        reason: 'Unavailable (isAvailable() returned false)',
+      }));
+
     if (providers.length === 0) {
-      logger.error('No exchange rate providers support historical data loading');
+      logger.error('No exchange rate providers support historical data loading', { unavailable });
       return null;
     }
+
+    const baseCurrency = params.baseCurrency ?? DEFAULT_BASE_CURRENCY;
+    // date -> provider rates for that date, accumulated in provider-priority order
+    // (outer loop is priority order) so the per-date merge keeps precedence.
+    const ratesByDate = new Map<string, ProviderRatesInput[]>();
+    const failed: ProviderFailure[] = [];
 
     for (const provider of providers) {
       try {
         logger.info(`Attempting to fetch historical rates from ${provider.metadata.name}`);
         const results = await provider.fetchRatesForDateRange(params);
 
-        if (results && results.length > 0) {
-          logger.info(`Successfully fetched ${results.length} date entries from ${provider.metadata.name}`);
-          return {
-            results,
-            providerName: provider.metadata.name,
-            providerType: provider.metadata.type,
-          };
+        if (!results || results.length === 0) {
+          logger.warn(`${provider.metadata.name} returned no historical rates, continuing to next provider`);
+          failed.push({ name: provider.metadata.name, type: provider.metadata.type, reason: 'No rates returned' });
+          continue;
         }
 
-        logger.warn(`${provider.metadata.name} returned no historical rates, trying next provider`);
+        for (const result of results) {
+          const forDate = ratesByDate.get(result.date) ?? [];
+          forDate.push({ type: provider.metadata.type, name: provider.metadata.name, rates: result.rates });
+          ratesByDate.set(result.date, forDate);
+        }
       } catch (error) {
-        logger.warn(`${provider.metadata.name} failed to fetch historical rates, trying next provider`, {
-          error: error instanceof Error ? error.message : String(error),
+        const reason = error instanceof Error ? error.message : String(error);
+        logger.warn(`${provider.metadata.name} failed to fetch historical rates, continuing to next provider`, {
+          error: reason,
         });
+        failed.push({ name: provider.metadata.name, type: provider.metadata.type, reason });
       }
     }
 
-    logger.error('All providers failed to fetch historical rates');
-    return null;
+    if (ratesByDate.size === 0) {
+      logger.error('All providers failed to fetch historical rates', { failed });
+      return null;
+    }
+
+    const results: MergedRatesForDate[] = [];
+    const contributionByType = new Map<EXCHANGE_RATE_PROVIDER_TYPE, ProviderContribution>();
+
+    for (const [date, providerRates] of ratesByDate) {
+      const { rates, providersUsed } = mergeProviderRates({ providerRates, baseCurrency });
+      results.push({ date, baseCurrency, rates });
+
+      // Aggregate per-provider contribution across all dates for the summary.
+      for (const used of providersUsed) {
+        const existing = contributionByType.get(used.type);
+        if (existing) {
+          existing.ratesContributed += used.ratesContributed;
+        } else {
+          contributionByType.set(used.type, { ...used });
+        }
+      }
+    }
+
+    // Degradation here is unusual (no per-date coverage check, since the historical
+    // providers never cover the exotic long tail and missing exotics across years
+    // would be expected noise) but a failed OR unavailable provider during backfill
+    // is still worth a Sentry signal so a silently-skipped provider is visible.
+    const degradedProviders = [...failed, ...unavailable];
+    if (degradedProviders.length > 0) {
+      logger.error('[exchange-rates] Historical backfill degraded: provider(s) failed or unavailable', {
+        degradedProviders,
+        date: `${params.startDate.toISOString().slice(0, 10)}..${params.endDate.toISOString().slice(0, 10)}`,
+      });
+    }
+
+    return { results, providersUsed: Array.from(contributionByType.values()) };
   }
 
   /**

--- a/packages/backend/src/services/exchange-rates/providers/types.ts
+++ b/packages/backend/src/services/exchange-rates/providers/types.ts
@@ -5,10 +5,15 @@
  */
 import { EXCHANGE_RATE_PROVIDER_TYPE } from '@bt/shared/types';
 
+import { AttributedRate, ProviderContribution } from './merge-provider-rates';
+
 // Re-exported so service-internal modules can keep importing from `./types`.
 // The model imports the enum directly from `@bt/shared/types` to avoid a
 // model → service layer dependency.
 export { EXCHANGE_RATE_PROVIDER_TYPE };
+
+/** Default base currency used across providers and the merge logic. */
+export const DEFAULT_BASE_CURRENCY = 'USD';
 
 // ============================================================================
 // Provider Configuration
@@ -81,27 +86,41 @@ export interface ExchangeRateResult {
 }
 
 /**
- * Result from fetchRatesWithFallback including provider info
+ * Merged exchange rates for a single date.
+ *
+ * Rates are MERGED across providers by priority: each lower-priority provider
+ * only fills currencies the higher-priority ones didn't supply. Because rates
+ * can originate from different providers, each rate carries its own `source`
+ * (see `AttributedRate`) — rate and provenance always travel together, so a
+ * rate can never be persisted without a known source.
  */
-export interface FetchRatesWithFallbackResult {
-  /** The exchange rate data */
-  result: ExchangeRateResult;
-  /** Name of the provider that successfully fetched the rates */
-  providerName: string;
-  /** Type of the provider */
-  providerType: EXCHANGE_RATE_PROVIDER_TYPE;
+export interface MergedRatesForDate {
+  /** ISO date string (yyyy-MM-dd) */
+  date: string;
+  /** Base currency code */
+  baseCurrency: string;
+  /** quoteCode -> { rate, source } */
+  rates: Record<string, AttributedRate>;
 }
 
 /**
- * Result from fetchHistoricalRatesWithFallback including provider info
+ * Result from fetchRatesWithFallback — merged rates for one date plus the
+ * per-provider contribution summary.
+ */
+export interface FetchRatesWithFallbackResult {
+  merged: MergedRatesForDate;
+  /** Providers that contributed at least one rate, in priority order */
+  providersUsed: ProviderContribution[];
+}
+
+/**
+ * Result from fetchHistoricalRatesWithFallback — merged rates per date across
+ * the range, with the same priority-merge semantics as the daily path.
  */
 export interface FetchHistoricalRatesWithFallbackResult {
-  /** Array of exchange rate results for the date range */
-  results: ExchangeRateResult[];
-  /** Name of the provider that successfully fetched the rates */
-  providerName: string;
-  /** Type of the provider */
-  providerType: EXCHANGE_RATE_PROVIDER_TYPE;
+  results: MergedRatesForDate[];
+  /** Providers that contributed at least one rate across the range */
+  providersUsed: ProviderContribution[];
 }
 
 // ============================================================================

--- a/packages/backend/src/services/user-exchange-rate/get-exchange-rate.service.ts
+++ b/packages/backend/src/services/user-exchange-rate/get-exchange-rate.service.ts
@@ -114,7 +114,10 @@ export async function getExchangeRate({
 
   if (needsFetch || hasStaleRates) {
     try {
-      await fetchExchangeRatesForDate(date);
+      // When a required rate is entirely absent, force past the "looks
+      // comprehensive" count-skip in the fetcher — otherwise a date that
+      // already holds many other rates would never backfill this one.
+      await fetchExchangeRatesForDate(date, { force: needsFetch });
     } catch (e) {
       // If we have no rates at all, propagate the error
       if (needsFetch) throw e;


### PR DESCRIPTION
Gap-filling merge replaces first-success-wins fallback so the comprehensive provider still refreshes exotic currencies the primary omits; degraded/partial syncs now report to Sentry