### PR TITLE
Auto-shrink initial-sync lookback when bank caps it

### DIFF
--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
@@ -39,7 +39,7 @@ interface PSUContext {
 /**
  * JSON.stringify that falls back to `String(value)` when serialization throws
  * (circular references, BigInt members, throwing toJSON, etc.). Logs a warning
- * on the fallback path so a degraded serialization is at least visible —
+ * on the fallback path so a degraded serialization is at least visible –
  * silently returning "[object Object]" would destroy debugging info in Sentry.
  */
 export function safeStringify(value: unknown): string {
@@ -61,7 +61,7 @@ type AspspAuthFailureReason = 'nested-code' | 'nested-status' | 'keyword-match';
  * Strict keyword pattern for cases where Enable Banking strips `error_data`
  * (seen in dev) but the wrapper / nested message still describes an auth or
  * consent failure. Each alternative is anchored to phrases that strongly
- * imply auth state — bare words like "forbidden" or "unauthorized" were
+ * imply auth state – bare words like "forbidden" or "unauthorized" were
  * intentionally removed to avoid promoting unrelated 400s (e.g. "Operation
  * forbidden by bank during maintenance") into connection deactivations.
  */
@@ -112,6 +112,46 @@ export function classifyAspspError({
 }
 
 /**
+ * True when 400 from /transactions means the bank refused the lookback as too wide.
+ * Callers shrink the window and retry on true.
+ *
+ * PSD2 caps vary per ASPSP (BNP Fortis BE: 2y; others: 90d; German banks: up to 7y)
+ * with no API to query the limit up-front.
+ *
+ * Match: concept anchor + limit verb + time window, all three required.
+ *   concept    – datefrom/dateto OR range/period/window/lookback/history/interval/transactions
+ *   limit verb – within/exceed/maximum/limited to/older than
+ *   time       – N day/week/month/year
+ * Each alone is too permissive (e.g. "account opened within last 30 days" hits
+ * limit + time but has no concept anchor).
+ */
+export function isAspspDateRangeRejection(error: unknown): boolean {
+  if (!(error instanceof BadRequestError)) return false;
+
+  const details = error.details as
+    | { method?: unknown; aspspError?: unknown; aspspMessage?: unknown; aspspErrorDataStr?: unknown }
+    | undefined;
+  if (!details) return false;
+  if (details.method !== 'getAccountTransactions') return false;
+  if (details.aspspError !== 'ASPSP_ERROR') return false;
+
+  const parts: string[] = [];
+  if (typeof details.aspspMessage === 'string') parts.push(details.aspspMessage);
+  if (typeof details.aspspErrorDataStr === 'string') parts.push(details.aspspErrorDataStr);
+  if (typeof error.message === 'string') parts.push(error.message);
+  const haystack = parts.join(' ').toLowerCase();
+  if (haystack === '') return false;
+
+  const hasLimitVerb = /\b(?:within|exceed|exceeds|maximum|max|limited?\s+to|older\s+than)\b/.test(haystack);
+  const hasTimeWindow = /\b\d+\s*(?:day|week|month|year)s?\b/.test(haystack);
+  if (!hasLimitVerb || !hasTimeWindow) return false;
+
+  const hasFieldName = /\b(?:datefrom|dateto)\b/.test(haystack);
+  const hasRangeNoun = /\b(?:range|period|window|lookback|history|interval|transactions?)\b/.test(haystack);
+  return hasFieldName || hasRangeNoun;
+}
+
+/**
  * Exponential backoff delays for transient-error retries on slow ASPSP
  * transactions endpoints. List length defines the max retry count.
  */
@@ -122,7 +162,7 @@ const RETRYABLE_AXIOS_CODES = new Set(['ECONNABORTED', 'ETIMEDOUT', 'ECONNRESET'
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
- * Retry only on transient signals — timeouts, dropped connections, and 5xx —
+ * Retry only on transient signals – timeouts, dropped connections, and 5xx –
  * never on 4xx, since those won't change on retry and would either burn time
  * (BadRequestError) or hide a real auth failure (ForbiddenError).
  */
@@ -216,13 +256,13 @@ export class EnableBankingApiClient {
       };
 
       // Detect ASPSP-wrapped session/token expiry. Upstream returns 401/403 but
-      // Enable Banking surfaces it as 400 ASPSP_ERROR — promote to ForbiddenError
+      // Enable Banking surfaces it as 400 ASPSP_ERROR – promote to ForbiddenError
       // so the provider's handleProviderError marks the connection inactive and
       // the UI prompts the user to reconnect.
       if (status === 400 && aspspError === 'ASPSP_ERROR') {
         const classification = classifyAspspError({ detail, aspspMessage });
         if (classification.matched) {
-          // Audit log so we can review classifications in Sentry — the wrong
+          // Audit log so we can review classifications in Sentry – the wrong
           // call here either silently lets a broken connection keep failing
           // (false negative) or kills a working one (false positive).
           logger.warn(

--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.unit.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.unit.ts
@@ -8,7 +8,9 @@ jest.mock('@js/utils/logger', () => ({
   },
 }));
 
-import { classifyAspspError, safeStringify } from './api-client';
+import { BadRequestError, ForbiddenError } from '@js/errors';
+
+import { classifyAspspError, isAspspDateRangeRejection, safeStringify } from './api-client';
 
 describe('safeStringify', () => {
   it('serializes plain objects normally', () => {
@@ -134,5 +136,133 @@ describe('classifyAspspError', () => {
         }).matched,
       ).toBe(false);
     });
+  });
+});
+
+const makeAspspBadRequest = ({
+  method = 'getAccountTransactions',
+  aspspError = 'ASPSP_ERROR',
+  aspspMessage,
+  aspspErrorDataStr,
+  message = 'Some upstream error',
+}: {
+  method?: string;
+  aspspError?: string;
+  aspspMessage?: string;
+  aspspErrorDataStr?: string;
+  message?: string;
+}): BadRequestError =>
+  new BadRequestError({
+    message,
+    details: { method, aspspError, aspspMessage, aspspErrorDataStr },
+  });
+
+describe('isAspspDateRangeRejection', () => {
+  it.each([
+    'The dateFrom and dateTo must be within 2 years',
+    'The dateFrom and dateTo must be within 730 days',
+    'dateFrom cannot be older than 24 months',
+  ])('matches BNP-Fortis-style "dateFrom/dateTo" phrasing: "%s"', (aspspMessage) => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage }))).toBe(true);
+  });
+
+  it.each([
+    'Date range cannot exceed 90 days',
+    'Maximum lookback is 365 days',
+    'Transaction history limited to 13 months',
+    'Requested period exceeds 2 years',
+    'Transactions older than 90 days are not available',
+  ])('matches generic limit phrasings: "%s"', (aspspMessage) => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage }))).toBe(true);
+  });
+
+  it('matches when limit phrasing is in aspspErrorDataStr only', () => {
+    expect(
+      isAspspDateRangeRejection(
+        makeAspspBadRequest({
+          aspspMessage: 'Error interacting with ASPSP',
+          aspspErrorDataStr: '{"status":400,"message":"date range cannot exceed 90 days"}',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT match generic 400s from the transactions endpoint with no date vocabulary', () => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage: 'Account not found for this session' }))).toBe(
+      false,
+    );
+  });
+
+  it('does NOT match a limit-keyword without a time-unit number', () => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage: 'Date range cannot be empty' }))).toBe(false);
+  });
+
+  it('does NOT match a time-unit number without a limit keyword', () => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage: 'Transaction posted 5 days ago' }))).toBe(
+      false,
+    );
+  });
+
+  it('does NOT match errors from other endpoints', () => {
+    expect(
+      isAspspDateRangeRejection(
+        makeAspspBadRequest({
+          method: 'createSession',
+          aspspMessage: 'The dateFrom and dateTo must be within 2 years',
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT match non-BadRequest errors', () => {
+    const forbidden = new ForbiddenError({
+      message: 'auth failure',
+      details: { method: 'getAccountTransactions', aspspMessage: 'dateFrom expired' },
+    });
+    expect(isAspspDateRangeRejection(forbidden)).toBe(false);
+  });
+
+  it('does NOT match plain Error instances', () => {
+    expect(isAspspDateRangeRejection(new Error('dateFrom 2 years'))).toBe(false);
+  });
+
+  it('does NOT match BadRequestError with no details', () => {
+    expect(isAspspDateRangeRejection(new BadRequestError({ message: 'dateFrom 2 years' }))).toBe(false);
+  });
+
+  it('does NOT match Enable Banking own-validation 400s (different aspspError tag)', () => {
+    expect(
+      isAspspDateRangeRejection(
+        makeAspspBadRequest({ aspspError: 'INVALID_REQUEST', aspspMessage: 'dateTo is required' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('does NOT match when aspspError tag is missing entirely', () => {
+    const err = new BadRequestError({
+      message: 'something',
+      details: { method: 'getAccountTransactions', aspspMessage: 'history limited to 13 months' },
+    });
+    expect(isAspspDateRangeRejection(err)).toBe(false);
+  });
+
+  it('does NOT match "dateTo is required" – field name without a limit verb', () => {
+    expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage: 'dateTo is required' }))).toBe(false);
+  });
+
+  it('does NOT match limit-verb + time-window without a concept anchor (no field name, no range noun)', () => {
+    expect(
+      isAspspDateRangeRejection(
+        makeAspspBadRequest({ aspspMessage: 'Account opened within last 30 days; limited access' }),
+      ),
+    ).toBe(false);
+  });
+
+  it('matches when the limit phrasing appears only in error.message (not aspspMessage)', () => {
+    const err = new BadRequestError({
+      message: 'Date range cannot exceed 90 days',
+      details: { method: 'getAccountTransactions', aspspError: 'ASPSP_ERROR' },
+    });
+    expect(isAspspDateRangeRejection(err)).toBe(true);
   });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -31,7 +31,18 @@ import { Op, Sequelize } from 'sequelize';
 
 import { encryptCredentials } from '../utils/credential-encryption';
 import { writeBankBalanceWithHistory } from '../utils/write-bank-balance-with-history';
-import { EnableBankingApiClient } from './api-client';
+import { EnableBankingApiClient, isAspspDateRangeRejection } from './api-client';
+
+/**
+ * Initial-sync lookback schedule. PSD2 cap unknown per bank, no API to query,
+ * so try widest first then shrink on rejection.
+ *   1095d ≈ 3y – German banks
+ *   730d  = 2y – BNP Paribas Fortis BE
+ *   365d  = 1y – Swedbank, Baltic ASPSPs
+ *   90d   = PSD2 baseline (unattended access)
+ */
+const INITIAL_SYNC_FALLBACK_DAYS = [1095, 730, 365, 90] as const;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
 import { generateState, validatePrivateKey, validateState } from './jwt-utils';
 import {
   CreditDebitIndicator,
@@ -221,7 +232,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
       state: undefined, // Clear state after successful auth
       consentValidFrom: consentValidFrom.toISOString(),
       consentValidUntil: consentValidUntil.toISOString(),
-      // Clear the "needs reauth" markers — successful OAuth means the prior
+      // Clear the "needs reauth" markers – successful OAuth means the prior
       // auth failure is resolved. Without this, the connection would still
       // appear in `connectionsNeedingReauth` whenever it's later marked
       // inactive for any reason (manual disconnect, future failure path).
@@ -694,20 +705,24 @@ export class EnableBankingProvider extends BaseBankDataProvider {
             order: [['time', 'DESC']],
           });
 
-          // Default to last 3 years if no transactions found
-          const days = 1095;
-          const from = latestTransaction
-            ? new Date(latestTransaction.time)
-            : new Date(Date.now() - days * 24 * 60 * 60 * 1000);
           const to = new Date();
 
-          // Fetch transactions using uid for API calls, but externalId (identification_hash) for hashing
-          const providerTransactions = await this.fetchTransactions(
-            connectionId,
-            apiUid,
-            { from, to },
-            account.externalId,
-          );
+          // Incremental: `from` anchored to last tx – bank lookback can't be exceeded.
+          // Initial: no anchor, must negotiate window with bank.
+          const providerTransactions = latestTransaction
+            ? await this.fetchTransactions(
+                connectionId,
+                apiUid,
+                { from: new Date(latestTransaction.time), to },
+                account.externalId,
+              )
+            : await this.fetchInitialTransactionsWithShrinkingWindow({
+                connectionId,
+                apiUid,
+                accountExternalId: account.externalId,
+                accountId: account.id,
+                to,
+              });
 
           // Sort transactions by date (ascending) so the last transaction for each day
           // will have the correct end-of-day balance in balance_after_transaction.
@@ -764,7 +779,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
 
             // `merchantName` here is the debtor/creditor name lifted from the raw
             // Enable Banking payload (or the literal 'Unknown' sentinel when both
-            // sides were absent — which is NOT a real merchant string). Forward
+            // sides were absent – which is NOT a real merchant string). Forward
             // the cleaned value into `externalData.merchantName` for audit and
             // historical Payee-promotion scans, and as `rawMerchantName` for
             // the per-row extraction pipeline.
@@ -814,6 +829,55 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     } catch (error) {
       return this.handleProviderError({ error, connectionId });
     }
+  }
+
+  /**
+   * Initial-sync: shrink lookback until bank accepts it. Schedule in
+   * INITIAL_SYNC_FALLBACK_DAYS. Only date-range rejections retry –
+   * auth/network/5xx rethrow immediately. On full exhaustion, log the
+   * cascade before rethrowing (caller would otherwise see only the 90d failure).
+   */
+  private async fetchInitialTransactionsWithShrinkingWindow({
+    connectionId,
+    apiUid,
+    accountExternalId,
+    accountId,
+    to,
+  }: {
+    connectionId: string;
+    apiUid: string;
+    accountExternalId: string;
+    accountId: string;
+    to: Date;
+  }): Promise<ProviderTransaction[]> {
+    let lastError: unknown;
+    for (const days of INITIAL_SYNC_FALLBACK_DAYS) {
+      const from = new Date(to.getTime() - days * MS_PER_DAY);
+      try {
+        return await this.fetchTransactions(connectionId, apiUid, { from, to }, accountExternalId);
+      } catch (error) {
+        if (!isAspspDateRangeRejection(error)) {
+          logger.info(`Enable Banking initial sync: non-retryable error during ${days}-day window attempt`, {
+            connectionId,
+            accountId,
+          });
+          throw error;
+        }
+        lastError = error;
+        logger.info(`Enable Banking initial sync: ASPSP rejected ${days}-day lookback; trying smaller window`, {
+          connectionId,
+          accountId,
+        });
+      }
+    }
+    logger.error(
+      {
+        message: 'Enable Banking initial sync: every fallback lookback window rejected by ASPSP',
+        error: lastError as Error,
+      },
+      { connectionId, accountId, attempted: [...INITIAL_SYNC_FALLBACK_DAYS] },
+    );
+    throw lastError;
   }
 
   // ============================================================================
@@ -1140,7 +1204,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
 
   /**
    * Tiered match for an incoming provider transaction against existing rows.
-   * Order matters — earlier paths are stronger guarantees.
+   * Order matters – earlier paths are stronger guarantees.
    */
   private async findExistingTransactionForSync({
     accountId,
@@ -1152,7 +1216,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     const entryReference = tx.metadata?.entryReference as string | undefined;
 
     // (1) entry_reference: ASPSP promises this is unique + immutable per account.
-    // Cheapest, strongest match — short-circuits the rest.
+    // Cheapest, strongest match – short-circuits the rest.
     if (entryReference) {
       const byEntryRef = await Transactions.findOne({
         where: {
@@ -1195,7 +1259,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         Sequelize.literal(`"externalData"->>'${isExpense ? 'creditorAccount' : 'debtorAccount'}'`),
         counterpartyIban,
       ),
-      // Only consider rows that have no entryReference yet — anything with
+      // Only consider rows that have no entryReference yet – anything with
       // one already would have been handled by step (1).
       Sequelize.where(Sequelize.literal(`"externalData"->>'entryReference'`), { [Op.is]: null as unknown as null }),
     ];
@@ -1217,9 +1281,9 @@ export class EnableBankingProvider extends BaseBankDataProvider {
    * entryReference, one without) within ±2 days and delete the orphan.
    *
    * Conservative: only collapses when (a) both rows share the same
-   * counterparty IBAN — mirroring the live-sync gate in
+   * counterparty IBAN – mirroring the live-sync gate in
    * findExistingTransactionForSync so different-party same-amount payments
-   * don't get merged — and (b) the orphan has no dependent rows and no
+   * don't get merged – and (b) the orphan has no dependent rows and no
    * user-edited scalars (note / categoryId / paymentType) that diverge from
    * the canonical. Returns counts for observability and idempotency
    * assertions.
@@ -1265,7 +1329,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         // IBAN gate: require both rows to share the same counterparty IBAN.
         // Expenses use creditorAccount (money going out to a creditor), income
         // uses debtorAccount. If the orphan has no IBAN (e.g. a manual entry
-        // that happens to share amount/currency/type with a bank row), skip —
+        // that happens to share amount/currency/type with a bank row), skip –
         // same rule findExistingTransactionForSync applies for live syncs.
         const orphanIban = this.getCounterpartyIban(orphan);
         if (!orphanIban) continue;
@@ -1282,7 +1346,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         if (!safeToDelete) {
           skippedCount++;
           logger.info(
-            `Reconcile: skipping orphan tx ${orphan.id} (account ${account.id}) — has dependent rows or divergent user edits`,
+            `Reconcile: skipping orphan tx ${orphan.id} (account ${account.id}) – has dependent rows or divergent user edits`,
           );
           continue;
         }
@@ -1312,7 +1376,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
    *   - dependent rows exist (splits, tags, refunds, transferId, group
    *     membership, etc.), OR
    *   - the orphan has user-mutable scalars (note, categoryId, paymentType)
-   *     that diverge from the canonical — those values would be silently lost
+   *     that diverge from the canonical – those values would be silently lost
    *     on destroy(), which is strictly worse than leaving a duplicate behind.
    */
   private async orphanIsSafeToDelete({


### PR DESCRIPTION
Some PSD2 ASPSPs (e.g. BNP Paribas Fortis BE) cap initial lookback below the 3y default.

Closes #318