### PR TITLE
Isolate docker resources per worktree for parallel e2e tests runs

### DIFF
--- a/docker/test/backend/Dockerfile
+++ b/docker/test/backend/Dockerfile
@@ -1,7 +1,5 @@
 FROM node:23.11.0
 
-LABEL com.docker.compose.project=test
-
 WORKDIR /app
 
 # Copy package.json and package-lock.json files. This allows Docker to cache the

--- a/docker/test/backend/docker-compose.yml
+++ b/docker/test/backend/docker-compose.yml
@@ -2,7 +2,6 @@ services:
   test-db:
     image: postgres:16
     restart: always
-    container_name: test-budget-tracker-db
     volumes: ['test_db_data:/var/lib/postgresql/data']
     environment:
       - POSTGRES_USER=${APPLICATION_DB_USERNAME}
@@ -46,7 +45,6 @@ services:
 
   test-redis:
     image: redis:7
-    container_name: test-budget-tracker-redis
     volumes: ['test_redis_data:/data']
     labels:
       - 'com.docker.compose.project=test'

--- a/packages/backend/src/tests/setup-e2e-tests.sh
+++ b/packages/backend/src/tests/setup-e2e-tests.sh
@@ -8,6 +8,13 @@ else
     exit 1
 fi
 
+# Namespace the docker compose project by the worktree basename so multiple
+# worktrees get their own containers/volumes and do not destroy each other's
+# template DB / worker DBs / images.
+WORKTREE_ID=$(basename "$(cd ../.. && pwd)")
+export COMPOSE_PROJECT_NAME="bt-test-${WORKTREE_ID}"
+echo "Using COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME}"
+
 
 # Start the containers and run tests
 docker compose -f ../../docker/test/backend/docker-compose.yml up --build -d
@@ -88,12 +95,10 @@ docker compose -f ../../docker/test/backend/docker-compose.yml exec -T test-runn
 # Capture the exit code
 TEST_EXIT_CODE=$?
 
-# Clean up containers
-docker compose -f ../../docker/test/backend/docker-compose.yml down -v --remove-orphans --volumes
-
-# Clean up images
-echo "Cleaning up Docker images..."
-docker image prune -af --filter "label=com.docker.compose.project=test"
+# Clean up containers + the test-runner image built for this worktree's project.
+# Using --rmi local keeps the cleanup scoped to this COMPOSE_PROJECT_NAME so
+# parallel runs from other worktrees are unaffected.
+docker compose -f ../../docker/test/backend/docker-compose.yml down -v --remove-orphans --volumes --rmi local
 
 # Check the exit code and display an error message if it's 1
 if [ $TEST_EXIT_CODE -eq 1 ]; then


### PR DESCRIPTION
Lets multiple worktrees run e2e simultaneously without destroying each other's template DB, worker DBs, containers, or images