### PR TITLE
Deterministic cost-basis replay order for same-day sell+buy

### DIFF
--- a/packages/backend/src/migrations/20260620000000-recalculate-holding-cost-basis.ts
+++ b/packages/backend/src/migrations/20260620000000-recalculate-holding-cost-basis.ts
@@ -1,0 +1,176 @@
+import { Big } from 'big.js';
+import { QueryInterface, QueryTypes } from 'sequelize';
+
+/**
+ * Recomputes every Holding's persisted cost basis from its transactions using
+ * the corrected (date, createdAt) replay ordering.
+ *
+ * `Holdings.costBasis` / `refCostBasis` are stored columns, rewritten only when a
+ * transaction is created/updated/deleted on that holding. A row last written
+ * before the replay-ordering fix can carry an inflated basis: a same-day wash
+ * sale (sell the whole position, then rebuy it) blended the liquidated lots into
+ * the basis instead of resetting it, because the same-day SELL/BUY pair had no
+ * deterministic order under the DATEONLY `date` column alone.
+ *
+ * This backfill replays each holding's transactions in (date, createdAt) order
+ * and overwrites `costBasis` / `refCostBasis`. `quantity` is a straight signed
+ * sum — order-independent and already correct — so it is left untouched.
+ *
+ * NOTES:
+ * - The fold inlines `computeHoldingTotals` (holding-totals.ts) as a frozen copy
+ *   driven by raw SQL: the production image ships only `dist/` + `src/migrations`,
+ *   not the service/model layer, so the migration cannot import app code (and a
+ *   migration must not depend on app code that may later change).
+ * - Each holding is recalculated in its own try/catch. A failure on one holding
+ *   is logged and skipped rather than thrown, so a single bad row cannot abort
+ *   the migration — which would halt the whole deploy via the entrypoint.
+ * - `down` is a no-op: the pre-fix values were incorrect and are not worth
+ *   restoring.
+ */
+
+const BUY = 'buy';
+const SELL = 'sell';
+
+interface HoldingRow {
+  portfolioId: string;
+  securityId: string;
+}
+
+interface TransactionRow {
+  category: string;
+  quantity: string;
+  amount: string;
+  refAmount: string;
+}
+
+/**
+ * Folds a holding's transactions (in chronological order) into its current cost
+ * basis. Cost basis tracks the cost of the *current long position* only: a SELL
+ * that drains the position to zero resets it, so a same-day wash sale keeps only
+ * the rebuy lot. Mirrors `computeHoldingTotals`; only BUY and SELL affect the
+ * basis, every other category is a no-op.
+ */
+function foldCostBasis({ transactions }: { transactions: TransactionRow[] }): {
+  costBasis: Big;
+  refCostBasis: Big;
+} {
+  let quantity = new Big(0);
+  let costBasis = new Big(0);
+  let refCostBasis = new Big(0);
+
+  for (const tx of transactions) {
+    const legQuantity = new Big(tx.quantity);
+    const amount = new Big(tx.amount);
+    const refAmount = new Big(tx.refAmount);
+
+    if (tx.category === BUY) {
+      const newQuantity = quantity.plus(legQuantity);
+      if (newQuantity.lte(0)) {
+        // Still short after the buy — no long position to attribute cost to.
+        costBasis = new Big(0);
+        refCostBasis = new Big(0);
+      } else if (quantity.lte(0)) {
+        // Crosses from short/zero into long; only the portion above zero is new
+        // long basis, the rest covered the short.
+        const longProportion = newQuantity.div(legQuantity);
+        costBasis = amount.times(longProportion);
+        refCostBasis = refAmount.times(longProportion);
+      } else {
+        costBasis = costBasis.plus(amount);
+        refCostBasis = refCostBasis.plus(refAmount);
+      }
+      quantity = newQuantity;
+    } else if (tx.category === SELL) {
+      if (quantity.gt(0)) {
+        const newQuantity = quantity.minus(legQuantity);
+        if (newQuantity.lte(0)) {
+          costBasis = new Big(0);
+          refCostBasis = new Big(0);
+        } else {
+          const remainingProportion = newQuantity.div(quantity);
+          costBasis = costBasis.times(remainingProportion);
+          refCostBasis = refCostBasis.times(remainingProportion);
+        }
+      }
+      // Selling from a zero/short position leaves the basis untouched.
+      quantity = quantity.minus(legQuantity);
+    }
+  }
+
+  return {
+    costBasis: costBasis.lt(0) ? new Big(0) : costBasis,
+    refCostBasis: refCostBasis.lt(0) ? new Big(0) : refCostBasis,
+  };
+}
+
+module.exports = {
+  // Exported only so a unit test can assert this frozen fold stays identical to
+  // the live `computeHoldingTotals`. The migration runner ignores extra keys.
+  foldCostBasis,
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    const sequelize = queryInterface.sequelize;
+
+    const holdings = await sequelize.query<HoldingRow>(`SELECT "portfolioId", "securityId" FROM "Holdings"`, {
+      type: QueryTypes.SELECT,
+    });
+
+    let updated = 0;
+    const failedHoldings: string[] = [];
+
+    for (const holding of holdings) {
+      try {
+        const transactions = await sequelize.query<TransactionRow>(
+          `SELECT "category", "quantity", "amount", "refAmount"
+           FROM "InvestmentTransactions"
+           WHERE "portfolioId" = :portfolioId AND "securityId" = :securityId
+           ORDER BY "date" ASC, "createdAt" ASC`,
+          {
+            replacements: { portfolioId: holding.portfolioId, securityId: holding.securityId },
+            type: QueryTypes.SELECT,
+          },
+        );
+
+        const { costBasis, refCostBasis } = foldCostBasis({ transactions });
+
+        await sequelize.query(
+          `UPDATE "Holdings"
+           SET "costBasis" = :costBasis, "refCostBasis" = :refCostBasis, "updatedAt" = NOW()
+           WHERE "portfolioId" = :portfolioId AND "securityId" = :securityId`,
+          {
+            replacements: {
+              costBasis: costBasis.toFixed(10),
+              refCostBasis: refCostBasis.toFixed(10),
+              portfolioId: holding.portfolioId,
+              securityId: holding.securityId,
+            },
+            type: QueryTypes.UPDATE,
+          },
+        );
+        updated += 1;
+      } catch (error) {
+        failedHoldings.push(`${holding.portfolioId}/${holding.securityId}`);
+        if (process.env.NODE_ENV !== 'test') {
+          console.error(`Failed to recalculate holding ${holding.portfolioId}/${holding.securityId}:`, error);
+        }
+      }
+    }
+
+    if (process.env.NODE_ENV !== 'test') {
+      if (failedHoldings.length > 0) {
+        // Loud + greppable: these holdings still carry the stale, pre-fix cost
+        // basis this migration was meant to correct, and the migration is marked
+        // applied regardless — surface them as one block so they can be retargeted.
+        console.error(
+          `Holding cost basis recalculation: ${updated} updated, ${failedHoldings.length} FAILED. ` +
+            `Stale cost basis remains on (portfolioId/securityId): ${failedHoldings.join(', ')}`,
+        );
+      } else {
+        console.log(`Holding cost basis recalculation complete: ${updated} updated, 0 failed`);
+      }
+    }
+  },
+
+  down: async (): Promise<void> => {
+    // No-op: the pre-fix cost basis values were incorrect and are not restored.
+  },
+};

--- a/packages/backend/src/services/investments/holdings/holding-totals.ts
+++ b/packages/backend/src/services/investments/holdings/holding-totals.ts
@@ -1,0 +1,121 @@
+import { INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
+import { Big } from 'big.js';
+
+export interface HoldingTotalsLeg {
+  category: INVESTMENT_TRANSACTION_CATEGORY;
+  /** Signed share count for the leg (always positive in this model; direction comes from `category`). */
+  quantity: Big;
+  /** Total cost of the leg in the holding's own currency (price × quantity + fees). */
+  amount: Big;
+  /** Same as `amount`, expressed in the user's base currency. */
+  refAmount: Big;
+}
+
+interface HoldingTotals {
+  quantity: Big;
+  costBasis: Big;
+  refCostBasis: Big;
+}
+
+/**
+ * Replays a holding's transactions into its current quantity and cost basis.
+ *
+ * Cost basis tracks the cost of the *current long position* only:
+ * - While the running quantity is ≤ 0 there is no long position, so the basis
+ *   is zero.
+ * - A BUY that crosses from short/zero into long counts only the portion above
+ *   zero; the rest merely covered the short.
+ * - A BUY on top of an existing long position adds its full cost.
+ * - A SELL reduces the basis proportionally to the shares remaining, and a SELL
+ *   that drains the position to zero resets the basis. This is what makes a
+ *   same-day wash sale (sell the whole position, then rebuy) keep only the
+ *   rebuy lot.
+ *
+ * The replay is order-sensitive: `transactions` MUST be supplied in
+ * chronological (date, then insertion) order. A rebuy seen before the sell that
+ * liquidated the previous lots would blend their cost into the basis instead of
+ * resetting it.
+ *
+ * NOTES:
+ * - The `quantity ≤ 0 ⇒ basis 0` guard is load-bearing, not defensive: without
+ *   it, a SELL taken while the running quantity is negative computes a negative
+ *   `remaining / total` proportion and *adds* to the basis instead of reducing
+ *   it, which can balloon the cost basis (e.g. crypto positions that drift
+ *   negative on fee/staking rows).
+ * - DIVIDEND and FEE legs intentionally affect neither quantity nor basis here;
+ *   they are accounted for elsewhere.
+ */
+export const computeHoldingTotals = ({ transactions }: { transactions: HoldingTotalsLeg[] }): HoldingTotals => {
+  let totalQuantity = new Big(0);
+  let totalCostBasis = new Big(0);
+  let totalRefCostBasis = new Big(0);
+
+  for (const { category, quantity, amount, refAmount } of transactions) {
+    switch (category) {
+      case INVESTMENT_TRANSACTION_CATEGORY.buy: {
+        const newQuantity = totalQuantity.plus(quantity);
+        if (newQuantity.lte(0)) {
+          // Still short after the buy — no long position to attribute cost to.
+          totalCostBasis = new Big(0);
+          totalRefCostBasis = new Big(0);
+        } else if (totalQuantity.lte(0)) {
+          // Crosses from short/zero into long; only the portion above zero is
+          // new long basis, the rest covered the short.
+          const longProportion = newQuantity.div(quantity);
+          totalCostBasis = amount.times(longProportion);
+          totalRefCostBasis = refAmount.times(longProportion);
+        } else {
+          totalCostBasis = totalCostBasis.plus(amount);
+          totalRefCostBasis = totalRefCostBasis.plus(refAmount);
+        }
+        totalQuantity = newQuantity;
+        break;
+      }
+
+      case INVESTMENT_TRANSACTION_CATEGORY.sell: {
+        if (totalQuantity.gt(0)) {
+          const newQuantity = totalQuantity.minus(quantity);
+          if (newQuantity.lte(0)) {
+            totalCostBasis = new Big(0);
+            totalRefCostBasis = new Big(0);
+          } else {
+            const remainingProportion = newQuantity.div(totalQuantity);
+            totalCostBasis = totalCostBasis.times(remainingProportion);
+            totalRefCostBasis = totalRefCostBasis.times(remainingProportion);
+          }
+        }
+        // Selling from a zero/short position leaves the basis untouched.
+        totalQuantity = totalQuantity.minus(quantity);
+        break;
+      }
+
+      // Categories that move neither the position nor its cost basis. Listed
+      // exhaustively (with the default guard below) so a newly added category
+      // fails to compile here until its effect is decided, rather than being
+      // silently treated as a no-op.
+      case INVESTMENT_TRANSACTION_CATEGORY.dividend:
+      case INVESTMENT_TRANSACTION_CATEGORY.fee:
+      case INVESTMENT_TRANSACTION_CATEGORY.transfer:
+      case INVESTMENT_TRANSACTION_CATEGORY.tax:
+      case INVESTMENT_TRANSACTION_CATEGORY.cancel:
+      case INVESTMENT_TRANSACTION_CATEGORY.other:
+        break;
+
+      default: {
+        // Exhaustiveness guard: erased at runtime (the column is a constrained
+        // enum), but breaks the build if the enum gains a member.
+        const exhaustiveCheck: never = category;
+        return exhaustiveCheck;
+      }
+    }
+  }
+
+  // Cost basis floors at zero. The long-position replay above never yields a
+  // negative basis, but clamp at the return so callers don't each re-apply it
+  // (and so this matches the migration's frozen fold, which clamps the same way).
+  return {
+    quantity: totalQuantity,
+    costBasis: totalCostBasis.lt(0) ? new Big(0) : totalCostBasis,
+    refCostBasis: totalRefCostBasis.lt(0) ? new Big(0) : totalRefCostBasis,
+  };
+};

--- a/packages/backend/src/services/investments/holdings/holding-totals.unit.ts
+++ b/packages/backend/src/services/investments/holdings/holding-totals.unit.ts
@@ -1,0 +1,210 @@
+import { INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
+import { describe, expect, it } from '@jest/globals';
+import { Big } from 'big.js';
+
+import { type HoldingTotalsLeg, computeHoldingTotals } from './holding-totals';
+
+const buy = (quantity: number, amount: number, refAmount = amount): HoldingTotalsLeg => ({
+  category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+  quantity: new Big(quantity),
+  amount: new Big(amount),
+  refAmount: new Big(refAmount),
+});
+
+// Sell proceeds don't affect cost basis (basis reduces proportionally to shares
+// left), so the amount is irrelevant — pass it only for readability.
+const sell = (quantity: number, proceeds = 0, refProceeds = proceeds): HoldingTotalsLeg => ({
+  category: INVESTMENT_TRANSACTION_CATEGORY.sell,
+  quantity: new Big(quantity),
+  amount: new Big(proceeds),
+  refAmount: new Big(refProceeds),
+});
+
+const nonPositional = (category: INVESTMENT_TRANSACTION_CATEGORY, amount = 0): HoldingTotalsLeg => ({
+  category,
+  quantity: new Big(0),
+  amount: new Big(amount),
+  refAmount: new Big(amount),
+});
+
+const totals = (transactions: HoldingTotalsLeg[]) => {
+  const result = computeHoldingTotals({ transactions });
+  return {
+    quantity: result.quantity.toNumber(),
+    costBasis: result.costBasis.toNumber(),
+    refCostBasis: result.refCostBasis.toNumber(),
+  };
+};
+
+describe('computeHoldingTotals', () => {
+  describe('replay order sensitivity (the wash-sale bug)', () => {
+    // The three legs of a full wash sale: an old cheap lot, the sell that
+    // liquidates it, and the rebuy. The recalculation service feeds these in
+    // (date, createdAt) order; these two tests pin down WHY that ordering
+    // matters by replaying the very same legs both ways.
+    const oldLot = buy(10, 500); // 10 @ $50
+    const liquidate = sell(10, 600); // 10 @ $60
+    const rebuy = buy(10, 700); // 10 @ $70
+
+    it('resets the basis to the rebuy lot when the sell precedes the rebuy', () => {
+      expect(totals([oldLot, liquidate, rebuy])).toEqual({
+        quantity: 10,
+        costBasis: 700, // rebuy lot only
+        refCostBasis: 700,
+      });
+    });
+
+    it('blends the liquidated lot into the basis when the rebuy precedes the sell', () => {
+      // Identical legs, rebuy before the sell — the corruption that an
+      // unordered same-day replay produced (AC/Share $60 instead of $70).
+      expect(totals([oldLot, rebuy, liquidate])).toEqual({
+        quantity: 10,
+        costBasis: 600, // (500 + 700) halved by the sell
+        refCostBasis: 600,
+      });
+    });
+  });
+
+  it('keeps the surviving lot plus the rebuy on a partial wash sale', () => {
+    // 20 @ $40 (basis 800), sell 15 (5 survive → basis 200), rebuy 15 @ $60 (+900).
+    expect(totals([buy(20, 800), sell(15, 750), buy(15, 900)])).toEqual({
+      quantity: 20,
+      costBasis: 1100,
+      refCostBasis: 1100,
+    });
+  });
+
+  it('resets to the latest lot across multiple sell-all/rebuy cycles', () => {
+    expect(totals([buy(10, 500), sell(10, 600), buy(10, 700), sell(10, 800), buy(10, 900)])).toEqual({
+      quantity: 10,
+      costBasis: 900, // only the final rebuy survives
+      refCostBasis: 900,
+    });
+  });
+
+  it('does not inflate the basis when the position is sold below zero', () => {
+    // Selling from a flat position drives quantity negative (allowed for crypto
+    // drift). Without the "quantity ≤ 0 ⇒ basis 0" guard, the later buy's
+    // proportional math would balloon the basis instead of leaving it at zero.
+    expect(totals([sell(5, 300), buy(3, 210)])).toEqual({
+      quantity: -2,
+      costBasis: 0,
+      refCostBasis: 0,
+    });
+  });
+
+  it('counts only the above-zero portion when a buy crosses from short to long', () => {
+    // sell 5 from flat → qty -5, basis 0; buy 8 @ $800 → crosses to +3. Only the
+    // 3 shares above zero are basis: 800 × (3/8) = 300 (the rest covered the short).
+    expect(totals([sell(5, 300), buy(8, 800)])).toEqual({
+      quantity: 3,
+      costBasis: 300,
+      refCostBasis: 300,
+    });
+  });
+
+  it('tracks refCostBasis independently of costBasis through a full reset', () => {
+    // Distinct own-currency vs base-currency amounts must stay in lockstep
+    // through the reset and rebuy.
+    expect(totals([buy(10, 500, 450), sell(10), buy(10, 700, 630)])).toEqual({
+      quantity: 10,
+      costBasis: 700,
+      refCostBasis: 630,
+    });
+  });
+
+  it('scales costBasis and refCostBasis independently through a partial sell', () => {
+    // buy 20 (own $800 / base $720), sell 15 → 5 remain, proportion 5/20 = 0.25.
+    // Each currency leg scales by the same proportion off its own running total.
+    expect(totals([buy(20, 800, 720), sell(15)])).toEqual({
+      quantity: 5,
+      costBasis: 200, // 800 × 0.25
+      refCostBasis: 180, // 720 × 0.25
+    });
+  });
+
+  it('treats dividend and fee legs as no-ops for quantity and basis', () => {
+    expect(
+      totals([
+        buy(10, 500),
+        nonPositional(INVESTMENT_TRANSACTION_CATEGORY.dividend, 50),
+        nonPositional(INVESTMENT_TRANSACTION_CATEGORY.fee, 5),
+      ]),
+    ).toEqual({
+      quantity: 10,
+      costBasis: 500,
+      refCostBasis: 500,
+    });
+  });
+
+  it('returns zeroes for an empty transaction list', () => {
+    expect(totals([])).toEqual({ quantity: 0, costBasis: 0, refCostBasis: 0 });
+  });
+});
+
+/**
+ * The migration `20260620000000-recalculate-holding-cost-basis` cannot import
+ * `computeHoldingTotals` — the production image ships only `dist/` + `src/migrations`,
+ * not the service layer — so it inlines a frozen copy (`foldCostBasis`) driven by
+ * raw SQL string rows instead of Big/enum legs. This pins the two implementations
+ * together: if the copy ever drifts from the live fold, these assertions fail.
+ */
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const migration = require('../../../migrations/20260620000000-recalculate-holding-cost-basis');
+const foldCostBasis = migration.foldCostBasis as (args: {
+  transactions: { category: string; quantity: string; amount: string; refAmount: string }[];
+}) => { costBasis: Big; refCostBasis: Big };
+
+describe('migration foldCostBasis parity with computeHoldingTotals', () => {
+  // Raw rows in the shape the migration reads from Postgres (DECIMAL → string).
+  type RawRow = { category: string; quantity: string; amount: string; refAmount: string };
+  const SCENARIOS: { name: string; rows: RawRow[] }[] = [
+    {
+      name: 'full same-day wash sale',
+      rows: [
+        { category: 'buy', quantity: '10', amount: '500', refAmount: '450' },
+        { category: 'sell', quantity: '10', amount: '600', refAmount: '540' },
+        { category: 'buy', quantity: '10', amount: '700', refAmount: '630' },
+      ],
+    },
+    {
+      name: 'partial sell then rebuy',
+      rows: [
+        { category: 'buy', quantity: '20', amount: '800', refAmount: '720' },
+        { category: 'sell', quantity: '15', amount: '750', refAmount: '675' },
+        { category: 'buy', quantity: '15', amount: '900', refAmount: '810' },
+      ],
+    },
+    {
+      name: 'buy crossing from short to long',
+      rows: [
+        { category: 'sell', quantity: '5', amount: '300', refAmount: '270' },
+        { category: 'buy', quantity: '8', amount: '800', refAmount: '640' },
+      ],
+    },
+    {
+      name: 'dividend and fee no-ops',
+      rows: [
+        { category: 'buy', quantity: '10', amount: '500', refAmount: '500' },
+        { category: 'dividend', quantity: '0', amount: '50', refAmount: '50' },
+        { category: 'fee', quantity: '0', amount: '5', refAmount: '5' },
+      ],
+    },
+    { name: 'empty ledger', rows: [] },
+  ];
+
+  it.each(SCENARIOS)('produces identical cost basis for: $name', ({ rows }) => {
+    const live = computeHoldingTotals({
+      transactions: rows.map((r) => ({
+        category: r.category as INVESTMENT_TRANSACTION_CATEGORY,
+        quantity: new Big(r.quantity),
+        amount: new Big(r.amount),
+        refAmount: new Big(r.refAmount),
+      })),
+    });
+    const frozen = foldCostBasis({ transactions: rows });
+
+    expect(frozen.costBasis.toFixed(10)).toBe(live.costBasis.toFixed(10));
+    expect(frozen.refCostBasis.toFixed(10)).toBe(live.refCostBasis.toFixed(10));
+  });
+});

--- a/packages/backend/src/services/investments/holdings/recalculation.service.ts
+++ b/packages/backend/src/services/investments/holdings/recalculation.service.ts
@@ -1,4 +1,4 @@
-import { ASSET_CLASS, INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
+import { ASSET_CLASS } from '@bt/shared/types/investments';
 import { Money } from '@common/types/money';
 import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
 import { t } from '@i18n/index';
@@ -6,7 +6,8 @@ import Holdings from '@models/investments/holdings.model';
 import InvestmentTransaction from '@models/investments/investment-transaction.model';
 import Securities from '@models/investments/securities.model';
 import { withTransaction } from '@services/common/with-transaction';
-import { Big } from 'big.js';
+
+import { computeHoldingTotals } from './holding-totals';
 
 const recalculateHoldingImpl = async (holdingId: { portfolioId: string; securityId: string }) => {
   const holding = await findOrThrowNotFound({
@@ -17,83 +18,44 @@ const recalculateHoldingImpl = async (holdingId: { portfolioId: string; security
     message: t({ key: 'investments.holdingNotFoundForRecalculation' }),
   });
 
+  // Same-day transactions replay in insertion order (createdAt) so a full wash
+  // sale — sell the whole position, then rebuy it on the same calendar date —
+  // resets the cost basis before the rebuy instead of blending the liquidated
+  // lots into it. `date` is DATEONLY, so without the createdAt tiebreaker
+  // Postgres is free to return the rebuy ahead of the sell and inflate
+  // AC/Share. Matches the ordering used by the balance-history and
+  // annualized-returns replays.
   const transactions = await InvestmentTransaction.findAll({
     where: {
       portfolioId: holding.portfolioId,
       securityId: holding.securityId,
     },
-    order: [['date', 'ASC']],
+    order: [
+      ['date', 'ASC'],
+      ['createdAt', 'ASC'],
+    ],
   });
 
-  let totalQuantity = new Big(0);
-  let totalCostBasis = new Big(0);
-  let totalRefCostBasis = new Big(0);
-
-  for (const tx of transactions) {
-    const quantity = tx.quantity.toBig();
-    const amount = tx.amount.toBig();
-    const refAmount = tx.refAmount.toBig();
-
-    // Invariant: cost basis represents the cost of the *current long position*.
-    // While running quantity is ≤ 0 (allowed for crypto drift), there is no
-    // long position, so cost basis must stay zero. Otherwise, average-cost
-    // tracking on the long portion. Without this invariant, the previous code
-    // silently inflated cost basis: a SELL while qty was negative produced a
-    // negative `quantity / totalQuantity` proportion and *added* to cost
-    // instead of reducing it (seen as a $1.27M cost basis on 0.28 BTC after a
-    // realistic Yahoo CSV import).
-    switch (tx.category) {
-      case INVESTMENT_TRANSACTION_CATEGORY.buy: {
-        const newQuantity = totalQuantity.plus(quantity);
-        if (newQuantity.lte(0)) {
-          // Buy that doesn't bring the position out of short — no long position
-          // to attribute cost to.
-          totalCostBasis = new Big(0);
-          totalRefCostBasis = new Big(0);
-        } else if (totalQuantity.lte(0)) {
-          // Buy crosses from short/zero into a long position. Only the portion
-          // above zero counts as a new long basis; the rest just covered the short.
-          const longProportion = newQuantity.div(quantity);
-          totalCostBasis = amount.times(longProportion);
-          totalRefCostBasis = refAmount.times(longProportion);
-        } else {
-          totalCostBasis = totalCostBasis.plus(amount);
-          totalRefCostBasis = totalRefCostBasis.plus(refAmount);
-        }
-        totalQuantity = newQuantity;
-        break;
-      }
-
-      case INVESTMENT_TRANSACTION_CATEGORY.sell: {
-        if (totalQuantity.gt(0)) {
-          const newQuantity = totalQuantity.minus(quantity);
-          if (newQuantity.lte(0)) {
-            totalCostBasis = new Big(0);
-            totalRefCostBasis = new Big(0);
-          } else {
-            const remainingProportion = newQuantity.div(totalQuantity);
-            totalCostBasis = totalCostBasis.times(remainingProportion);
-            totalRefCostBasis = totalRefCostBasis.times(remainingProportion);
-          }
-        }
-        // Sell from zero/short position doesn't touch cost basis.
-        totalQuantity = totalQuantity.minus(quantity);
-        break;
-      }
-
-      case INVESTMENT_TRANSACTION_CATEGORY.dividend:
-      case INVESTMENT_TRANSACTION_CATEGORY.fee:
-        // These do not affect quantity or cost basis in this model
-        break;
-    }
-  }
+  const {
+    quantity: totalQuantity,
+    costBasis: totalCostBasis,
+    refCostBasis: totalRefCostBasis,
+  } = computeHoldingTotals({
+    transactions: transactions.map((tx) => ({
+      category: tx.category,
+      quantity: tx.quantity.toBig(),
+      amount: tx.amount.toBig(),
+      refAmount: tx.refAmount.toBig(),
+    })),
+  });
 
   // Crypto holdings may legitimately go negative (staking/fee drift) until the
   // user reconciles via a "mark as zero" adjustment; stocks always cap at zero.
   const allowNegativeQuantity = holding.security?.assetClass === ASSET_CLASS.crypto;
   holding.quantity = Money.fromDecimal(!allowNegativeQuantity && totalQuantity.lt(0) ? '0' : totalQuantity.toFixed(10));
-  holding.costBasis = Money.fromDecimal(totalCostBasis.lt(0) ? '0' : totalCostBasis.toFixed(10));
-  holding.refCostBasis = Money.fromDecimal(totalRefCostBasis.lt(0) ? '0' : totalRefCostBasis.toFixed(10));
+  // costBasis / refCostBasis are already floored at zero by computeHoldingTotals.
+  holding.costBasis = Money.fromDecimal(totalCostBasis.toFixed(10));
+  holding.refCostBasis = Money.fromDecimal(totalRefCostBasis.toFixed(10));
   await holding.save();
 
   return holding;

--- a/packages/backend/src/services/investments/transactions/same-day-wash-sale.e2e.ts
+++ b/packages/backend/src/services/investments/transactions/same-day-wash-sale.e2e.ts
@@ -1,0 +1,231 @@
+import { INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
+import { describe, expect, it } from '@jest/globals';
+import Portfolios from '@models/investments/portfolios.model';
+import Securities from '@models/investments/securities.model';
+import * as helpers from '@tests/helpers';
+
+/**
+ * Cost-basis replay ordering for same-day SELL+BUY, exercised through the real
+ * create-transaction HTTP path.
+ *
+ * A holding's cost basis represents the cost of the *current* long position.
+ * When the whole position is sold and rebought on the same calendar date (a
+ * wash sale), AC/Share must reflect only the rebuy lot — the liquidated lots
+ * are gone and must not blend into it. Recalculation replays transactions in
+ * (date, createdAt) order: `date` settles the calendar day, `createdAt` settles
+ * same-day order so the sell drains the position to zero (resetting the basis)
+ * before the rebuy rebuilds it.
+ *
+ * Scope of these tests: they confirm the fold + recalc trigger produce the right
+ * basis end-to-end, and the back-dated case below has real teeth for the `date`
+ * dimension. They do NOT reproduce the original nondeterministic-ordering bug:
+ * on a fresh DB Postgres returns same-day rows in insertion order regardless of
+ * the `createdAt` tiebreaker, so these would pass even with the tiebreaker
+ * removed. The deterministic regression guard for the tiebreaker (same legs,
+ * two orders → different basis) lives in `holding-totals.unit.ts`.
+ */
+describe('Same-day SELL+BUY cost-basis ordering', () => {
+  let investmentPortfolio: Portfolios;
+  let security: Securities;
+
+  beforeEach(async () => {
+    investmentPortfolio = await helpers.createPortfolio({
+      payload: helpers.buildPortfolioPayload({ name: 'Wash Sale Test Portfolio' }),
+      raw: true,
+    });
+
+    const seededSecurities: Securities[] = await helpers.seedSecurities([
+      { symbol: 'MSFT', name: 'Microsoft Corporation' },
+    ]);
+    const seededMsft = seededSecurities.find((s) => s.symbol === 'MSFT');
+    if (!seededMsft) throw new Error('MSFT security not found after seeding');
+    security = seededMsft;
+
+    await helpers.createHolding({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+      },
+    });
+  });
+
+  const getHolding = async () => {
+    const [holding] = await helpers.getHoldings({
+      portfolioId: investmentPortfolio.id,
+      payload: { securityId: security.id },
+      raw: true,
+    });
+    expect(holding).toBeTruthy();
+    return holding!;
+  };
+
+  it('resets cost basis to the rebuy lot when the full position is sold then rebought same day', async () => {
+    // Old cheap lot — must NOT bleed into AC/Share after the wash sale.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-01-01',
+        quantity: '10',
+        price: '50',
+      },
+    });
+
+    // Sell the entire position (basis resets to 0).
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.sell,
+        date: '2026-03-01',
+        quantity: '10',
+        price: '60',
+      },
+    });
+
+    // Rebuy the position the same day (new lot only).
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-03-01',
+        quantity: '10',
+        price: '70',
+      },
+    });
+
+    const holding = await getHolding();
+    expect(holding.quantity).toBeNumericEqual(10);
+    // 10 @ $70 = $700, NOT $500 (old lot) or any blend of the two.
+    expect(holding.costBasis).toBeNumericEqual(700);
+  });
+
+  it('keeps the surviving lot plus the rebuy on a partial same-day wash sale', async () => {
+    // 20 @ $40 → basis $800.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-01-01',
+        quantity: '20',
+        price: '40',
+      },
+    });
+
+    // Sell 15 → 5 survive, basis reduces proportionally to $200.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.sell,
+        date: '2026-03-01',
+        quantity: '15',
+        price: '50',
+      },
+    });
+
+    // Rebuy 15 @ $60 the same day → adds $900.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-03-01',
+        quantity: '15',
+        price: '60',
+      },
+    });
+
+    const holding = await getHolding();
+    expect(holding.quantity).toBeNumericEqual(20);
+    // 5 surviving @ $40 ($200) + 15 new @ $60 ($900) = $1100.
+    expect(holding.costBasis).toBeNumericEqual(1100);
+  });
+
+  it('resets to the latest lot across multiple sell-all/rebuy cycles on the same day', async () => {
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-01-01',
+        quantity: '10',
+        price: '50',
+      },
+    });
+
+    // Three sell-all/rebuy cycles, all on the same day, in insertion order.
+    const sameDayCycle: Array<{ category: INVESTMENT_TRANSACTION_CATEGORY; price: string }> = [
+      { category: INVESTMENT_TRANSACTION_CATEGORY.sell, price: '60' },
+      { category: INVESTMENT_TRANSACTION_CATEGORY.buy, price: '70' },
+      { category: INVESTMENT_TRANSACTION_CATEGORY.sell, price: '80' },
+      { category: INVESTMENT_TRANSACTION_CATEGORY.buy, price: '90' },
+    ];
+    for (const leg of sameDayCycle) {
+      await helpers.createInvestmentTransaction({
+        payload: {
+          portfolioId: investmentPortfolio.id,
+          securityId: security.id,
+          category: leg.category,
+          date: '2026-03-01',
+          quantity: '10',
+          price: leg.price,
+        },
+      });
+    }
+
+    const holding = await getHolding();
+    expect(holding.quantity).toBeNumericEqual(10);
+    // Only the final rebuy survives: 10 @ $90 = $900.
+    expect(holding.costBasis).toBeNumericEqual(900);
+  });
+
+  it('replays by calendar date, not insertion order, when a sell is back-dated between two buys', async () => {
+    // Inserted first, earliest date.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-01-01',
+        quantity: '10',
+        price: '50',
+      },
+    });
+
+    // Inserted second, latest date — this is the lot that must survive.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.buy,
+        date: '2026-03-05',
+        quantity: '10',
+        price: '70',
+      },
+    });
+
+    // Inserted last but dated BETWEEN the two buys. By date it liquidates the
+    // first lot before the second is bought; by insertion order it would wrongly
+    // sell against the combined position and leave a blended basis.
+    await helpers.createInvestmentTransaction({
+      payload: {
+        portfolioId: investmentPortfolio.id,
+        securityId: security.id,
+        category: INVESTMENT_TRANSACTION_CATEGORY.sell,
+        date: '2026-02-01',
+        quantity: '10',
+        price: '60',
+      },
+    });
+
+    const holding = await getHolding();
+    expect(holding.quantity).toBeNumericEqual(10);
+    // Date order (buy@50 → sell-all → buy@70) leaves 10 @ $70 = $700.
+    // Insertion order would have left a blended $600 — this asserts the former.
+    expect(holding.costBasis).toBeNumericEqual(700);
+  });
+});


### PR DESCRIPTION
Adds a createdAt tiebreaker so a same-day wash sale resets the basis before the rebuy, with a backfill migration to correct existing holdings