### PR TITLE
Require CLA signing via bot check on pull requests

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: CLA Assistant
+
+# Requires every contributor to sign the CLA (CLA.md) before their pull request
+# can be merged. Signatures are recorded in a JSON file on a dedicated branch of
+# this repo (no external service or database). A contributor signs by commenting
+# the agreed sentence on their PR; the bot then updates the PR status check.
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+# Least privilege for the token: enough to comment on PRs, set the status check,
+# and commit the signature file to the signatures branch.
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla-assistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://github.com/letehaha/budget-tracker/blob/main/CLA.md'
+          # Dedicated branch that stores the signature file. The action creates
+          # it on first sign; keep it out of normal development.
+          branch: 'cla-signatures'
+          # The maintainer owns 100% of the code and does not sign their own CLA.
+          # Bots that open PRs (e.g. Dependabot) never author copyrightable work.
+          allowlist: 'letehaha,dependabot[bot],*[bot]'
+          custom-notsigned-prcomment: 'Thank you for your pull request. Before it can be merged we need you to sign our [Contributor License Agreement](https://github.com/letehaha/budget-tracker/blob/main/CLA.md). It takes one comment and you keep the copyright to your work — see [CONTRIBUTING.md](https://github.com/letehaha/budget-tracker/blob/main/CONTRIBUTING.md) for the plain-language summary.'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,114 @@
+# MoneyMatter Individual Contributor License Agreement
+
+Thank you for your interest in contributing to MoneyMatter (the "Project"),
+maintained by Dmytro Svyrydenko (the "Maintainer").
+
+This Contributor License Agreement ("Agreement") sets out the terms under which
+you grant rights in any Contribution you make to the Project. It protects both
+you and the Maintainer, and it lets the Maintainer keep licensing the Project
+freely – including offering it under licenses other than the AGPL-3.0 – without
+having to track down every contributor for permission later.
+
+This is a legal document. Please read it carefully before signing. You keep the
+copyright to your work; you are granting a license, not selling your code.
+
+By signing this Agreement, you accept and agree to the following terms for your
+past, present, and future Contributions to the Project.
+
+## 1. Definitions
+
+- **"You"** (or **"Your"**) means the individual who submits a Contribution, or
+  the legal entity on whose behalf the Contribution is submitted. For a legal
+  entity, the entity and all entities that control, are controlled by, or are
+  under common control with it are considered a single Contributor.
+- **"Contribution"** means any original work of authorship – including any
+  changes or additions to existing work – that You intentionally submit to the
+  Project in any form, including code, documentation, configuration, and
+  associated materials. "Submit" means any form of electronic, verbal, or
+  written communication sent to the Maintainer or the Project, including but not
+  limited to pull requests, patches, issues, and comments, excluding any
+  communication conspicuously marked in writing as "Not a Contribution."
+
+## 2. Copyright License
+
+You retain ownership of the copyright in Your Contribution.
+
+Subject to the terms of this Agreement, You grant to the Maintainer and to
+recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare derivative works of, publicly display, publicly perform,
+sublicense, and distribute Your Contribution and such derivative works.
+
+## 3. Right to Relicense
+
+You expressly agree that the Maintainer may license and distribute Your
+Contribution, and any derivative work of it, **under any license terms the
+Maintainer chooses**, including open-source licenses, proprietary
+(closed-source) licenses, and commercial or dual-license arrangements, now or in
+the future, and may do so without any further permission from, notice to, or
+compensation to You.
+
+Nothing in this Agreement obligates the Maintainer to use or distribute Your
+Contribution.
+
+## 4. Patent License
+
+Subject to the terms of this Agreement, You grant to the Maintainer and to
+recipients of software distributed by the Maintainer a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer Your Contribution, where such license applies only to
+those patent claims licensable by You that are necessarily infringed by Your
+Contribution alone or by combination of Your Contribution with the Project.
+
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Project shall terminate as
+of the date such litigation is filed.
+
+## 5. Your Representations
+
+You represent that:
+
+1. You are legally entitled to grant the above licenses.
+2. Each of Your Contributions is Your original creation, or You otherwise have
+   the right to submit it under the terms of this Agreement.
+3. If Your employer has rights to intellectual property that You create,
+   including Your Contributions, You represent that You have received permission
+   to make the Contribution on behalf of that employer, that Your employer has
+   waived such rights for Your Contribution, or that Your employer has executed a
+   separate corporate agreement with the Maintainer.
+4. Your Contribution includes complete details of any third-party license or
+   other restriction (including related patents and trademarks) of which You are
+   personally aware and which are associated with any part of Your Contribution.
+
+## 6. Disclaimer
+
+Except for the express representations in Section 5, You provide Your
+Contribution "AS IS", without warranty of any kind, express or implied,
+including, without limitation, any warranties of merchantability, fitness for a
+particular purpose, title, or non-infringement.
+
+## 7. Public Distribution of the Project
+
+For clarity: the Project itself remains publicly available under the
+GNU Affero General Public License v3.0 (AGPL-3.0). This Agreement does not change
+the license under which the public receives the Project; it grants the
+Maintainer the additional rights described above so the Maintainer may relicense
+as set out in Section 3.
+
+---
+
+## How to sign
+
+You do not need to edit this file. When you open a pull request, an automated
+check (CLA Assistant) will ask you to sign by posting a single comment on your
+pull request:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Your signature (your GitHub username, timestamp, and the pull request reference)
+is recorded automatically. You sign once; it covers all your future
+Contributions to the Project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to MoneyMatter
+
+Thanks for your interest in contributing. Bug reports, fixes, and features are
+all welcome. This page explains the two things every contribution needs: the
+license it lands under, and the one-time agreement you sign.
+
+## License and the CLA (please read before your first PR)
+
+MoneyMatter is distributed to the public under the
+[GNU Affero General Public License v3.0](./LICENSE) (AGPL-3.0). Your
+contributions reach everyone under that same license.
+
+In addition, before your first pull request can be merged, you sign a
+**Contributor License Agreement** ([CLA.md](./CLA.md)). In plain terms:
+
+- **You keep the copyright to your work.** You are granting a license, not
+  giving away or selling your code. You can still reuse your own contribution
+  anywhere else you like.
+- The CLA grants the maintainer the right to license the project – including
+  your contribution – under terms beyond AGPL-3.0 in the future (for example a
+  commercial or dual license). This keeps the project's licensing flexible
+  without having to chase down every past contributor for permission.
+- The project stays publicly available under AGPL-3.0. The CLA does not change
+  what the public receives today.
+
+**Signing is automatic and takes one comment.** When you open a pull request, a
+bot (CLA Assistant) checks whether you've signed. If not, it posts a link to the
+CLA and asks you to reply on the PR with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+That's it – you sign once and it covers all your future contributions.
+
+> **Contributing on behalf of an employer?** If you write code as part of your
+> job, your employer may own the copyright, not you. In that case the individual
+> CLA isn't enough – please have someone authorized at your employer contact the
+> maintainer so a corporate agreement can be arranged before you contribute.
+
+## How to contribute
+
+1. **Open an issue first** for anything non-trivial (new feature, larger
+   refactor, behavior change). It saves you building something that doesn't fit
+   the project's direction. Small fixes can go straight to a PR.
+2. **Fork the repo** and create a branch for your change.
+3. **Make your change**, following the conventions already in the codebase.
+4. **Run the checks** before opening the PR:
+   - Lint / type-check and tests should pass locally.
+   - The CI workflow (`.github/workflows/check-source-code.yml`) runs the same
+     checks on your PR.
+5. **Open a pull request** against the default branch. Describe what changed and
+   why, and link the related issue.
+6. **Sign the CLA** when the bot asks (see above).
+
+## Commit and PR conventions
+
+- Keep pull requests focused – one logical change per PR is easier to review.
+- Write clear commit messages describing what changed and why.
+- Don't include unrelated formatting churn or dependency bumps in a feature PR.
+
+## Reporting bugs and requesting features
+
+- Use GitHub Issues. Include steps to reproduce, what you expected, and what
+  actually happened. For UI issues, a screenshot or short recording helps a lot.
+
+## Questions
+
+Open an issue or start a discussion. Thanks for helping make MoneyMatter better.


### PR DESCRIPTION
Adds `CLA.md`, a contributor-assistant workflow that records signatures on a dedicated branch, and `CONTRIBUTING.md` with a plain-language summary