### PR TITLE
fix(share): coerce resourceId string to number in zod schema

### DIFF
--- a/packages/backend/src/controllers/share/create-invitation.ts
+++ b/packages/backend/src/controllers/share/create-invitation.ts
@@ -10,7 +10,7 @@ const schema = z.object({
   body: z.object({
     inviteeEmail: z.string().email().max(320).trim(),
     resourceType: shareableResourceTypeEnum,
-    resourceId: z.union([z.number().int().positive(), recordId()]),
+    resourceId: z.union([z.coerce.number().int().positive(), recordId()]),
     permission: z.enum([SHARE_PERMISSIONS.read, SHARE_PERMISSIONS.write, SHARE_PERMISSIONS.manage] as const),
     policy: z
       .object({


### PR DESCRIPTION
### Problem

Household invitation fails with `resourceId: Invalid input`. Root cause: zod schema uses `z.number().int().positive()` but JSON payload sends the ID as string `"1"` because `JSON.stringify` serialises all values as strings when the frontend does `String(myHouseholdId.value)`.

### Fix

```diff
- resourceId: z.union([z.number().int().positive(), recordId()]),
+ resourceId: z.union([z.coerce.number().int().positive(), recordId()]),
```

`z.coerce.number()` at parse time converts `"1"` → `1`, while UUID strings produce `NaN` and correctly fall through to `recordId()`.

Service layer already handles `resourceId: number | string` — this is purely a zod gate issue.

### Related

Closes #382

### Checklist

- [x] Backend change only (one line)
- [x] No migration or DB changes needed
- [x] Service layer already expects `number | string`