### PR TITLE
Fix numbers formatting for zero-decimal currencies

### DIFF
--- a/packages/frontend/src/components/dialogs/tag-form-dialog.vue
+++ b/packages/frontend/src/components/dialogs/tag-form-dialog.vue
@@ -80,7 +80,7 @@
                 <p class="text-muted-foreground text-xs">
                   {{ getReminderScheduleLabel(reminder) }}
                   <template v-if="getAmountThreshold(reminder)">
-                    &middot; {{ formatCurrency(getAmountThreshold(reminder)!) }}
+                    &middot; {{ formatBaseCurrency(getAmountThreshold(reminder)!) }}
                   </template>
                 </p>
               </div>
@@ -130,8 +130,9 @@ import TagReminderForm from '@/components/dialogs/tag-reminder-form.vue';
 import { Button } from '@/components/lib/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/lib/ui/tabs';
 import { useNotificationCenter } from '@/components/notification-center';
+import { useFormatCurrency } from '@/composable';
 import { ApiErrorResponseError } from '@/js/errors';
-import { useCurrenciesStore, useTagsStore } from '@/stores';
+import { useTagsStore } from '@/stores';
 import {
   TAG_REMINDER_FREQUENCIES,
   TAG_REMINDER_TYPES,
@@ -177,8 +178,8 @@ const closeReminderDialog = () => {
 
 const { t } = useI18n();
 const tagsStore = useTagsStore();
-const currenciesStore = useCurrenciesStore();
 const { addErrorNotification, addSuccessNotification } = useNotificationCenter();
+const { formatBaseCurrency } = useFormatCurrency();
 
 const isEditMode = computed(() => !!props.tag);
 
@@ -255,17 +256,6 @@ const getFrequencyLabel = (frequency: TagReminderFrequency) => {
 const getAmountThreshold = (reminder: TagReminderModel): number | undefined => {
   const settings = reminder.settings as { amountThreshold?: number } | undefined;
   return settings?.amountThreshold;
-};
-
-const formatCurrency = (amount: number) => {
-  const baseCurrency = currenciesStore.baseCurrency;
-  const currencyCode = baseCurrency?.currency?.code || 'USD';
-  // Amount is already in display format (API layer converts from system amount)
-  return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: currencyCode,
-    maximumFractionDigits: 2,
-  }).format(amount);
 };
 
 const DEFAULT_TAG_COLOR = '#3b82f6';

--- a/packages/frontend/src/js/helpers/formatters.spec.ts
+++ b/packages/frontend/src/js/helpers/formatters.spec.ts
@@ -1,4 +1,4 @@
-import { formatFiat, formatUIAmount } from './formatters';
+import { formatFiat, formatUIAmount, toLocalCurrencyNumber } from './formatters';
 
 describe('js/helpers/formatters', () => {
   describe('formatUIAmount', () => {
@@ -12,6 +12,85 @@ describe('js/helpers/formatters', () => {
       [Infinity, 'Infinity'],
     ])('%s to be %s', (value, expected) => {
       expect(formatUIAmount(value)).toBe(expected);
+    });
+  });
+
+  describe('formatUIAmount per-currency decimals', () => {
+    test.each<[string, number, string]>([
+      ['KRW', 1234.5, '1,235'],
+      ['KRW', 1_000_000, '1,000,000'],
+      ['JPY', 1234.5, '1,235'],
+    ])('zero-decimal currency %s drops the fraction: %d', (currency, value, grouped) => {
+      const out = formatUIAmount(value, { currency });
+      expect(out).toContain(grouped);
+      expect(out).not.toContain('.');
+    });
+
+    test('negative value in a zero-decimal currency keeps the sign, no fraction', () => {
+      const out = formatUIAmount(-1234.5, { currency: 'KRW' });
+      expect(out).toContain('-');
+      expect(out).toContain('1,235');
+      expect(out).not.toContain('.');
+    });
+
+    test('zero in a zero-decimal currency renders without fraction', () => {
+      const out = formatUIAmount(0, { currency: 'KRW' });
+      expect(out).toContain('0');
+      expect(out).not.toContain('.');
+    });
+
+    test.each<[number, string]>([
+      [1234.5, '$1,234.50'],
+      [1, '$1.00'],
+      [10_000, '$10,000.00'],
+    ])('two-decimal currency (USD) is unchanged: %d → %s', (value, expected) => {
+      expect(formatUIAmount(value, { currency: 'USD' })).toBe(expected);
+    });
+
+    test('three-decimal currency (BHD) is clamped to 2 (cents storage)', () => {
+      const out = formatUIAmount(1234.567, { currency: 'BHD' });
+      expect(out).toContain('1,234.57');
+      expect(out).not.toMatch(/\.\d{3}/);
+    });
+
+    test('malformed currency code degrades to a bare number + code instead of throwing', () => {
+      expect(formatUIAmount(1234.5, { currency: 'USDT' })).toBe('1,234.50 USDT');
+    });
+  });
+
+  describe('toLocalCurrencyNumber (bare number, no symbol)', () => {
+    test.each<[number, string, string]>([
+      [1500, 'KRW', '1,500'],
+      [7_188_072.8, 'KRW', '7,188,073'],
+      [1500, 'JPY', '1,500'],
+      [1500, 'USD', '1,500.00'],
+      [1500.5, 'USD', '1,500.50'],
+    ])('%d in %s → %s', (value, currency, expected) => {
+      expect(toLocalCurrencyNumber(value, { currency })).toBe(expected);
+    });
+
+    test('renders no currency symbol', () => {
+      const out = toLocalCurrencyNumber(1500, { currency: 'KRW' });
+      expect(out).not.toContain('₩');
+      expect(out).not.toContain('.');
+    });
+
+    test('defaults to 2 digits when currency is omitted', () => {
+      expect(toLocalCurrencyNumber(1500)).toBe('1,500.00');
+    });
+
+    test('three-decimal currency (BHD) is clamped to 2 (cents storage)', () => {
+      expect(toLocalCurrencyNumber(1234.567, { currency: 'BHD' })).toBe('1,234.57');
+    });
+
+    test('malformed currency code falls back to 2 digits without throwing', () => {
+      expect(toLocalCurrencyNumber(1234.5, { currency: 'USDT' })).toBe('1,234.50');
+    });
+
+    test('explicit fraction digits override the currency-derived default', () => {
+      expect(
+        toLocalCurrencyNumber(1234.5, { currency: 'KRW', minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+      ).toBe('1,234.50');
     });
   });
 

--- a/packages/frontend/src/js/helpers/formatters.ts
+++ b/packages/frontend/src/js/helpers/formatters.ts
@@ -16,16 +16,53 @@ export function toLocalNumber(
   return String(value);
 }
 
+// Fraction digits a fiat currency renders per ISO-4217/CLDR (KRW→0, USD→2, BHD→3),
+// clamped to 2 because Money stores cents (×100) so only 2 decimals are ever real.
+// Codes Intl rejects (malformed, e.g. a stray ticker from DB data) resolve to null so
+// callers can skip currency-styled formatting instead of crashing the render. Cached —
+// building an Intl formatter per render is costly.
+const currencyFractionDigitsCache = new Map<string, number | null>();
+
+function resolveCurrencyDigits(currency: string): number | null {
+  const cached = currencyFractionDigitsCache.get(currency);
+  if (cached !== undefined) return cached;
+
+  let digits: number | null;
+  try {
+    const cldrDigits = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency,
+    }).resolvedOptions().maximumFractionDigits;
+    digits = Math.min(cldrDigits ?? 2, 2);
+  } catch {
+    digits = null;
+  }
+
+  currencyFractionDigitsCache.set(currency, digits);
+  return digits;
+}
+
 function toLocalFiatCurrency(
   value: string | number | undefined | null,
   options: Intl.NumberFormatOptions = {},
 ): string {
   if (value !== undefined && value !== null) {
+    const currency = options.currency || 'USD';
+    const currencyDigits = resolveCurrencyDigits(currency);
+    // Intl rejects the code — render a bare 2-decimal number with the code appended
+    // instead of letting toLocaleString throw a RangeError mid-render.
+    if (currencyDigits === null) {
+      return `${toLocalNumber(value, {
+        minimumFractionDigits: options.minimumFractionDigits ?? 2,
+        maximumFractionDigits: options.maximumFractionDigits ?? 2,
+        useGrouping: options.useGrouping ?? true,
+      })} ${currency}`;
+    }
     return toLocalNumber(value, {
       ...options,
-      minimumFractionDigits: options.minimumFractionDigits ?? 2,
-      maximumFractionDigits: options.maximumFractionDigits ?? 2,
-      currency: options.currency ?? 'USD',
+      minimumFractionDigits: options.minimumFractionDigits ?? currencyDigits,
+      maximumFractionDigits: options.maximumFractionDigits ?? currencyDigits,
+      currency,
       currencyDisplay: options.currencyDisplay ?? 'symbol',
       useGrouping: options.useGrouping ?? true,
       style: 'currency',
@@ -35,12 +72,34 @@ function toLocalFiatCurrency(
 }
 
 /**
+ * Bare amount (no symbol) with the fraction digits its currency uses — for the
+ * "1,500 KRW" layout where the code is rendered separately. KRW → "1,500", USD →
+ * "1,500.00". Unknown/non-ISO codes fall back to 2.
+ */
+export function toLocalCurrencyNumber(
+  value: string | number | undefined | null,
+  options: Omit<Intl.NumberFormatOptions, 'style' | 'currency' | 'currencyDisplay'> & {
+    /** ISO-4217 code whose fraction digits to apply; only affects digits, never adds a symbol. */
+    currency?: string;
+    locale?: Intl.LocalesArgument;
+  } = {},
+): string {
+  const { currency, ...numberOptions } = options;
+  const digits = resolveCurrencyDigits(currency || 'USD') ?? 2;
+  return toLocalNumber(value, {
+    ...numberOptions,
+    minimumFractionDigits: numberOptions.minimumFractionDigits ?? digits,
+    maximumFractionDigits: numberOptions.maximumFractionDigits ?? digits,
+  });
+}
+
+/**
  * Format large numbers to be like:
  *
  * 1,000 - 9,999
  * 100,000 / 100k - 999,999 / 999.99k
  * 100,000,000 / 100m - 999,999,999 / 999.99m
- * @param {number} number - The number to format
+ * @param {number} value - The number to format
  * @param {string} options.thousandSuffix - suffix for thousands
  * @param {string} options.millionSuffix - suffix for millions
  * @param {string} options.billionSuffix - suffix for billions
@@ -103,6 +162,8 @@ export function formatLargeNumber(
 
   const formatterFunc = options.isFiat ? toLocalFiatCurrency : toLocalNumber;
 
+  // Fraction digits here are scale digits ("₩12.35k" = ₩12,350), not currency sub-units,
+  // so per-currency digit resolution deliberately doesn't apply.
   const formatted = formatterFunc(localNumber / delimiter, {
     maximumFractionDigits: options.maximumFractionDigits ?? 2,
     minimumFractionDigits: options.minimumFractionDigits ?? 0,

--- a/packages/frontend/src/pages/account/components/account-details-tab.vue
+++ b/packages/frontend/src/pages/account/components/account-details-tab.vue
@@ -4,7 +4,7 @@ import * as Collapsible from '@/components/lib/ui/collapsible';
 import { Separator } from '@/components/lib/ui/separator';
 import * as Tabs from '@/components/lib/ui/tabs';
 import { useAccountCurrencyCode } from '@/composable/use-account-currency-code';
-import { toLocalNumber } from '@/js/helpers';
+import { toLocalCurrencyNumber } from '@/js/helpers';
 import { useCurrenciesStore } from '@/stores';
 import { ACCOUNT_TYPES, AccountModel } from '@bt/shared/types';
 import { ChevronDownIcon, ChevronUpIcon } from '@lucide/vue';
@@ -35,7 +35,7 @@ const currencyCode = useAccountCurrencyCode({ account: toRef(() => props.account
         <span>{{ t('pages.account.details.creditLimit') }}</span>
 
         <div class="flex items-center gap-1.5">
-          <span>{{ toLocalNumber(account.creditLimit) }} {{ currencyCode }}</span>
+          <span>{{ toLocalCurrencyNumber(account.creditLimit, { currency: currencyCode }) }} {{ currencyCode }}</span>
 
           <CreditLimitEditPopover v-if="isSystemAccount" :account="account" :currency-code="currencyCode" />
         </div>
@@ -45,7 +45,7 @@ const currencyCode = useAccountCurrencyCode({ account: toRef(() => props.account
       <div class="flex items-center justify-between gap-2">
         <span>{{ t('pages.account.details.initialBalance') }}</span>
 
-        {{ toLocalNumber(account.initialBalance) }} {{ currencyCode }}
+        {{ toLocalCurrencyNumber(account.initialBalance, { currency: currencyCode }) }} {{ currencyCode }}
       </div>
       <Separator />
       <div class="flex items-center justify-between gap-2">

--- a/packages/frontend/src/pages/account/components/balance-adjustment-dialog.vue
+++ b/packages/frontend/src/pages/account/components/balance-adjustment-dialog.vue
@@ -8,7 +8,7 @@ import { useFormValidation } from '@/composable';
 import { useAdjustAccountBalance } from '@/composable/data-queries/accounts';
 import { useAccountCurrencyCode } from '@/composable/use-account-currency-code';
 import { useAccountDisplayBalance } from '@/composable/use-account-display-balance';
-import { toLocalNumber } from '@/js/helpers';
+import { toLocalCurrencyNumber } from '@/js/helpers';
 import * as validators from '@/js/helpers/validators';
 import { captureException } from '@/lib/sentry';
 import { cn } from '@/lib/utils';
@@ -229,9 +229,11 @@ watch(mode, () => {
         </template>
         <template v-else>
           <p class="text-muted-foreground mb-1 text-sm">
-            {{ toLocalNumber(displayBalance) }} {{ currencyCode }}
+            {{ toLocalCurrencyNumber(displayBalance, { currency: currencyCode }) }} {{ currencyCode }}
             →
-            <span class="text-foreground font-medium">{{ toLocalNumber(displayTarget!) }} {{ currencyCode }}</span>
+            <span class="text-foreground font-medium"
+              >{{ toLocalCurrencyNumber(displayTarget!, { currency: currencyCode }) }} {{ currencyCode }}</span
+            >
           </p>
           <p
             class="text-sm font-medium"
@@ -240,11 +242,11 @@ watch(mode, () => {
             {{
               previewType === 'income'
                 ? label('incomeWillBeCreated', {
-                    amount: toLocalNumber(Math.abs(diff)),
+                    amount: toLocalCurrencyNumber(Math.abs(diff), { currency: currencyCode }),
                     currency: currencyCode,
                   })
                 : label('expenseWillBeCreated', {
-                    amount: toLocalNumber(Math.abs(diff)),
+                    amount: toLocalCurrencyNumber(Math.abs(diff), { currency: currencyCode }),
                     currency: currencyCode,
                   })
             }}

--- a/packages/frontend/src/pages/account/components/header.vue
+++ b/packages/frontend/src/pages/account/components/header.vue
@@ -16,7 +16,7 @@ import { useNotificationCenter } from '@/components/notification-center';
 import { useFormValidation } from '@/composable';
 import { useAccountAccess } from '@/composable/use-account-access';
 import { useAccountDisplayBalance } from '@/composable/use-account-display-balance';
-import { toLocalNumber } from '@/js/helpers';
+import { toLocalCurrencyNumber } from '@/js/helpers';
 import * as validators from '@/js/helpers/validators';
 import { useAccountsStore, useCurrenciesStore } from '@/stores';
 import { ACCOUNT_TYPES, AccountModel, SHARE_PERMISSIONS, TRANSACTIONS_WRITE_SCOPES } from '@bt/shared/types';
@@ -213,23 +213,23 @@ watch([formEditingPopoverOpen, () => props.account.id], () => {
           @click="adjustmentDialogOpen = true"
         >
           <span class="text-amount text-3xl">
-            {{ toLocalNumber(displayBalance) }}
+            {{ toLocalCurrencyNumber(displayBalance, { currency: account.currencyCode }) }}
             {{ currenciesMap[account.currencyCode]?.currency?.code }}
           </span>
           <span v-if="baseCurrency && account.currencyCode !== baseCurrency.currencyCode" class="text-white opacity-50">
             ~
-            {{ toLocalNumber(displayRefBalance) }}
+            {{ toLocalCurrencyNumber(displayRefBalance, { currency: baseCurrency.currencyCode }) }}
             {{ baseCurrency.currency?.code }}
           </span>
         </button>
         <div v-else class="flex flex-wrap items-end justify-start gap-2">
           <span class="text-amount text-3xl">
-            {{ toLocalNumber(displayBalance) }}
+            {{ toLocalCurrencyNumber(displayBalance, { currency: account.currencyCode }) }}
             {{ currenciesMap[account.currencyCode]?.currency?.code }}
           </span>
           <span v-if="baseCurrency && account.currencyCode !== baseCurrency.currencyCode" class="text-white opacity-50">
             ~
-            {{ toLocalNumber(displayRefBalance) }}
+            {{ toLocalCurrencyNumber(displayRefBalance, { currency: baseCurrency.currencyCode }) }}
             {{ baseCurrency.currency?.code }}
           </span>
         </div>

--- a/packages/frontend/src/pages/loans/components/loan-form.vue
+++ b/packages/frontend/src/pages/loans/components/loan-form.vue
@@ -6,7 +6,7 @@ import InputField from '@/components/fields/input-field.vue';
 import SelectField from '@/components/fields/select-field.vue';
 import UiButton from '@/components/lib/ui/button/Button.vue';
 import { DesktopOnlyTooltip } from '@/components/lib/ui/tooltip';
-import { useCurrencyName } from '@/composable';
+import { useCurrencyName, useFormatCurrency } from '@/composable';
 import { useFormValidation } from '@/composable/form-validator';
 import { useCurrenciesStore } from '@/stores';
 import { type CurrencyModel, LOAN_TYPE, SUPPORTED_LOAN_TYPES } from '@bt/shared/types';
@@ -46,6 +46,7 @@ const isEdit = computed(() => props.mode === 'edit');
 const { t } = useI18n();
 const currenciesStore = useCurrenciesStore();
 const { formatCurrencyLabel } = useCurrencyName();
+const { formatAmountByCurrencyCode } = useFormatCurrency();
 const { baseCurrency, systemCurrenciesVerbose } = storeToRefs(currenciesStore);
 
 const defaultCurrency = computed(
@@ -130,16 +131,6 @@ const selectedCurrency = computed(
 const currencyLabel = (item: CurrencyModel): string =>
   formatCurrencyLabel({ code: item.code, fallbackName: item.currency });
 
-const currencyFormatter = computed(
-  () =>
-    new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency: form.currencyCode || 'USD',
-      maximumFractionDigits: 2,
-      minimumFractionDigits: 2,
-    }),
-);
-
 // Amortization over what's left: M = B·r·(1+r)^m / ((1+r)^m − 1), where B is the outstanding
 // balance and m the months remaining in the term. Interest accrues on the current balance, so for
 // an off-schedule loan (extra payments, missed payments, mid-life creation) this yields the payment
@@ -169,7 +160,7 @@ const estimatedMinPayment = computed<number | null>(() => {
 
 const estimatedMinPaymentLabel = computed(() => {
   if (estimatedMinPayment.value === null) return null;
-  return currencyFormatter.value.format(estimatedMinPayment.value);
+  return formatAmountByCurrencyCode(estimatedMinPayment.value, form.currencyCode || 'USD');
 });
 
 const applyEstimatedMinPayment = () => {


### PR DESCRIPTION
Zero-decimal currencies (KRW, JPY) no longer render a bogus fraction; shared formatters replace the ad-hoc Intl.NumberFormat copies in tag/loan/account views. Closes [user's request](https://moneymatter.featurebase.app/p/disable-decimal-points-option)