### PR TITLE
Show % of avg income on the Subs & Bills widget

### DIFF
--- a/packages/backend/src/controllers/subscriptions/get-subscriptions-summary.ts
+++ b/packages/backend/src/controllers/subscriptions/get-subscriptions-summary.ts
@@ -1,11 +1,19 @@
 import { SUBSCRIPTION_TYPES } from '@bt/shared/types';
 import { createController } from '@controllers/helpers/controller-factory';
 import * as subscriptionsService from '@services/subscriptions';
+import { INCOME_LOOKBACK_MONTHS_OPTIONS } from '@services/subscriptions/get-subscriptions-summary';
 import { z } from 'zod';
 
 const schema = z.object({
   query: z.object({
     type: z.enum(Object.values(SUBSCRIPTION_TYPES) as [SUBSCRIPTION_TYPES, ...SUBSCRIPTION_TYPES[]]).optional(),
+    lookbackMonths: z.coerce
+      .number()
+      .int()
+      .refine((v) => (INCOME_LOOKBACK_MONTHS_OPTIONS as readonly number[]).includes(v), {
+        message: `lookbackMonths must be one of ${INCOME_LOOKBACK_MONTHS_OPTIONS.join(', ')}`,
+      })
+      .optional(),
   }),
 });
 
@@ -13,6 +21,7 @@ export default createController(schema, async ({ user, query }) => {
   const summary = await subscriptionsService.getSubscriptionsSummary({
     userId: user.id,
     type: query.type,
+    lookbackMonths: query.lookbackMonths as (typeof INCOME_LOOKBACK_MONTHS_OPTIONS)[number] | undefined,
   });
 
   return { data: summary };

--- a/packages/backend/src/services/mcp/tools/get-subscriptions-summary.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscriptions-summary.ts
@@ -11,7 +11,7 @@ export function registerGetSubscriptionsSummary(server: McpServer) {
     'get_subscriptions_summary',
     {
       description:
-        'Aggregate cost summary across all active subscriptions with an expected amount. Returns estimated monthly cost, projected yearly cost (both in the user base currency), and count of active subscriptions. Useful for "how much am I spending on subscriptions per month?"',
+        'Aggregate cost summary across all active subscriptions with an expected amount. Returns estimated monthly cost, projected yearly cost, count of active subscriptions, average monthly income over the last 6 complete months, and percent of income spent on subscriptions (all monetary values in the user base currency). Useful for "how much am I spending on subscriptions per month?" or "what share of my income goes to subscriptions?"',
       inputSchema: {
         type: z
           .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill])

--- a/packages/backend/src/services/subscriptions/get-subscriptions-summary.ts
+++ b/packages/backend/src/services/subscriptions/get-subscriptions-summary.ts
@@ -1,11 +1,53 @@
-import { SUBSCRIPTION_FREQUENCIES, SUBSCRIPTION_TYPES } from '@bt/shared/types';
+import {
+  SUBSCRIPTION_FREQUENCIES,
+  SUBSCRIPTION_TYPES,
+  TRANSACTION_TRANSFER_NATURE,
+  TRANSACTION_TYPES,
+} from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { logger } from '@js/utils/logger';
+import Accounts from '@models/accounts.model';
 import Subscriptions from '@models/subscriptions.model';
+import Transactions from '@models/transactions.model';
 import * as UsersCurrencies from '@models/users-currencies.model';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { withTransaction } from '@services/common/with-transaction';
+import { endOfMonth, startOfMonth, subMonths } from 'date-fns';
 import { Op } from 'sequelize';
+
+export const INCOME_LOOKBACK_MONTHS_OPTIONS = [1, 3, 6, 12] as const;
+type IncomeLookbackMonths = (typeof INCOME_LOOKBACK_MONTHS_OPTIONS)[number];
+const DEFAULT_INCOME_LOOKBACK_MONTHS: IncomeLookbackMonths = 6;
+
+const getAverageMonthlyIncome = async ({
+  userId,
+  lookbackMonths,
+}: {
+  userId: number;
+  lookbackMonths: IncomeLookbackMonths;
+}): Promise<Money> => {
+  const now = new Date();
+  const from = startOfMonth(subMonths(now, lookbackMonths));
+  const to = endOfMonth(subMonths(now, 1));
+
+  const incomeTxs = await Transactions.findAll({
+    where: {
+      userId,
+      transactionType: TRANSACTION_TYPES.income,
+      transferNature: TRANSACTION_TRANSFER_NATURE.not_transfer,
+      time: { [Op.between]: [from, to] },
+    },
+    include: [{ model: Accounts, where: { excludeFromStats: false }, attributes: [] }],
+    attributes: ['refAmount'],
+  });
+
+  let total = Money.zero();
+  for (const tx of incomeTxs) {
+    total = total.add(tx.refAmount);
+  }
+
+  return total.divide(lookbackMonths);
+};
 
 const MONTHLY_MULTIPLIERS: Record<SUBSCRIPTION_FREQUENCIES, number> = {
   [SUBSCRIPTION_FREQUENCIES.weekly]: 4.33,
@@ -19,9 +61,14 @@ const MONTHLY_MULTIPLIERS: Record<SUBSCRIPTION_FREQUENCIES, number> = {
 interface GetSubscriptionsSummaryParams {
   userId: number;
   type?: SUBSCRIPTION_TYPES;
+  lookbackMonths?: IncomeLookbackMonths;
 }
 
-const getSubscriptionsSummaryImpl = async ({ userId, type }: GetSubscriptionsSummaryParams) => {
+const getSubscriptionsSummaryImpl = async ({
+  userId,
+  type,
+  lookbackMonths = DEFAULT_INCOME_LOOKBACK_MONTHS,
+}: GetSubscriptionsSummaryParams) => {
   const where: Record<string, unknown> = {
     userId,
     isActive: true,
@@ -64,11 +111,19 @@ const getSubscriptionsSummaryImpl = async ({ userId, type }: GetSubscriptionsSum
   const monthlyMoney = totalMonthly.round();
   const yearlyMoney = monthlyMoney.multiply(12);
 
+  const averageMonthlyIncomeMoney = await getAverageMonthlyIncome({ userId, lookbackMonths });
+  const averageMonthlyIncome = averageMonthlyIncomeMoney.toNumber();
+  const percentOfIncome =
+    averageMonthlyIncome > 0 ? Math.round((monthlyMoney.toNumber() / averageMonthlyIncome) * 1000) / 10 : null;
+
   return {
     estimatedMonthlyCost: monthlyMoney.toNumber(),
     projectedYearlyCost: yearlyMoney.toNumber(),
     activeCount: subscriptions.length,
     currencyCode: baseCurrencyCode,
+    averageMonthlyIncome,
+    percentOfIncome,
+    lookbackMonths,
   };
 };
 

--- a/packages/backend/src/services/subscriptions/subscriptions.e2e.ts
+++ b/packages/backend/src/services/subscriptions/subscriptions.e2e.ts
@@ -575,6 +575,135 @@ describe('Subscriptions', () => {
         expect(summary.estimatedMonthlyCost).toBe(10);
         expect(summary.projectedYearlyCost).toBe(120);
       });
+
+      it('returns null percentOfIncome when no income transactions exist', async () => {
+        await helpers.createSubscription({
+          name: 'Netflix',
+          expectedAmount: 1500,
+          expectedCurrencyCode: global.BASE_CURRENCY_CODE,
+          frequency: SUBSCRIPTION_FREQUENCIES.monthly,
+          startDate: '2025-01-01',
+          raw: true,
+        });
+
+        const summary = await helpers.getSubscriptionsSummary({ raw: true });
+        expect(summary.averageMonthlyIncome).toBe(0);
+        expect(summary.percentOfIncome).toBeNull();
+      });
+
+      it('returns averageMonthlyIncome and percentOfIncome based on income in last 6 months', async () => {
+        const account = await helpers.createAccount({ raw: true });
+
+        // 6 income transactions across last 6 complete months, $600 each
+        // → $3600 total, $600/month average
+        for (let monthsAgo = 1; monthsAgo <= 6; monthsAgo++) {
+          const date = new Date();
+          date.setMonth(date.getMonth() - monthsAgo);
+          date.setDate(15);
+          await helpers.createTransaction({
+            payload: helpers.buildTransactionPayload({
+              accountId: account.id,
+              amount: 600,
+              transactionType: TRANSACTION_TYPES.income,
+              time: date.toISOString(),
+            }),
+            raw: true,
+          });
+        }
+
+        await helpers.createSubscription({
+          name: 'Netflix',
+          expectedAmount: 6000,
+          expectedCurrencyCode: global.BASE_CURRENCY_CODE,
+          frequency: SUBSCRIPTION_FREQUENCIES.monthly,
+          startDate: '2025-01-01',
+          raw: true,
+        });
+
+        const summary = await helpers.getSubscriptionsSummary({ raw: true });
+        expect(summary.estimatedMonthlyCost).toBe(60);
+        expect(summary.averageMonthlyIncome).toBe(600);
+        // 60 / 600 = 10%
+        expect(summary.percentOfIncome).toBe(10);
+      });
+
+      it('honors lookbackMonths query param when averaging income', async () => {
+        const account = await helpers.createAccount({ raw: true });
+
+        // Income only in the most recent complete month: $900
+        const recent = new Date();
+        recent.setMonth(recent.getMonth() - 1);
+        recent.setDate(10);
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account.id,
+            amount: 900,
+            transactionType: TRANSACTION_TYPES.income,
+            time: recent.toISOString(),
+          }),
+          raw: true,
+        });
+
+        // lookback=1 → avg = 900
+        const oneMonth = await helpers.getSubscriptionsSummary({ lookbackMonths: 1, raw: true });
+        expect(oneMonth.averageMonthlyIncome).toBe(900);
+        expect(oneMonth.lookbackMonths).toBe(1);
+
+        // lookback=12 → 900 / 12 = 75
+        const twelveMonths = await helpers.getSubscriptionsSummary({ lookbackMonths: 12, raw: true });
+        expect(twelveMonths.averageMonthlyIncome).toBe(75);
+        expect(twelveMonths.lookbackMonths).toBe(12);
+      });
+
+      it('rejects invalid lookbackMonths values', async () => {
+        const res = await helpers.getSubscriptionsSummary({ lookbackMonths: 5 });
+        expect(res.statusCode).toBe(422);
+      });
+
+      it('excludes current-month and >6-month-old income from the average', async () => {
+        const account = await helpers.createAccount({ raw: true });
+
+        // Current month — should NOT count
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account.id,
+            amount: 9999,
+            transactionType: TRANSACTION_TYPES.income,
+            time: new Date().toISOString(),
+          }),
+          raw: true,
+        });
+
+        // 10 months ago — outside lookback window, should NOT count
+        const old = new Date();
+        old.setMonth(old.getMonth() - 10);
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account.id,
+            amount: 9999,
+            transactionType: TRANSACTION_TYPES.income,
+            time: old.toISOString(),
+          }),
+          raw: true,
+        });
+
+        // 2 months ago — counts. $300, divided by 6 → $50/month
+        const recent = new Date();
+        recent.setMonth(recent.getMonth() - 2);
+        recent.setDate(10);
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId: account.id,
+            amount: 300,
+            transactionType: TRANSACTION_TYPES.income,
+            time: recent.toISOString(),
+          }),
+          raw: true,
+        });
+
+        const summary = await helpers.getSubscriptionsSummary({ raw: true });
+        expect(summary.averageMonthlyIncome).toBe(50);
+      });
     });
   });
 

--- a/packages/backend/src/tests/helpers/subscriptions.ts
+++ b/packages/backend/src/tests/helpers/subscriptions.ts
@@ -188,12 +188,15 @@ export async function getSuggestedMatches<R extends boolean | undefined = undefi
 export async function getSubscriptionsSummary<R extends boolean | undefined = undefined>({
   raw,
   type,
+  lookbackMonths,
 }: {
   raw?: R;
   type?: string;
+  lookbackMonths?: number;
 } = {}) {
   const query: Record<string, string> = {};
   if (type) query.type = type;
+  if (lookbackMonths !== undefined) query.lookbackMonths = String(lookbackMonths);
 
   return makeRequest<Awaited<ReturnType<typeof apiGetSubscriptionsSummary>>, R>({
     method: 'get',

--- a/packages/frontend/src/api/subscriptions.ts
+++ b/packages/frontend/src/api/subscriptions.ts
@@ -116,20 +116,30 @@ export const loadUpcomingPayments = async ({ limit, type }: { limit?: number; ty
   return api.get('/subscriptions/upcoming', query);
 };
 
+export const INCOME_LOOKBACK_MONTHS_OPTIONS = [1, 3, 6, 12] as const;
+export type IncomeLookbackMonths = (typeof INCOME_LOOKBACK_MONTHS_OPTIONS)[number];
+export const DEFAULT_INCOME_LOOKBACK_MONTHS: IncomeLookbackMonths = 6;
+
 interface SubscriptionsSummary {
   estimatedMonthlyCost: number;
   projectedYearlyCost: number;
   activeCount: number;
   currencyCode: string;
+  averageMonthlyIncome: number;
+  percentOfIncome: number | null;
+  lookbackMonths: IncomeLookbackMonths;
 }
 
 export const loadSubscriptionsSummary = async ({
   type,
+  lookbackMonths,
 }: {
   type?: string;
+  lookbackMonths?: IncomeLookbackMonths;
 } = {}): Promise<SubscriptionsSummary> => {
   const query: Record<string, string> = {};
   if (type) query.type = type;
+  if (lookbackMonths !== undefined) query.lookbackMonths = String(lookbackMonths);
 
   return api.get('/subscriptions/summary', query);
 };

--- a/packages/frontend/src/components/widgets/components/subscriptions-overview-settings-popover.vue
+++ b/packages/frontend/src/components/widgets/components/subscriptions-overview-settings-popover.vue
@@ -1,0 +1,213 @@
+<template>
+  <Popover v-model:open="isOpen">
+    <PopoverTrigger as-child>
+      <Button size="icon-sm" variant="ghost">
+        <SettingsIcon class="text-muted-foreground size-4" />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent class="w-64 overflow-hidden p-0" align="end">
+      <SlidingPanels v-model="view" :panels="['main', 'type', 'lookback']">
+        <template #main>
+          <div class="flex flex-col">
+            <header class="border-b px-3 py-2 text-sm font-medium">
+              {{ t('dashboard.widgets.subscriptions.settings.title') }}
+            </header>
+
+            <div class="flex flex-col p-2">
+              <button
+                type="button"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors"
+                @click="goTo('type')"
+              >
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium">
+                    {{ t('dashboard.widgets.subscriptions.settings.show') }}
+                  </span>
+                  <span class="text-muted-foreground text-xs">
+                    {{ t(currentTypeChoice.label) }}
+                  </span>
+                </span>
+                <ChevronRightIcon class="text-muted-foreground size-4" />
+              </button>
+
+              <button
+                type="button"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors"
+                @click="goTo('lookback')"
+              >
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium">
+                    {{ t('dashboard.widgets.subscriptions.settings.incomeWindow') }}
+                  </span>
+                  <span class="text-muted-foreground text-xs">
+                    {{ t(currentLookbackChoice.label) }}
+                  </span>
+                </span>
+                <ChevronRightIcon class="text-muted-foreground size-4" />
+              </button>
+
+              <router-link
+                :to="{ name: ROUTES_NAMES.plannedSubscriptions }"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 transition-colors"
+                @click="isOpen = false"
+              >
+                <span class="text-sm font-medium">{{ t('common.actions.viewAll') }}</span>
+                <ArrowUpRightIcon class="text-muted-foreground size-4" />
+              </router-link>
+            </div>
+          </div>
+        </template>
+
+        <template #type>
+          <div class="flex flex-col">
+            <header class="flex items-center gap-2 border-b px-2 py-2">
+              <Button size="icon-sm" variant="ghost" type="button" @click="goTo('main')">
+                <ArrowLeftIcon class="size-4" />
+              </Button>
+              <span class="text-sm font-medium">
+                {{ t('dashboard.widgets.subscriptions.settings.show') }}
+              </span>
+            </header>
+
+            <div class="flex flex-col p-2">
+              <button
+                v-for="choice in TYPE_CHOICES"
+                :key="choice.value"
+                type="button"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors"
+                @click="onTypeChange(choice.value)"
+              >
+                <span class="text-sm">{{ t(choice.label) }}</span>
+                <CheckIcon v-if="currentType === choice.value" class="text-primary size-4" />
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <template #lookback>
+          <div class="flex flex-col">
+            <header class="flex items-center gap-2 border-b px-2 py-2">
+              <Button size="icon-sm" variant="ghost" type="button" @click="goTo('main')">
+                <ArrowLeftIcon class="size-4" />
+              </Button>
+              <span class="flex items-center gap-1 text-sm font-medium">
+                {{ t('dashboard.widgets.subscriptions.settings.incomeWindow') }}
+                <ResponsiveTooltip
+                  :delay-duration="100"
+                  :content="t('dashboard.widgets.subscriptions.settings.incomeWindowTooltip')"
+                  content-class-name="max-w-60"
+                >
+                  <InfoIcon class="text-muted-foreground size-3.5 cursor-help" @click.prevent.stop />
+                </ResponsiveTooltip>
+              </span>
+            </header>
+
+            <div class="flex flex-col p-2">
+              <button
+                v-for="choice in LOOKBACK_CHOICES"
+                :key="choice.value"
+                type="button"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors"
+                @click="onLookbackChange(choice.value)"
+              >
+                <span class="text-sm">{{ t(choice.label) }}</span>
+                <CheckIcon v-if="currentLookback === choice.value" class="text-primary size-4" />
+              </button>
+            </div>
+          </div>
+        </template>
+      </SlidingPanels>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<script lang="ts" setup>
+import { DEFAULT_INCOME_LOOKBACK_MONTHS, type IncomeLookbackMonths } from '@/api/subscriptions';
+import type { DashboardWidgetConfig } from '@/api/user-settings';
+import ResponsiveTooltip from '@/components/common/responsive-tooltip.vue';
+import SlidingPanels from '@/components/common/sliding-panels.vue';
+import { Button } from '@/components/lib/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/lib/ui/popover';
+import { useUserSettings } from '@/composable/data-queries/user-settings';
+import { ROUTES_NAMES } from '@/routes/constants';
+import { ArrowLeftIcon, ArrowUpRightIcon, CheckIcon, ChevronRightIcon, InfoIcon, SettingsIcon } from '@lucide/vue';
+import type { Ref } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const TYPE_CHOICES = [
+  { value: '', label: 'dashboard.widgets.subscriptions.configTypeAll' },
+  { value: 'subscription', label: 'dashboard.widgets.subscriptions.configTypeSubscriptions' },
+  { value: 'bill', label: 'dashboard.widgets.subscriptions.configTypeBills' },
+] as const;
+
+const LOOKBACK_CHOICES: Array<{ value: IncomeLookbackMonths; label: string }> = [
+  { value: 1, label: 'dashboard.widgets.subscriptions.settings.lookbackOption.1' },
+  { value: 3, label: 'dashboard.widgets.subscriptions.settings.lookbackOption.3' },
+  { value: 6, label: 'dashboard.widgets.subscriptions.settings.lookbackOption.6' },
+  { value: 12, label: 'dashboard.widgets.subscriptions.settings.lookbackOption.12' },
+];
+
+const { t } = useI18n({ useScope: 'global' });
+const widgetConfigRef = inject<Ref<DashboardWidgetConfig> | null>('dashboard-widget-config', null);
+const { data: userSettingsData, mutateAsync: saveUserSettings } = useUserSettings();
+
+const isOpen = ref(false);
+type View = 'main' | 'type' | 'lookback';
+const view = ref<View>('main');
+
+watch(isOpen, (open) => {
+  if (!open) {
+    setTimeout(() => {
+      view.value = 'main';
+    }, 320);
+  }
+});
+
+const currentType = computed(() => {
+  const cfg = widgetConfigRef?.value?.config;
+  return (cfg?.type as string | undefined) ?? '';
+});
+
+const currentTypeChoice = computed(() => TYPE_CHOICES.find((c) => c.value === currentType.value) ?? TYPE_CHOICES[0]);
+
+const currentLookback = computed<IncomeLookbackMonths>(() => {
+  const cfg = widgetConfigRef?.value?.config;
+  const raw = cfg?.lookbackMonths as number | undefined;
+  return raw === 1 || raw === 3 || raw === 6 || raw === 12 ? raw : DEFAULT_INCOME_LOOKBACK_MONTHS;
+});
+
+const currentLookbackChoice = computed(
+  () => LOOKBACK_CHOICES.find((c) => c.value === currentLookback.value) ?? LOOKBACK_CHOICES[2]!,
+);
+
+function goTo(target: View) {
+  view.value = target;
+}
+
+async function persistConfig(patch: Record<string, unknown>) {
+  const settings = userSettingsData.value;
+  if (!settings || !widgetConfigRef?.value) return;
+
+  const widgets = [...(settings.dashboard?.widgets ?? [])];
+  const idx = widgets.findIndex((w) => w.widgetId === widgetConfigRef.value!.widgetId);
+  if (idx === -1) return;
+
+  widgets[idx] = {
+    ...widgets[idx]!,
+    config: { ...widgets[idx]!.config, ...patch },
+  };
+
+  await saveUserSettings({ ...settings, dashboard: { widgets } });
+}
+
+function onTypeChange(value: string) {
+  persistConfig({ type: value });
+  goTo('main');
+}
+
+function onLookbackChange(value: IncomeLookbackMonths) {
+  persistConfig({ lookbackMonths: value });
+  goTo('main');
+}
+</script>

--- a/packages/frontend/src/components/widgets/subscriptions-overview.vue
+++ b/packages/frontend/src/components/widgets/subscriptions-overview.vue
@@ -1,11 +1,16 @@
 <script lang="ts" setup>
-import { loadSubscriptionsSummary, loadUpcomingPayments } from '@/api/subscriptions';
+import {
+  DEFAULT_INCOME_LOOKBACK_MONTHS,
+  type IncomeLookbackMonths,
+  loadSubscriptionsSummary,
+  loadUpcomingPayments,
+} from '@/api/subscriptions';
 import type { DashboardWidgetConfig } from '@/api/user-settings';
 import { VUE_QUERY_CACHE_KEYS } from '@/common/const';
-import { buttonVariants } from '@/components/lib/ui/button';
 import { useFormatCurrency } from '@/composable/formatters';
 import { useAnimatedNumber } from '@/composable/use-animated-number';
 import { useDateLocale } from '@/composable/use-date-locale';
+import { findServiceByName } from '@/common/utils/find-subscription-service';
 import SubscriptionServiceLogo from '@/pages/planned/subscriptions/components/subscription-service-logo.vue';
 import { ROUTES_NAMES } from '@/routes/constants';
 import { useRootStore } from '@/stores';
@@ -19,6 +24,7 @@ import { useI18n } from 'vue-i18n';
 
 import EmptyState from './components/empty-state.vue';
 import LoadingState from './components/loading-state.vue';
+import SubscriptionsOverviewSettingsPopover from './components/subscriptions-overview-settings-popover.vue';
 import WidgetWrapper from './components/widget-wrapper.vue';
 
 const { t } = useI18n();
@@ -35,15 +41,42 @@ const widgetType = computed(() => {
   return (cfg?.type as string) || undefined;
 });
 
+const widgetLookbackMonths = computed<IncomeLookbackMonths>(() => {
+  const cfg = widgetConfigRef?.value?.config;
+  const raw = cfg?.lookbackMonths as number | undefined;
+  return raw === 1 || raw === 3 || raw === 6 || raw === 12 ? raw : DEFAULT_INCOME_LOOKBACK_MONTHS;
+});
+
 const TITLE_KEYS: Record<string, string> = {
   subscription: 'dashboard.widgets.subscriptions.titleSubscriptions',
   bill: 'dashboard.widgets.subscriptions.titleBills',
 };
 const widgetTitle = computed(() => t(TITLE_KEYS[widgetType.value ?? ''] ?? 'dashboard.widgets.subscriptions.title'));
 
+// Per-type thresholds for highlighting how heavy the recurring cost is relative to income.
+// Subscriptions (entertainment-ish) should fire alarms much earlier than bills (rent/utilities).
+const PERCENT_OF_INCOME_THRESHOLDS: Record<string, { yellow: number; red: number }> = {
+  subscription: { yellow: 5, red: 10 },
+  bill: { yellow: 30, red: 50 },
+  all: { yellow: 20, red: 40 },
+};
+
+const percentOfIncomeColorClass = computed(() => {
+  const percent = summary.value?.percentOfIncome;
+  if (percent === null || percent === undefined) return 'text-muted-foreground';
+  const { yellow, red } = PERCENT_OF_INCOME_THRESHOLDS[widgetType.value ?? 'all']!;
+  if (percent >= red) return 'text-app-expense-color';
+  if (percent >= yellow) return 'text-warning-text';
+  return 'text-app-income-color';
+});
+
 const { data: summary, isFetching: isSummaryFetching } = useQuery({
-  queryKey: computed(() => [...VUE_QUERY_CACHE_KEYS.subscriptionsSummary, widgetType.value ?? 'all']),
-  queryFn: () => loadSubscriptionsSummary({ type: widgetType.value }),
+  queryKey: computed(() => [
+    ...VUE_QUERY_CACHE_KEYS.subscriptionsSummary,
+    widgetType.value ?? 'all',
+    widgetLookbackMonths.value,
+  ]),
+  queryFn: () => loadSubscriptionsSummary({ type: widgetType.value, lookbackMonths: widgetLookbackMonths.value }),
   staleTime: Infinity,
   enabled: isAppInitialized,
 });
@@ -68,18 +101,15 @@ const formatNextDate = (dateStr: string | null) => {
   if (!dateStr) return '';
   return formatDistanceToNow(parseISO(dateStr), { addSuffix: true });
 };
+
+const hasServiceLogo = (name: string) => !!findServiceByName({ name });
 </script>
 
 <template>
   <WidgetWrapper :is-fetching="isFetching">
     <template #title> {{ widgetTitle }} </template>
-    <template #action>
-      <router-link
-        :to="{ name: ROUTES_NAMES.plannedSubscriptions }"
-        :class="buttonVariants({ variant: 'ghost', size: 'sm', class: 'text-muted-foreground' })"
-      >
-        {{ $t('common.actions.viewAll') }}
-      </router-link>
+    <template v-if="isOnDashboard" #action>
+      <SubscriptionsOverviewSettingsPopover />
     </template>
 
     <template v-if="isInitialLoading">
@@ -95,8 +125,11 @@ const formatNextDate = (dateStr: string | null) => {
     <template v-else>
       <!-- Monthly total -->
       <div v-if="summary && summary.activeCount > 0" class="mb-4">
-        <p class="text-2xl font-bold tracking-tight">
+        <p class="flex flex-wrap items-baseline gap-x-2 text-2xl font-bold tracking-tight">
           {{ formatBaseCurrency(animatedMonthlyCost) }}
+          <span v-if="summary.percentOfIncome !== null" :class="[percentOfIncomeColorClass, 'text-sm font-normal']">
+            {{ $t('dashboard.widgets.subscriptions.percentOfIncome', { percent: summary.percentOfIncome }) }}
+          </span>
         </p>
         <p class="text-muted-foreground mt-1 text-xs">
           {{ t('dashboard.widgets.subscriptions.activeSummary', { count: summary.activeCount }) }} &middot; ~{{
@@ -113,7 +146,11 @@ const formatNextDate = (dateStr: string | null) => {
           :to="{ name: ROUTES_NAMES.plannedSubscriptionDetails, params: { id: payment.subscriptionId } }"
           class="hover:bg-muted/50 flex items-center gap-3 rounded-md px-3 py-1.5 transition-colors"
         >
-          <SubscriptionServiceLogo :name="payment.subscriptionName" class="size-5" />
+          <SubscriptionServiceLogo
+            v-if="hasServiceLogo(payment.subscriptionName)"
+            :name="payment.subscriptionName"
+            class="size-5"
+          />
           <div class="min-w-0 flex-1">
             <p class="truncate text-sm font-medium">{{ payment.subscriptionName }}</p>
             <p class="text-muted-foreground text-xs">{{ formatNextDate(payment.nextPaymentDate) }}</p>

--- a/packages/frontend/src/components/widgets/widget-registry.ts
+++ b/packages/frontend/src/components/widgets/widget-registry.ts
@@ -116,17 +116,6 @@ export const WIDGET_REGISTRY: Record<string, WidgetDefinition> = {
     ],
     component: () => import('@/components/widgets/subscriptions-overview.vue'),
     needsPeriod: false,
-    configOptions: [
-      {
-        key: 'type',
-        label: 'dashboard.widgets.subscriptions.configType',
-        choices: [
-          { value: '', label: 'dashboard.widgets.subscriptions.configTypeAll' },
-          { value: 'subscription', label: 'dashboard.widgets.subscriptions.configTypeSubscriptions' },
-          { value: 'bill', label: 'dashboard.widgets.subscriptions.configTypeBills' },
-        ],
-      },
-    ],
   },
 };
 

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/dashboard.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/dashboard.json
@@ -88,12 +88,24 @@
         "title": "Subscriptions & Bills",
         "titleSubscriptions": "Subscriptions",
         "titleBills": "Bills",
-        "configType": "Type",
         "configTypeAll": "All",
         "configTypeSubscriptions": "Subscriptions",
         "configTypeBills": "Bills",
         "activeSummary": "{count} active",
-        "perYear": " per year"
+        "perYear": " per year",
+        "percentOfIncome": "{percent}% of avg income",
+        "settings": {
+          "title": "Settings",
+          "show": "Show",
+          "incomeWindow": "Income window",
+          "incomeWindowTooltip": "We average your incoming transactions over this period to compute the % of income spent on recurring payments.",
+          "lookbackOption": {
+            "1": "Last month",
+            "3": "Last 3 months",
+            "6": "Last 6 months",
+            "12": "Last 12 months"
+          }
+        }
       },
       "categoryTracker": {
         "title": "Categories Watchlist",

--- a/packages/frontend/src/i18n/locales/chunks/uk/pages/dashboard.json
+++ b/packages/frontend/src/i18n/locales/chunks/uk/pages/dashboard.json
@@ -88,12 +88,24 @@
         "title": "Підписки та рахунки",
         "titleSubscriptions": "Підписки",
         "titleBills": "Рахунки",
-        "configType": "Тип",
         "configTypeAll": "Всі",
         "configTypeSubscriptions": "Підписки",
         "configTypeBills": "Рахунки",
         "activeSummary": "{count} активна",
-        "perYear": " на рік"
+        "perYear": " на рік",
+        "percentOfIncome": "{percent}% від сер. доходу",
+        "settings": {
+          "title": "Налаштування",
+          "show": "Показати",
+          "incomeWindow": "Період доходу",
+          "incomeWindowTooltip": "За цей період усереднюються ваші доходи для розрахунку відсотка регулярних платежів від доходу.",
+          "lookbackOption": {
+            "1": "Минулий місяць",
+            "3": "Останні 3 місяці",
+            "6": "Останні 6 місяців",
+            "12": "Останні 12 місяців"
+          }
+        }
       },
       "categoryTracker": {
         "title": "Спостереження Категорій",


### PR DESCRIPTION
- show % of avg income on the Subs & Bills widget
- also moved filer All/Subs/Bills from layout editing to the widget's gear-icon popover alog with an income window setting
- the % is colored green/yellow/red against per-type thresholds