### PR TITLE
Revalidate persisted query cache after restore

### DIFF
--- a/packages/frontend/src/composable/use-sync-status.ts
+++ b/packages/frontend/src/composable/use-sync-status.ts
@@ -1,6 +1,6 @@
 import * as bankDataProvidersApi from '@/api/bank-data-providers';
 import type { SyncStatusResponse } from '@/api/bank-data-providers';
-import { VUE_QUERY_CACHE_KEYS } from '@/common/const';
+import { VUE_QUERY_CACHE_KEYS, VUE_QUERY_GLOBAL_PREFIXES } from '@/common/const';
 import type { AccountGroups } from '@/common/types/models';
 import { ensureChunkLoaded } from '@/i18n';
 import { useAuthStore } from '@/stores/auth';
@@ -48,7 +48,7 @@ const justCompleted = ref(false);
 const syncStuck = ref(false);
 let stuckTimer: ReturnType<typeof setTimeout> | null = null;
 
-// SSE subscription state — one shared subscription regardless of how many
+// SSE subscription state – one shared subscription regardless of how many
 // consumers mount.
 let sseUnsubscribe: (() => void) | null = null;
 let isSSESubscribed = false;
@@ -60,7 +60,7 @@ export function useSyncStatus() {
   const { isLoggedIn } = storeToRefs(useAuthStore());
 
   // Provider names show up in the always-visible header popover regardless of
-  // which page the user is on, but live in the integrations route chunk —
+  // which page the user is on, but live in the integrations route chunk –
   // pull it eagerly so the tooltip resolves before the user hovers.
   void ensureChunkLoaded('pages/account-integrations');
 
@@ -119,7 +119,7 @@ export function useSyncStatus() {
   });
 
   // Built once per reactivity tick so per-account / per-group lookups stay O(1)
-  // — three different sidebar/details components query this for every render.
+  // – three different sidebar/details components query this for every render.
   const reauthConnectionIdsSet = computed(() => new Set(connectionsNeedingReauth.value.map((c) => c.connectionId)));
 
   function isAccountNeedingReauth(account: Pick<AccountModel, 'bankDataProviderConnectionId'>): boolean {
@@ -133,7 +133,7 @@ export function useSyncStatus() {
 
   // Walk the group tree (direct accounts + nested child groups) so a mixed-
   // content group still surfaces a warning when any descendant account is on
-  // an expired connection — important because groups can hold both bank-linked
+  // an expired connection – important because groups can hold both bank-linked
   // and manual accounts side by side. Tolerant of undefined arrays so a
   // partial cache payload doesn't crash the sidebar.
   function groupHasReauthAccount(group: AccountGroups): boolean {
@@ -185,7 +185,7 @@ export function useSyncStatus() {
    * through the shared query cache via the app-level `queryClient` (stable across
    * component instances). It is registered once at module scope and outlives the
    * component that first opened it, so it must not close over this instance's
-   * `syncStatusData` / `rawIsSyncing` computeds — those stop updating once that
+   * `syncStatusData` / `rawIsSyncing` computeds – those stop updating once that
    * component unmounts, whereas the cache is always current.
    */
   const subscribeToSSE = () => {
@@ -204,11 +204,12 @@ export function useSyncStatus() {
       if (wasSyncingBefore && !isPayloadSyncing(snapshot)) {
         justCompleted.value = true;
 
-        // A finished sync can fuzzy-create payees and always shifts the
-        // transaction-count stats carried in the payee list. payeesList sits
-        // outside the transactionChange prefix, so invalidate it explicitly here —
-        // this is the one hook that observes every completed sync regardless of
-        // which page triggered it.
+        // This is the one hook that observes every completed sync, so it owns
+        // invalidating everything a sync touches. payeesList is named explicitly
+        // because a sync fuzzy-creates payees and shifts their transaction-count
+        // stats, yet sits outside both prefixes above.
+        queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.transactionChange] });
+        queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.bankConnectionChange] });
         queryClient.invalidateQueries({ queryKey: VUE_QUERY_CACHE_KEYS.payeesList });
 
         setTimeout(() => {
@@ -238,7 +239,7 @@ export function useSyncStatus() {
     isSSESubscribed = false;
   };
 
-  // Attach the shared SSE subscription and open the connection. Idempotent —
+  // Attach the shared SSE subscription and open the connection. Idempotent –
   // subscribeToSSE no-ops when already subscribed.
   const ensureSSEConnected = async () => {
     subscribeToSSE();

--- a/packages/frontend/src/lib/query-client.ts
+++ b/packages/frontend/src/lib/query-client.ts
@@ -3,7 +3,7 @@ import { ApiErrorResponseError, AuthError, UnexpectedError } from '@/js/errors';
 import { API_ERROR_CODES } from '@bt/shared/types';
 import { QueryClient, type QueryKey } from '@tanstack/vue-query';
 
-import { persistedQueryFn } from './query-persister';
+import { persistedImmutableQueryFn, persistedQueryFn } from './query-persister';
 
 // Client-terminal codes: the caller cannot fix by retrying (auth/permission
 // gaps, missing resources, malformed requests). Transient codes like
@@ -45,24 +45,18 @@ export const queryClient = new QueryClient({
   },
 });
 
-// Rarely-changing, non-financial queries that are safe to restore instantly from
-// disk on reload (stale-while-revalidate: cached data shows immediately while a
-// background refetch runs). Volatile data — transactions, balances, cash-flow,
-// stats, notifications, sync status — is intentionally excluded.
+// Data worth painting from disk before the network answers. Volatile data
+// (transactions, balances history, cash-flow, stats, notifications, sync status)
+// stays off this list – restoring it would flash figures wrong more often than right.
 //
-// Keys are matched by PREFIX, so filtered variants (e.g. subscriptions with a
-// filter suffix) are covered by their stable base key. Each prefix is chosen to
-// avoid overlapping a volatile sibling under the same global prefix.
+// Matched by PREFIX, so every variant of a key (a filtered subscriptions list, a
+// payee search term) persists as its own entry, and each prefix must avoid
+// overlapping a volatile sibling under the same global prefix.
 //
-// INVARIANT: only persist queries kept fresh by invalidate/refetch on mutation.
-// The persister writes to IndexedDB from its own fetch path only, so a query
-// updated optimistically via `queryClient.setQueryData` (never refetched) would
-// leave a stale snapshot on disk and restore it on the next reload. `userSettings`
-// is the abolished candidate here — its mutations use setQueryData, so persisting
-// it made a reordered dashboard revert after reload; it stays off this list.
+// A restored snapshot is always confirmed by one background refetch on idle (see
+// `persistedQueryFn`), so a key needs no mutation-time freshness guarantee to belong
+// here – whatever wrote to it is picked up on the next load.
 const PERSISTED_QUERY_KEY_PREFIXES: readonly QueryKey[] = [
-  // Static reference data
-  VUE_QUERY_CACHE_KEYS.allCurrencies,
   VUE_QUERY_CACHE_KEYS.userCurrencies,
   VUE_QUERY_CACHE_KEYS.baseCurrency,
   VUE_QUERY_CACHE_KEYS.categoriesList,
@@ -74,17 +68,15 @@ const PERSISTED_QUERY_KEY_PREFIXES: readonly QueryKey[] = [
   VUE_QUERY_CACHE_KEYS.portfoliosList,
   VUE_QUERY_CACHE_KEYS.loansList,
   VUE_QUERY_CACHE_KEYS.subscriptionsList,
-  // Linked-bank list — changes only on link/unlink/reauth, all of which invalidate
-  // the whole bankConnectionChange prefix. The full two-element key is deliberate:
-  // it excludes the volatile bank-sync-status sibling living under the same prefix.
+  // The full two-element key is deliberate: it excludes the volatile
+  // bank-sync-status sibling living under the same prefix.
   VUE_QUERY_CACHE_KEYS.bankConnections,
-  // Payee autocomplete list. Every path that creates a payee or shifts its
-  // transaction-count stats — payee CRUD, bulk categorization, CSV import, and
-  // bank sync — invalidates payeesList, so restoring it from disk is safe. The
-  // infinite management-table variant shares this prefix but keeps a finite
-  // staleTime, so it restores instantly and still revalidates in the background.
   VUE_QUERY_CACHE_KEYS.payeesList,
 ];
+
+// The ISO currency table can't change while a build is live – restore-and-trust,
+// no confirming request (see `persistedImmutableQueryFn`).
+const IMMUTABLE_PERSISTED_QUERY_KEY_PREFIXES: readonly QueryKey[] = [VUE_QUERY_CACHE_KEYS.allCurrencies];
 
 // Attach the persister centrally via query defaults so individual useQuery call
 // sites stay untouched. Per-call options still win over these defaults, and no
@@ -92,5 +84,11 @@ const PERSISTED_QUERY_KEY_PREFIXES: readonly QueryKey[] = [
 if (persistedQueryFn) {
   for (const queryKey of PERSISTED_QUERY_KEY_PREFIXES) {
     queryClient.setQueryDefaults(queryKey, { persister: persistedQueryFn });
+  }
+}
+
+if (persistedImmutableQueryFn) {
+  for (const queryKey of IMMUTABLE_PERSISTED_QUERY_KEY_PREFIXES) {
+    queryClient.setQueryDefaults(queryKey, { persister: persistedImmutableQueryFn });
   }
 }

--- a/packages/frontend/src/lib/query-persister.test.ts
+++ b/packages/frontend/src/lib/query-persister.test.ts
@@ -24,23 +24,43 @@ vi.mock('idb-keyval', () => ({
 // asserting on storage / simulating a reload.
 const flushScheduler = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+// The confirming refetch is queued behind requestIdleCallback (stubbed onto the
+// macrotask queue below) and is itself async, so drain twice.
+const flushIdle = async () => {
+  await flushScheduler();
+  await flushScheduler();
+};
+
 let persistedQueryFn: NonNullable<Awaited<ReturnType<typeof loadModule>>['persistedQueryFn']>;
+let persistedImmutableQueryFn: NonNullable<Awaited<ReturnType<typeof loadModule>>['persistedImmutableQueryFn']>;
 
 const loadModule = () => import('@/lib/query-persister');
 
 // A fresh QueryClient shares the in-memory `memory` store but starts with an empty
-// in-memory cache — i.e. what a full page reload gives you.
+// in-memory cache – i.e. what a full page reload gives you.
 const freshClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
+// staleTime: Infinity throughout – the worst case for restore staleness, and what
+// several whitelisted call sites really declare.
 const fetchThrough = <T>(client: QueryClient, queryKey: QueryKey, queryFn: QueryFunction<T>) =>
   client.fetchQuery({ queryKey, queryFn, persister: persistedQueryFn, staleTime: Infinity });
+
+const fetchThroughImmutable = <T>(client: QueryClient, queryKey: QueryKey, queryFn: QueryFunction<T>) =>
+  client.fetchQuery({ queryKey, queryFn, persister: persistedImmutableQueryFn, staleTime: Infinity });
 
 beforeAll(async () => {
   // jsdom ships no IndexedDB; presence is all the availability guard checks.
   vi.stubGlobal('indexedDB', {});
+  // jsdom ships no requestIdleCallback either. Put the callback on the macrotask
+  // queue so `flushIdle` can drive it deterministically, instead of leaving the
+  // module on its 2s setTimeout fallback.
+  vi.stubGlobal('requestIdleCallback', (cb: () => void) => setTimeout(cb, 0));
   const mod = await loadModule();
   if (!mod.persistedQueryFn) throw new Error('persister should be enabled when indexedDB is present');
+  if (!mod.persistedImmutableQueryFn)
+    throw new Error('immutable persister should be enabled when indexedDB is present');
   persistedQueryFn = mod.persistedQueryFn;
+  persistedImmutableQueryFn = mod.persistedImmutableQueryFn;
 });
 
 afterAll(() => {
@@ -51,7 +71,7 @@ beforeEach(() => {
   memory.clear();
 });
 
-describe('query persister — empty snapshots are not persisted', () => {
+describe('query persister – empty snapshots are not persisted', () => {
   it('does not persist an empty list result', async () => {
     await fetchThrough(freshClient(), ['accounts'], async () => []);
     await flushScheduler();
@@ -75,7 +95,7 @@ describe('query persister — empty snapshots are not persisted', () => {
 
   it('drops a previously-persisted entry once its list becomes empty in-session', async () => {
     // Same client throughout: the query already holds data, so a refetch runs the
-    // queryFn (rather than restoring from disk) — the path a user hits by deleting
+    // queryFn (rather than restoring from disk) – the path a user hits by deleting
     // their last account. The now-empty result must prune the stale disk entry.
     const client = freshClient();
     let result: { id: number }[] = [{ id: 1 }];
@@ -91,7 +111,7 @@ describe('query persister — empty snapshots are not persisted', () => {
   });
 });
 
-describe('query persister — restore behaviour across a reload', () => {
+describe('query persister – restore behaviour across a reload', () => {
   it('refetches after an empty snapshot so data seeded out-of-band appears', async () => {
     // First load: user has no accounts yet -> empty result, nothing persisted.
     await fetchThrough(freshClient(), ['accounts'], async () => []);
@@ -109,17 +129,98 @@ describe('query persister — restore behaviour across a reload', () => {
     expect(data).toEqual([{ id: 'seeded' }]);
   });
 
-  it('restores a non-empty snapshot from disk without refetching', async () => {
+  it('paints a non-empty snapshot from disk without a request on the critical path', async () => {
     await fetchThrough(freshClient(), ['portfolios'], async () => [{ id: 1 }]);
     await flushScheduler();
 
     let calls = 0;
     const data = await fetchThrough(freshClient(), ['portfolios'], async () => {
       calls += 1;
-      return [];
+      return [{ id: 1 }, { id: 2 }];
     });
 
-    expect(calls).toBe(0);
     expect(data).toEqual([{ id: 1 }]);
+    expect(calls).toBe(0);
+  });
+
+  it('confirms a restored snapshot with a background refetch once idle', async () => {
+    await fetchThrough(freshClient(), ['portfolios'], async () => [{ id: 1 }]);
+    await flushScheduler();
+
+    let calls = 0;
+    const client = freshClient();
+    await fetchThrough(client, ['portfolios'], async () => {
+      calls += 1;
+      return [{ id: 1 }, { id: 2 }];
+    });
+
+    await flushIdle();
+
+    // Confirm fires unconditionally, independent of staleTime/maxAge – this is how
+    // out-of-band writes (another device, an import) surface after restore.
+    expect(calls).toBe(1);
+    expect(client.getQueryData(['portfolios'])).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('writes the confirmed data back to disk so the next reload restores it', async () => {
+    await fetchThrough(freshClient(), ['portfolios'], async () => [{ id: 1 }]);
+    await flushScheduler();
+
+    await fetchThrough(freshClient(), ['portfolios'], async () => [{ id: 1 }, { id: 2 }]);
+    await flushIdle();
+    await flushScheduler();
+
+    const persisted = JSON.parse([...memory.values()][0]!) as { state: { data: unknown } };
+    expect(persisted.state.data).toEqual([{ id: 1 }, { id: 2 }]);
+  });
+
+  it('confirms exactly once – the background refetch does not re-defer', async () => {
+    await fetchThrough(freshClient(), ['portfolios'], async () => [{ id: 1 }]);
+    await flushScheduler();
+
+    let calls = 0;
+    await fetchThrough(freshClient(), ['portfolios'], async () => {
+      calls += 1;
+      return [{ id: 1 }, { id: 2 }];
+    });
+
+    await flushIdle();
+    await flushIdle();
+
+    // Re-entering with data already cached fails the restore gate (see
+    // `persistedQueryFn`), so this run hits queryFn directly – nothing left to confirm.
+    expect(calls).toBe(1);
+  });
+
+  it('does not schedule a second request when there was no snapshot to confirm', async () => {
+    let calls = 0;
+    await fetchThrough(freshClient(), ['portfolios'], async () => {
+      calls += 1;
+      return [{ id: 1 }];
+    });
+
+    await flushIdle();
+
+    // A cold fetch already went to the network; confirming it would be a duplicate.
+    expect(calls).toBe(1);
+  });
+});
+
+describe('query persister – immutable reference data', () => {
+  it('restores without any confirming request', async () => {
+    await fetchThroughImmutable(freshClient(), ['currencies', 'all'], async () => [{ code: 'USD' }]);
+    await flushScheduler();
+
+    let calls = 0;
+    const data = await fetchThroughImmutable(freshClient(), ['currencies', 'all'], async () => {
+      calls += 1;
+      return [{ code: 'USD' }, { code: 'EUR' }];
+    });
+
+    await flushIdle();
+
+    // Only key that's genuinely zero-request – see `persistedImmutableQueryFn`.
+    expect(data).toEqual([{ code: 'USD' }]);
+    expect(calls).toBe(0);
   });
 });

--- a/packages/frontend/src/lib/query-persister.ts
+++ b/packages/frontend/src/lib/query-persister.ts
@@ -3,16 +3,20 @@ import {
   type PersistedQuery,
   experimental_createQueryPersister,
 } from '@tanstack/query-persist-client-core';
-import type { QueryClient } from '@tanstack/vue-query';
-import { type UseStore, clear, createStore, del, get, set } from 'idb-keyval';
+import type { Query, QueryClient, QueryFunctionContext, QueryKey } from '@tanstack/vue-query';
+import { type UseStore, clear, createStore, del, entries, get, set } from 'idb-keyval';
 
 // Discard restored entries older than a day so a user who returns after a long
 // break refetches from scratch rather than seeing day-stale figures.
 const MAX_PERSISTED_AGE_MS = 24 * 60 * 60 * 1000;
 
+// Deadline passed to requestIdleCallback, so the confirming refetch fires even if
+// the main thread never idles.
+const REVALIDATE_IDLE_TIMEOUT_MS = 2000;
+
 // A persisted entry only earns its keep if it carries real data. An empty list or
-// a null singleton captured before the user has any data — e.g. the accounts list
-// fetched right after signup, before any account exists — would otherwise be
+// a null singleton captured before the user has any data – e.g. the accounts list
+// fetched right after signup, before any account exists – would otherwise be
 // restored on the next load and, because whitelisted queries use `staleTime:
 // Infinity`, be treated as fresh. Data created out-of-band in the meantime (another
 // device, an import) would then stay invisible until the 24h maxAge elapses. Skip
@@ -40,6 +44,8 @@ const idbStorage: AsyncStorage<string> | undefined = persistedQueryStore
       setItem: (key, value) =>
         value === SKIP_PERSIST_SENTINEL ? del(key, persistedQueryStore) : set(key, value, persistedQueryStore),
       removeItem: (key) => del(key, persistedQueryStore),
+      // Lets `persisterGc` enumerate rows (see `collectPersistedQueryGarbage`).
+      entries: () => entries<string, string>(persistedQueryStore),
     }
   : undefined;
 
@@ -53,16 +59,82 @@ const persister = idbStorage
       serialize: (persistedQuery) =>
         isEmptyQueryData(persistedQuery.state.data) ? SKIP_PERSIST_SENTINEL : JSON.stringify(persistedQuery),
       deserialize: (cached) => JSON.parse(cached) as PersistedQuery,
+      // `persistedQueryFn` below drives the confirming refetch on a delay instead;
+      // the built-in `refetchOnRestore` fires it instantly, defeating that deferral.
+      refetchOnRestore: false,
     })
   : undefined;
+
+// Mirrors `useIdleEnabled` minus the Vue scope – runs from a query's fetch path,
+// which has no component lifetime to tie a handle to.
+const scheduleWhenIdle = (task: () => void): void => {
+  if (typeof window !== 'undefined' && typeof window.requestIdleCallback === 'function') {
+    window.requestIdleCallback(() => task(), { timeout: REVALIDATE_IDLE_TIMEOUT_MS });
+  } else {
+    setTimeout(task, REVALIDATE_IDLE_TIMEOUT_MS);
+  }
+};
 
 /**
  * The query-level persister function. Pass as the `persister` option (directly or
  * via `queryClient.setQueryDefaults`) on queries whose data is safe to restore
- * from disk. `undefined` when IndexedDB is unavailable — queries then run
+ * from disk. `undefined` when IndexedDB is unavailable – queries then run
  * unpersisted with no extra handling at the call site.
+ *
+ * A restored snapshot paints immediately, then is confirmed by one background
+ * refetch on browser idle – deferred because a dashboard load already fans out
+ * ~40-50 requests, and confirming immediately would put every persisted key back
+ * on the critical path it was persisted to stay off. Persistence buys instant
+ * paint, not fewer requests.
+ *
+ * Detected by whether `queryFn` ran: `persisterFn` calls it only when there's
+ * nothing usable to restore. The deferred `query.fetch()` re-enters with
+ * `state.data` already set, which fails that restore gate – so it runs `queryFn`
+ * directly and never re-defers.
  */
-export const persistedQueryFn = persister?.persisterFn;
+export const persistedQueryFn = persister
+  ? async <T, TQueryKey extends QueryKey>(
+      queryFn: (context: QueryFunctionContext<TQueryKey>) => T | Promise<T>,
+      context: QueryFunctionContext<TQueryKey>,
+      query: Query,
+    ): Promise<T> => {
+      let servedFromNetwork = false;
+      const trackedQueryFn = (ctx: QueryFunctionContext<TQueryKey>) => {
+        servedFromNetwork = true;
+        return queryFn(ctx);
+      };
+
+      const result = (await persister.persisterFn(trackedQueryFn, context, query)) as T;
+
+      if (!servedFromNetwork) {
+        // Failures surface through the query's own error state; caught only so a
+        // rejected background fetch isn't an unhandled rejection.
+        scheduleWhenIdle(() => void query.fetch().catch(() => {}));
+      }
+
+      return result;
+    }
+  : undefined;
+
+/**
+ * Persister for data that cannot change while a build is live, so a restored
+ * snapshot needs no confirming request at all. `buster: __APP_VERSION__` refetches
+ * it on the next deploy.
+ *
+ * Reserve this for genuinely immutable reference data. Anything a user, a cron, or
+ * another device can write must use `persistedQueryFn` – a snapshot with no
+ * revalidation is only correct if nothing can invalidate it.
+ */
+export const persistedImmutableQueryFn = persister?.persisterFn;
+
+/**
+ * Expire abandoned entries – rows whose key is no longer read through the
+ * persister, which lazy-on-read expiry can never reach.
+ */
+export const collectPersistedQueryGarbage = async (): Promise<void> => {
+  if (!persister) return;
+  await persister.persisterGc();
+};
 
 /**
  * Wipe every persisted query entry from IndexedDB. Called on logout and when a
@@ -77,7 +149,7 @@ export const clearPersistedQueries = async (): Promise<void> => {
  * Full on-device query-cache teardown: cancel in-flight queries (so nothing
  * refetches and re-persists mid-teardown), drop the in-memory cache, then wipe
  * the persisted IndexedDB store. Shared by every "no cached data may survive"
- * flow — logout, user-switch, and the destructive data wipe — so none of them
+ * flow – logout, user-switch, and the destructive data wipe – so none of them
  * can forget the persisted store and leave one state restoring another's data.
  */
 export const resetQueryCaches = async (queryClient: QueryClient): Promise<void> => {

--- a/packages/frontend/src/stores/auth.ts
+++ b/packages/frontend/src/stores/auth.ts
@@ -3,7 +3,7 @@ import { isMobileSheetOpen } from '@/composable/global-state/mobile-sheet';
 import { UnexpectedError } from '@/js/errors';
 import { authClient, getSession, signIn, signOut, signUp } from '@/lib/auth-client';
 import { identifyUser, resetUser } from '@/lib/posthog';
-import { resetQueryCaches } from '@/lib/query-persister';
+import { collectPersistedQueryGarbage, resetQueryCaches } from '@/lib/query-persister';
 import { clearSentryUser, setSentryUser } from '@/lib/sentry';
 import { useCategoriesStore, useCurrenciesStore, useUserStore } from '@/stores';
 import { OAUTH_PROVIDER, USER_ROLES, UserModel } from '@bt/shared/types';
@@ -88,6 +88,9 @@ export const useAuthStore = defineStore('auth', () => {
    */
   const loadPostAuthData = async () => {
     await reconcilePersistedQueriesForUser();
+    // Sweep abandoned persisted-query rows (see `collectPersistedQueryGarbage`);
+    // not awaited – nothing below depends on it.
+    void collectPersistedQueryGarbage();
     await Promise.all([currenciesStore.loadBaseCurrency(), categoriesStore.loadCategories()]);
   };
 

--- a/packages/frontend/src/stores/categories/categories.ts
+++ b/packages/frontend/src/stores/categories/categories.ts
@@ -27,13 +27,16 @@ export const useCategoriesStore = defineStore('categories', () => {
   // Routes through the vue-query cache (staleTime Infinity) so the list dedupes on init
   // and can be persisted/invalidated by key. `force` marks the cached entry stale first,
   // so post-mutation reloads (category CRUD, imports, accepting a share) pull fresh data.
+  //
+  // `fetchQuery`, not `ensureQueryData` – the latter short-circuits on present data
+  // and would hand back the entry `force` just invalidated, making the flag inert.
   const loadCategories = async ({ force = false }: { force?: boolean } = {}) => {
     try {
       if (force) {
         await queryClient.invalidateQueries({ queryKey: VUE_QUERY_CACHE_KEYS.categoriesList });
       }
 
-      const result = await queryClient.ensureQueryData({
+      const result = await queryClient.fetchQuery({
         queryKey: VUE_QUERY_CACHE_KEYS.categoriesList,
         queryFn: loadSystemCategories,
         staleTime: Infinity,

--- a/packages/frontend/src/stores/currencies.ts
+++ b/packages/frontend/src/stores/currencies.ts
@@ -41,6 +41,9 @@ export const useCurrenciesStore = defineStore('currencies', () => {
   // Both fetches run through the vue-query cache (staleTime Infinity) so they dedupe on
   // init and can be persisted/invalidated by key. `force` marks the cached entries stale
   // first, so post-mutation reloads pull fresh data instead of returning the cache.
+  //
+  // `fetchQuery`, not `ensureQueryData` – the latter short-circuits on present data
+  // and would hand back the entry `force` just invalidated, making the flag inert.
   const loadCurrencies = async ({ force = false }: { force?: boolean } = {}) => {
     if (force) {
       await Promise.all([
@@ -50,12 +53,12 @@ export const useCurrenciesStore = defineStore('currencies', () => {
     }
 
     const [userCurrencies, systemOnes] = await Promise.all([
-      queryClient.ensureQueryData({
+      queryClient.fetchQuery({
         queryKey: VUE_QUERY_CACHE_KEYS.userCurrencies,
         queryFn: loadUserCurrencies,
         staleTime: Infinity,
       }),
-      queryClient.ensureQueryData({
+      queryClient.fetchQuery({
         queryKey: VUE_QUERY_CACHE_KEYS.allCurrencies,
         queryFn: getAllCurrencies,
         staleTime: Infinity,
@@ -74,7 +77,7 @@ export const useCurrenciesStore = defineStore('currencies', () => {
       await queryClient.invalidateQueries({ queryKey: VUE_QUERY_CACHE_KEYS.baseCurrency });
     }
 
-    const result = await queryClient.ensureQueryData({
+    const result = await queryClient.fetchQuery({
       queryKey: VUE_QUERY_CACHE_KEYS.baseCurrency,
       queryFn: loadUserBaseCurrency,
       staleTime: Infinity,


### PR DESCRIPTION
Invalidation never reached IndexedDB, so a restored snapshot could serve stale data until the 24h maxAge elapsed; every restore now confirms itself with one background refetch on idle