### PR TITLE
Extend currencies rates providers list

### DIFF
--- a/packages/backend/README.md
+++ b/packages/backend/README.md
@@ -36,7 +36,7 @@ Now it should be accessible under the port that you defined in the `.env.develop
 
 For detailed documentation about the backend services and architecture, see the [`docs/`](./docs/) folder:
 
-- [Exchange Rates System](./docs/exchange-rates.md) - Hybrid exchange rates system (currency-rates-api + ApiLayer)
+- [Exchange Rates System](./docs/exchange-rates.md) - Hybrid exchange rates system (currency-rates-api + fawazahmed0 + ApiLayer)
 
 ### Troubleshoting:
 

--- a/packages/backend/docs/exchange-rates.md
+++ b/packages/backend/docs/exchange-rates.md
@@ -1,6 +1,6 @@
 # Exchange Rates – how rates actually get loaded
 
-Quick doc on how currency rates land in the `ExchangeRates` table – which provider does what, how the daily sync stays fresh, how the full historical archive gets backfilled, and what happens when you edit a transaction dated 12 years ago in some exotic currency. Also: why ApiLayer is deliberately skipped on the historical path.
+Quick doc on how currency rates land in the `ExchangeRates` table – which provider does what, how the daily sync stays fresh, how the full historical archive gets backfilled, and what happens when you edit a transaction dated 12 years ago in some exotic currency. Also: why ApiLayer is deliberately skipped on the historical path and only fires as a paid last resort.
 
 Everything is stored as `USD → X`. Any other pair (EUR/GBP, UAH/PLN, whatever) is derived in `getExchangeRate` by going through USD. Keeps the table small and the merge logic sane.
 
@@ -8,12 +8,13 @@ Everything is stored as `USD → X`. Any other pair (EUR/GBP, UAH/PLN, whatever)
 
 The providers
 
-There are two, queried in priority order:
+There are three, queried in priority order:
 
 1. **Currency Rates API** – primary. Custom self-hosted service backed by ECB + NBU data. ~38 currencies. Has a real time-series endpoint, so a whole year of history is one HTTP call. Goes back to 1999-01-04.
-2. **ApiLayer (Fixer)** – secondary. Paid, external, 150+ currencies. This is the one that covers the long tail – all those exotic currencies the ECB-based primary simply doesn't publish.
+2. **fawazahmed0/exchange-api** (source `fawaz-currency-api`) – secondary. Free, CDN-hosted, no API key, no rate limit. Covers 200+ currencies – the entire exotic long tail plus metals and crypto. Same `USD → X` convention as ours (lowercase codes). Single-date only, and its data floor is `2024-03-02`. This is the provider that keeps the fresh-date long tail covered without touching the paid dependency.
+3. **ApiLayer (Fixer)** – last resort. Paid, external, 150+ currencies. Now reached only when the two providers above leave a gap – i.e. mostly pre-2024 exotic dates on the on-demand path. It's never removed: it's the guaranteed fallback that covers dates and currencies fawazahmed0 can't.
 
-The registry (`providers/registry.ts`) does something slightly non-obvious here: it's a **gap-filling merge**, not first-success-wins. Every available provider gets queried in priority order, but a lower-priority provider only contributes currencies the higher-priority ones didn't supply. So even on a happy day when Currency Rates API succeeds, the chain still continues to ApiLayer – otherwise the ~110 exotic currencies that only ApiLayer covers would go permanently stale.
+The registry (`providers/registry.ts`) does something slightly non-obvious here: it's a **gap-filling merge**, not first-success-wins, and it's **coverage-gated**. It queries providers in priority order, each lower-priority provider only contributing currencies the higher ones didn't supply, and it **stops as soon as every enabled currency has a rate**. So on a fresh date, Currency Rates API covers the mainstream basket and fawazahmed0 fills the tail – coverage is complete, the chain short-circuits, and the paid ApiLayer fetch never fires. ApiLayer is only reached when a residual gap remains after both (predominantly pre-2024 exotic dates fawazahmed0's floor excludes).
 
 ---
 
@@ -34,16 +35,18 @@ flowchart TD
     Lookup -- no / stale --> Fetch[resolveUsdRates D]
 
     Hist --> HistReg[(fetchHistoricalRatesWithFallback<br/>HISTORICAL providers only)]
-    Sync --> DayReg[(fetchRatesWithFallback)]
+    Sync --> DayReg[(fetchRatesWithFallback<br/>stops once every currency covered)]
     Fetch --> DayReg
 
-    HistReg --> P1H[Currency Rates API]
-    HistReg -.skip.-> P2H[ApiLayer]
+    HistReg --> P1H[1· Currency Rates API]
+    HistReg -.skip.-> P2H[2· fawazahmed0]
+    HistReg -.skip.-> P3H[3· ApiLayer]
 
-    DayReg --> P1[Currency Rates API]
-    DayReg --> P2[ApiLayer – fills tail]
+    DayReg --> P1[1· Currency Rates API]
+    DayReg --> P2[2· fawazahmed0 – fresh-date tail]
+    DayReg -.residual gap only.-> P3[3· ApiLayer – paid last resort]
 
-    P1 & P2 --> Merge[mergeProviderRates<br/>gap-fill by priority]
+    P1 & P2 & P3 --> Merge[mergeProviderRates<br/>gap-fill by priority, short-circuit on full coverage]
     P1H --> Merge
     Merge --> DB[(ExchangeRates<br/>bulkCreate ignoreDuplicates)]
 ```
@@ -54,7 +57,7 @@ flowchart TD
 
 Fires once per process from `background-jobs.ts` → `initializeHistoricalRates()`. Non-blocking, so a slow backfill never delays app boot. Failure here doesn't block startup either – the daily cron eventually catches up.
 
-The range is `1999-01-04` (earliest ECB data) through today, processed in **yearly chunks** to keep memory under control on the bulk insert. Each chunk goes through `fetchHistoricalRatesWithFallback`, which only queries providers that opt in via `supportsHistoricalDataLoading=true` – currently just Currency Rates API. ApiLayer is intentionally skipped here, more on that below.
+The range is `1999-01-04` (earliest ECB data) through today, processed in **yearly chunks** to keep memory under control on the bulk insert. Each chunk goes through `fetchHistoricalRatesWithFallback`, which only queries providers that opt in via `supportsHistoricalDataLoading=true` – currently just Currency Rates API. Both fawazahmed0 and ApiLayer are intentionally skipped here (neither exposes a time-series range endpoint); more on that below.
 
 The whole thing is idempotent. Re-runs insert nothing thanks to `bulkCreate({ ignoreDuplicates: true })` against the unique `(baseCode, quoteCode, date)` constraint, so on every restart it's a no-op after the first successful run.
 
@@ -66,7 +69,14 @@ If no historical provider is available at startup (Docker still booting, network
 
 `crons/exchange-rates/index.ts`, fires at **18:00 UTC** every day. That's after ECB's ~16:00 CET publish, so the rates are actually there when we ask.
 
-It calls `syncExchangeRates` → `ensureRatesForDate(today)` (the full-sync entry). Both providers run on this path – and this is exactly the reason the gap-filling merge matters. Currency Rates API handles the ~38 mainstream currencies; ApiLayer is what keeps the long-tail currencies from drifting stale.
+It calls `syncExchangeRates` → `ensureRatesForDate(today)` (the full-sync entry). Currency Rates API handles the ~38 mainstream currencies; fawazahmed0 fills the long tail for the same fresh date. Between the two, every enabled currency is covered, so the coverage-gated merge short-circuits before reaching ApiLayer – the daily sync stays entirely on free providers.
+
+fawazahmed0 is fetched from an **immutable dated URL** so the CDN can cache it correctly:
+
+- jsDelivr (primary): `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@{YYYY-MM-DD}/v1/currencies/{base}.min.json`
+- Cloudflare Pages (fallback): `https://{YYYY-MM-DD}.currency-api.pages.dev/v1/currencies/{base}.min.json`
+
+If today's file isn't published yet at fetch time, fawazahmed0 simply returns nothing and the chain proceeds to ApiLayer, which serves the real requested date. It deliberately has **no yesterday-fallback** (unlike Currency Rates API): a stale whole-basket result would be stored under today's date, satisfy the comprehensiveness gate, and suppress ApiLayer – silently pinning day-old rates. And for any date before its `2024-03-02` floor it makes no request at all and returns nothing – so pre-2024 rates come from ApiLayer, never fawazahmed0.
 
 ---
 
@@ -80,9 +90,11 @@ This is the path most people don't think about. When you edit (or create) a tran
 `resolveUsdRates` is where the "do I actually need to hit a provider?" decision lives, and it asks two precise questions:
 
 - **Coverage** – are the requested currencies already present as exact-date rows? If so, do nothing.
-- **Comprehensiveness** – has the comprehensive provider (ApiLayer) already run for this date? We detect this by the presence of _any_ ApiLayer-sourced row on that date (the `source` column). ApiLayer answers per-_date_ – its whole ~150-currency basket – so if it ran and a currency is still absent, that currency is genuinely unavailable for that date and re-fetching is futile. Skip, and the caller uses its fallback.
+- **Comprehensiveness** – has the date already been fetched comprehensively? `isDateComprehensivelyFetched` answers yes if a **whole-basket** provider – fawazahmed0 or ApiLayer – has a row for the date. Both answer per-date with their entire basket, so once either has run, a currency still absent is genuinely unavailable for that date and re-fetching is futile – skip, and the caller uses its fallback. Currency Rates API is deliberately not a signal: it only ever supplies its ~38 currencies, so its rows never prove the exotic tail was attempted. On a post-2024 date fawazahmed0 is the signal (ApiLayer usually never runs, since the free providers cover the tail); below the 2024-03-02 floor fawazahmed0 makes no request, so ApiLayer is the sole signal there – which is correct, as it's the only source for old exotic dates.
 
-One edge worth knowing: if ApiLayer returns **zero** rows for a date (it was down, rate-limited, or has no API key configured), no ApiLayer-sourced row exists to key off, so the next lookup re-fetches. For a transient outage that's the intended behaviour – retry until ApiLayer answers. For a deployment without an ApiLayer key the exotic currency is unobtainable regardless, so the repeat fetch (bounded by the 30s dedup) is harmless.
+When a gap remains, the fetch walks the same priority chain as the daily sync: Currency Rates API → fawazahmed0 → ApiLayer, stopping at full coverage. For a fresh-date exotic currency, fawazahmed0 answers and ApiLayer is never touched. For a **pre-2024** exotic date, fawazahmed0's floor rules it out entirely, so ApiLayer is the only source that can fill the gap – and this is exactly the case where paying for one single-date request is worth it.
+
+One edge worth knowing: if a date genuinely reaches ApiLayer (a pre-2024 exotic date) and ApiLayer returns **zero** rows (it was down, rate-limited, or has no API key configured), no ApiLayer-sourced row exists and the date isn't fully covered, so the next lookup re-fetches. For a transient outage that's the intended behaviour – retry until ApiLayer answers. For a deployment without an ApiLayer key the exotic currency is unobtainable regardless, so the repeat fetch (bounded by the 30s dedup) is harmless.
 
 Two guards keep this from melting things under load – bulk-editing old transactions, stats jobs sweeping years of history, that kind of thing:
 
@@ -91,24 +103,27 @@ Two guards keep this from melting things under load – bulk-editing old transac
 
 ---
 
-Why ApiLayer is skipped on the historical path
+Why fawazahmed0 and ApiLayer are skipped on the historical path
 
-`ApiLayerProvider.metadata.supportsHistoricalDataLoading` is deliberately left unset (defaults falsy), so the historical registry filters it out. A few reasons stacked together:
+Neither provider sets `metadata.supportsHistoricalDataLoading` (defaults falsy), so the historical registry filters both out. Different reasons for each.
 
-**Cost.** ApiLayer is the only paid dependency – keyed via `API_LAYER_API_KEYS`, with cheap tiers capping monthly requests in the low thousands. A full 1999→today backfill is ~10,000 days. One quota-charged request per day per key would drain a month's quota on a single startup. And because `bulkCreate ignoreDuplicates` means most of those requests would re-insert data we already have, every restart would re-burn it for nothing.
+**fawazahmed0 – no time-series endpoint, and a hard data floor.** Its API answers a single date at a time (`@{YYYY-MM-DD}`), so a 1999→today backfill would be ~10,000 separate CDN requests instead of Currency Rates API's handful of year-range calls. And it has nothing before `2024-03-02` anyway, so it couldn't fill the deep archive even if we hammered it. On the fresh-date paths, one dated request per day is exactly the shape it's good for; as a bulk historical source it's the wrong tool.
 
-**No time-series endpoint here.** Currency Rates API exposes a proper `start..end` range endpoint – a whole year of history is a single HTTP call. ApiLayer's Fixer endpoint we use is single-date only (`/fixer/{date}`). So historical via ApiLayer would mean one quota hit per day – strictly worse than the primary that already covers the same mainstream currencies for free.
+**ApiLayer – cost, no range endpoint, and it's not its job.**
 
-**It's not the job ApiLayer exists for.** ApiLayer's whole purpose in this system is to cover the **exotic long tail today**. Historical rates for those exotic currencies, going years back, are rarely actually queried – and when they _are_ (someone edits an old transaction in a non-ECB currency), the on-demand path in `getExchangeRate` will pull ApiLayer for that single date. Which is exactly the case where paying for one request is worth it. So ApiLayer still fills historical gaps – just lazily, one date at a time, when the data is actually needed.
+- **Cost.** ApiLayer is the only paid dependency – keyed via `API_LAYER_API_KEYS`, with cheap tiers capping monthly requests in the low thousands. A full 1999→today backfill is ~10,000 days. One quota-charged request per day per key would drain a month's quota on a single startup. And because `bulkCreate ignoreDuplicates` means most of those requests would re-insert data we already have, every restart would re-burn it for nothing.
+- **No time-series endpoint here.** Currency Rates API exposes a proper `start..end` range endpoint – a whole year of history is a single HTTP call. ApiLayer's Fixer endpoint we use is single-date only (`/fixer/{date}`). So historical via ApiLayer would mean one quota hit per day – strictly worse than the primary that already covers the same mainstream currencies for free.
+- **It's not the job ApiLayer exists for.** ApiLayer's whole purpose in this system is to be the guaranteed backstop for dates and currencies the free providers can't reach – chiefly the **pre-2024 exotic tail** (before fawazahmed0's floor). Those old exotic rates are rarely actually queried, and when they _are_ (someone edits an old transaction in a non-ECB currency dated before 2024), the on-demand path in `getExchangeRate` pulls ApiLayer for that single date. So ApiLayer still fills historical gaps – just lazily, one date at a time, when the data is actually needed.
 
 ---
 
 Gap reporting
 
-After every daily/on-demand fetch, `registry.reportDegradedSync` emits a `logger.error` (→ Sentry) on two independent signals:
+After every daily/on-demand fetch, `registry.fetchRatesWithFallback` emits a `logger.error` (→ Sentry) on these signals (1 and 3 via its `reportDegradedSync` step, 2 inline):
 
-1. **Provider degraded** – any registered provider failed, returned nothing, or was unavailable, even if the others covered the gap. If the primary specifically degraded, the message keeps the legacy `[ALERT:CURRENCY_RATES_API_FAILED]` keyword so existing monitoring rules stay valid.
-2. **Coverage gap** – an enabled currency (from the `Currencies` table) is absent from the merged result, meaning some user's currency just didn't get a fresh rate today.
+1. **Provider degraded** – any registered provider failed, returned nothing, or was unavailable, even if the others covered the gap. A provider skipped because the requested date predates its data floor is NOT counted – declining by design is not degradation. If the primary specifically degraded, the message keeps the legacy `[ALERT:CURRENCY_RATES_API_FAILED]` keyword so existing monitoring rules stay valid.
+2. **fawazahmed0 gap** – `[ALERT:FAWAZ_CURRENCY_API_GAP]`. Fires when, for a **requested** date `>= 2024-03-02`, an enabled currency had to be filled by **ApiLayer**. Rationale: fawazahmed0 is supposed to have every currency for any post-2024 date, so falling back to the paid provider is an anomaly worth surfacing. Deliberately narrow to avoid double-reporting: a fawazahmed0 fetch _failure_ is already covered by signal 1, and a currency missing _entirely_ by signal 3 – this alert only means "fawazahmed0 ran but lacked a rate the paid fallback had".
+3. **Coverage gap** – an enabled currency (from the `Currencies` table) is absent from the merged result, meaning some user's currency just didn't get a fresh rate today. The "enabled" set excludes `NON_CURRENCY_CODES` (precious metals, ISO fund codes like `BOV`/`MXV`/`USN`) – no provider quotes those, so counting them would make full coverage unreachable, defeat the ApiLayer early-stop, and fire this alert on every sync.
 
 The historical backfill reports degradation the same way, but skips the per-date coverage check – the long tail is expected to be missing across years, and alerting on it would be pure noise.
 
@@ -117,6 +132,7 @@ The historical backfill reports degradation the same way, but skips the per-date
 Schema bits worth knowing
 
 - Table `exchange_rates`, unique on `(baseCode, quoteCode, date)`. There's a `source` column recording which provider supplied each row (added in migration `20260520000000-add-source-to-exchange-rates.ts`), useful when debugging "why is this rate weird".
+- The `source` column is a plain `VARCHAR` with **no DB-level CHECK constraint** – it was dropped in `20260720000000-drop-exchange-rates-source-check.ts`. The TypeScript enum `EXCHANGE_RATE_PROVIDER_TYPE` (`packages/shared/src/types/enums.ts`) is the single source of truth for the valid provider strings, so adding a provider is a **code-only** change with no accompanying migration.
 - Every row stores `baseCode = 'USD'`. Anything that looks like a non-USD pair on the frontend is computed at read time.
 
 ---
@@ -128,7 +144,7 @@ API_LAYER_API_KEYS=key1,key2,key3        # comma-separated; rotated automaticall
 CURRENCY_RATES_API_URL=http://currency-rates-api:8080
 ```
 
-`currency-rates-api` (image `letehaha/currency-rates-api`) is self-hosted in docker-compose. ApiLayer is the only external paid dep – and as covered above, it's only used where it actually earns its keep.
+`currency-rates-api` (image `letehaha/currency-rates-api`) is self-hosted in docker-compose. fawazahmed0 needs **no configuration at all** – it's a keyless public CDN, so there's nothing to set. ApiLayer is the only external paid dep, and as covered above it's only used where it actually earns its keep.
 
 ---
 
@@ -136,8 +152,13 @@ Notes – decisions & rejected alternatives
 
 Short rationale for the non-obvious choices, so they don't get re-litigated:
 
-- **Comprehensiveness gate keys off the `source` column, not a row count.** Presence of any `api-layer`-sourced row answers "did the comprehensive provider run for this date?" directly. A `count > N` threshold was rejected – N is coupled to how many currencies each provider happens to cover, so it silently breaks if coverage changes.
-- **No durable "already tried this date" marker.** A Redis/DB record written on every fetch attempt (to remember even a zero-row ApiLayer response) was considered and rejected: it would suppress the retry we _want_ during a transient ApiLayer outage, and for a no-key deployment the currency is unobtainable anyway. The `source` gate self-records via the basket ApiLayer does return.
+- **ApiLayer is coverage-gated, not always-called.** The registry stops the priority chain the moment every enabled currency is covered, so on fresh dates (where fawazahmed0 covers the tail) the paid provider never fires. Keeping the old always-continue-to-ApiLayer behaviour was rejected – it would pay for the exotic basket every single day even though the free CDN already carries it. ApiLayer stays wired in as the guaranteed last resort; it's just not reached until a real gap remains.
+- **Dropped the DB CHECK constraint instead of amending it per provider.** The `source` whitelist previously lived in a Postgres CHECK, which meant every new provider needed a migration just to enlarge the allowed set – and the enum and the constraint could silently drift. Dropping the CHECK and treating `EXCHANGE_RATE_PROVIDER_TYPE` as the sole source of truth makes adding a provider a code-only change and removes the drift surface entirely.
+- **fawazahmed0 is fetched via the dated `@{YYYY-MM-DD}` URL, never `@latest`.** jsDelivr caches `@latest` for up to ~24h, so it can serve yesterday's basket under today's name. The dated URL is immutable, so it's both correct and safely cacheable. Before today's file is published the provider simply returns nothing and the chain falls through to ApiLayer – deliberately no yesterday-fallback (see the comprehensiveness-gate rationale above).
+- **fawazahmed0 is excluded from the historical backfill.** It has no time-series/range endpoint (one request per date) and no data before `2024-03-02`, so it can't populate the deep archive – Currency Rates API's range endpoint is the only viable historical source. fawazahmed0 earns its place on the daily/on-demand fresh-date paths instead.
+- **The `2024-03-02` floor deliberately keeps ApiLayer as the pre-2024 source.** Below the floor fawazahmed0 makes no request, so the coverage-gated chain falls through to ApiLayer for old exotic dates. That's intended: the free CDN owns the fresh tail, the paid provider owns the (rarely queried, one-date-at-a-time) old tail.
+- **Comprehensiveness gate keys off a whole-basket provider's row (fawazahmed0 or ApiLayer), not full coverage.** The gate asks "did a provider that answers the entire basket per date already run?" – if so, a still-absent currency is genuinely unavailable and re-fetching is futile. Keying off _full coverage of every enabled currency_ was rejected: a currency no provider carries (a rare enabled ISO code outside all three baskets) leaves coverage permanently incomplete, so that gate would re-fetch the date forever. Currency Rates API is excluded as a signal because it only ever carries its ~38 currencies – its rows never prove the tail was attempted. A `count > N` threshold was also rejected – N is coupled to how many currencies each provider happens to cover, so it silently breaks if coverage changes. (The merge's early-stop still uses full coverage, but only to decide whether to _skip the paid ApiLayer call_; the comprehensiveness gate still bounds ApiLayer to at most one call per date even when a never-carried currency keeps that early-stop from firing.)
+- **No durable "already tried this date" marker.** A Redis/DB record written on every fetch attempt (to remember even a zero-row ApiLayer response) was considered and rejected: it would suppress the retry we _want_ during a transient ApiLayer outage, and for a no-key deployment the currency is unobtainable anyway. The comprehensiveness gate self-records via the fawazahmed0 / ApiLayer basket row.
 - **No "currency added after the date was synced" tracking.** Not needed: `Currencies` is seeded once with the full ISO set and has no timestamps (toggled via `isDisabled`, never added incrementally), so that state isn't reachable.
 - **Cross-rate cache is global, keyed `(date, base, quote)` without `userId`.** The conversion is user-independent; per-user keys would store N identical copies. The per-user custom-rate override (`liveRateUpdate=false`) is the lone user-specific case and deliberately skips this cache.
 - **Only exact-on-both-legs results are cached; fallbacks are recomputed every call.** Caching a fallback under the requested date's key was rejected: with the 4h TTL it would keep serving a stale approximation even after the real rate for that date lands (the worst case being "today" queried before the daily publish, then again within 4h). Recomputing a fallback is cheap – the comprehensiveness gate stops it from hammering providers and the 30s dedup collapses bursts – so correctness wins over the marginal cache hit.

--- a/packages/backend/src/migrations/20260720000000-drop-exchange-rates-source-check.ts
+++ b/packages/backend/src/migrations/20260720000000-drop-exchange-rates-source-check.ts
@@ -1,0 +1,49 @@
+import { QueryInterface } from 'sequelize';
+
+const TABLE = 'ExchangeRates';
+const COLUMN = 'source';
+const CHECK_CONSTRAINT = 'ExchangeRates_source_valid';
+
+// Values MUST stay in sync with EXCHANGE_RATE_PROVIDER_TYPE in
+// packages/shared/src/types/enums.ts. Migrations run in plain Node and cannot
+// import app code, so the strings are duplicated here. Only used by down().
+const PROVIDER_CURRENCY_RATES_API = 'currency-rates-api';
+const PROVIDER_API_LAYER = 'api-layer';
+const PROVIDER_UNKNOWN = 'unknown';
+
+// The set restored by down() — the whitelist that existed before this migration.
+const PRIOR_PROVIDERS = [PROVIDER_CURRENCY_RATES_API, PROVIDER_API_LAYER, PROVIDER_UNKNOWN] as const;
+
+/**
+ * Drop the DB-level whitelist on `ExchangeRates.source`.
+ *
+ * The column stays a `VARCHAR(32) NOT NULL DEFAULT 'unknown'`; only the CHECK
+ * constraint that enumerated the allowed provider strings goes away. That
+ * whitelist forced a new migration every time a rate provider was added — the
+ * TypeScript enum `EXCHANGE_RATE_PROVIDER_TYPE` is now the single source of
+ * truth for valid sources, and adding a provider is a code-only change.
+ */
+module.exports = {
+  up: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.query(`ALTER TABLE "${TABLE}" DROP CONSTRAINT IF EXISTS "${CHECK_CONSTRAINT}";`);
+  },
+
+  down: async (queryInterface: QueryInterface): Promise<void> => {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // Any source outside the pre-migration whitelist (e.g. providers added
+      // after the constraint was dropped) would violate the restored CHECK, so
+      // relabel them to the honest catch-all first. The rate value is untouched.
+      const placeholders = PRIOR_PROVIDERS.map((_, i) => `:p${i}`).join(', ');
+      const replacements = Object.fromEntries(PRIOR_PROVIDERS.map((value, i) => [`p${i}`, value]));
+      await queryInterface.sequelize.query(
+        `UPDATE "${TABLE}" SET "${COLUMN}" = :unknown WHERE "${COLUMN}" NOT IN (${placeholders});`,
+        { transaction, replacements: { ...replacements, unknown: PROVIDER_UNKNOWN } },
+      );
+
+      await queryInterface.sequelize.query(
+        `ALTER TABLE "${TABLE}" ADD CONSTRAINT "${CHECK_CONSTRAINT}" CHECK ("${COLUMN}" IN (${placeholders}));`,
+        { transaction, replacements },
+      );
+    });
+  },
+};

--- a/packages/backend/src/models/currencies.model.ts
+++ b/packages/backend/src/models/currencies.model.ts
@@ -47,9 +47,13 @@ export default class Currencies extends Model {
 }
 
 /**
- * ISO 4217 codes that are not actual currencies (precious metals, testing codes, supranational currencies).
- * These are excluded from the currency selection UI and rejected on bank-account import — none of them
- * have an exchange rate, so trying to compute a ref-amount against the user's base currency throws.
+ * ISO 4217 codes that are not actual currencies (precious metals, testing codes, supranational
+ * currencies, accounting fund codes). These are excluded from the currency selection UI and rejected
+ * on bank-account import — none of them have an exchange rate, so trying to compute a ref-amount
+ * against the user's base currency throws. They are also excluded from `getAllCurrencies`, which
+ * feeds the exchange-rate sync's coverage checks: treating them as expected would make full coverage
+ * permanently unreachable (no provider quotes them), defeating the ApiLayer early-stop and making
+ * the coverage alerts fire on every sync.
  */
 export const NON_CURRENCY_CODES = [
   'XAU', // Gold
@@ -65,6 +69,14 @@ export const NON_CURRENCY_CODES = [
   'XUA', // ADB Unit of Account
   'XXX', // No currency
   'XTS', // Testing code
+  'BOV', // Bolivian Mvdol (funds code)
+  'CHE', // WIR euro (complementary currency)
+  'CHW', // WIR franc (complementary currency)
+  'COU', // Colombian unidad de valor real (funds code)
+  'MXV', // Mexican unidad de inversión (funds code)
+  'USN', // US dollar next-day (funds code)
+  'UYI', // Uruguay peso en unidades indexadas (funds code)
+  'UYW', // Uruguayan unidad previsional (funds code)
 ];
 
 export const getAllCurrencies = async () => {

--- a/packages/backend/src/services/exchange-rates/ensure-rates-for-date.e2e.ts
+++ b/packages/backend/src/services/exchange-rates/ensure-rates-for-date.e2e.ts
@@ -2,8 +2,12 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@j
 import { logger } from '@js/utils';
 import { connection } from '@models/index';
 import * as helpers from '@tests/helpers';
-import { getApiLayerResposeMock, getCurrencyRatesApiResponseMock } from '@tests/mocks/exchange-rates/data';
-import { API_LAYER_ENDPOINT_REGEX, CURRENCY_RATES_API_ENDPOINT_REGEX } from '@tests/mocks/exchange-rates/endpoints';
+import { getCurrencyRatesApiResponseMock, getFawazCurrencyApiResponseMock } from '@tests/mocks/exchange-rates/data';
+import {
+  API_LAYER_ENDPOINT_REGEX,
+  CURRENCY_RATES_API_ENDPOINT_REGEX,
+  FAWAZ_CURRENCY_API_ENDPOINT_REGEX,
+} from '@tests/mocks/exchange-rates/endpoints';
 import { createCallsCounter, createOverride } from '@tests/mocks/helpers';
 import { format, startOfDay } from 'date-fns';
 
@@ -20,16 +24,20 @@ const loggerErrorCalledWith = (errorSpy: ReturnType<typeof jest.spyOn>, substrin
 
 describe('Exchange Rates Functionality', () => {
   let currencyRatesApiOverride: ReturnType<typeof createOverride>;
+  let fawazOverride: ReturnType<typeof createOverride>;
   let apiLayerOverride: ReturnType<typeof createOverride>;
 
   let currencyRatesApiCounter: ReturnType<typeof createCallsCounter>;
+  let fawazCounter: ReturnType<typeof createCallsCounter>;
   let apiLayerCounter: ReturnType<typeof createCallsCounter>;
 
   beforeAll(() => {
     currencyRatesApiOverride = createOverride(global.mswMockServer, CURRENCY_RATES_API_ENDPOINT_REGEX);
+    fawazOverride = createOverride(global.mswMockServer, FAWAZ_CURRENCY_API_ENDPOINT_REGEX);
     apiLayerOverride = createOverride(global.mswMockServer, API_LAYER_ENDPOINT_REGEX);
 
     currencyRatesApiCounter = createCallsCounter(global.mswMockServer, CURRENCY_RATES_API_ENDPOINT_REGEX);
+    fawazCounter = createCallsCounter(global.mswMockServer, FAWAZ_CURRENCY_API_ENDPOINT_REGEX);
     apiLayerCounter = createCallsCounter(global.mswMockServer, API_LAYER_ENDPOINT_REGEX);
   });
 
@@ -45,6 +53,7 @@ describe('Exchange Rates Functionality', () => {
     global.mswMockServer.resetHandlers();
     // Reset call counters
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
     // Drop any logger spies installed by degradation-signal tests
     jest.restoreAllMocks();
@@ -72,12 +81,12 @@ describe('Exchange Rates Functionality', () => {
   });
 
   it('should fill currencies missing from the primary provider using lower-priority fallbacks', async () => {
-    // Real-world bug: Currency Rates API (priority 1) only covers ~38 currencies
-    // and succeeds every day, so the chain used to stop there and never reach
-    // ApiLayer. Exotic currencies (ETB, HNL, PEN, RSD, TZS, XAF) that ONLY
-    // ApiLayer provides were therefore never refreshed. The fallback must MERGE
-    // providers – filling gaps left by higher-priority ones – instead of
-    // returning on first success.
+    // Currency Rates API (priority 1) only covers ~38 currencies but succeeds
+    // every day, so the chain must MERGE lower-priority providers to fill the
+    // gaps instead of returning on first success. fawazahmed0 (priority 2) now
+    // covers the exotic long tail (ETB, HNL, PEN, RSD, TZS, XAF), so those
+    // currencies come from it – and because it covers everything the enabled set
+    // needs, ApiLayer (priority 3) is never reached.
     const date = format(new Date(), 'yyyy-MM-dd');
 
     // All providers available with their default mocks (no overrides).
@@ -86,11 +95,11 @@ describe('Exchange Rates Functionality', () => {
     const response = (await helpers.getExchangeRates({ date, raw: true }))!;
     const byQuote = new Map(response.map((row) => [row.quoteCode, row]));
 
-    // Present in ApiLayer's mock but absent from Currency Rates API's mock.
+    // Absent from Currency Rates API's mock → filled by fawazahmed0's tail.
     for (const exotic of ['ETB', 'HNL', 'PEN', 'RSD', 'TZS', 'XAF']) {
       const row = byQuote.get(exotic);
       expect(row).toBeTruthy();
-      expect(row!.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER);
+      expect(row!.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API);
     }
 
     // Currencies the primary provider covers must keep its (higher-priority) source.
@@ -102,11 +111,11 @@ describe('Exchange Rates Functionality', () => {
     const date = format(new Date(), 'yyyy-MM-dd');
     const primaryEur = getCurrencyRatesApiResponseMock(date).rates.EUR;
 
-    // ApiLayer (priority 2) returns a DIFFERENT EUR value. The primary must win on
-    // the VALUE, not just the source label – guards the dedup precedence path.
-    apiLayerOverride.setOverride({
-      body: { ...getApiLayerResposeMock(date), rates: { ...getApiLayerResposeMock(date).rates, EUR: 0.123456 } },
-    });
+    // fawazahmed0 (priority 2) returns a DIFFERENT EUR value. The primary must win
+    // on the VALUE, not just the source label – guards the dedup precedence path.
+    // ApiLayer stays skipped here because fawazahmed0 already covers the enabled set.
+    const fawazMock = getFawazCurrencyApiResponseMock(date);
+    fawazOverride.setOverride({ body: { ...fawazMock, usd: { ...fawazMock.usd, eur: 0.123456 } } });
 
     await helpers.syncExchangeRates();
 
@@ -114,6 +123,45 @@ describe('Exchange Rates Functionality', () => {
     const eur = response.find((r) => r.quoteCode === 'EUR')!;
     expect(eur.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.CURRENCY_RATES_API);
     expect(eur.rate).toBeCloseTo(primaryEur, 6);
+  });
+
+  it('early-stop skips ApiLayer when free providers cover every enabled currency', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+
+    // The default mock basket lacks SSP and STN, so the enabled set is never fully
+    // covered and ApiLayer would still be queried. Extend fawazahmed0 with both →
+    // full coverage after priority 2, so the paid ApiLayer call must be skipped.
+    const fawazMock = getFawazCurrencyApiResponseMock(date);
+    fawazOverride.setOverride({ body: { ...fawazMock, usd: { ...fawazMock.usd, ssp: 130.26, stn: 22.72 } } });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    expect(apiLayerCounter.count).toBe(0);
+
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    expect(response.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(false);
+    // The extended tail actually landed – proves coverage came from fawazahmed0.
+    expect(response.find((r) => r.quoteCode === 'SSP')?.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API);
+  });
+
+  it('gap alert fires when ApiLayer fills a currency fawazahmed0 lacks', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+    const errorSpy = jest.spyOn(logger, 'error');
+
+    // fawazahmed0 succeeds but its basket lacks ETB (a currency the primary never
+    // supplies), so only the paid ApiLayer can fill it. A post-2024 date where
+    // fawazahmed0 ran yet left a hole is a data anomaly the alert must surface.
+    const fawazMock = getFawazCurrencyApiResponseMock(date);
+    const usd = { ...fawazMock.usd };
+    delete usd.etb;
+    fawazOverride.setOverride({ body: { ...fawazMock, usd } });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    expect(loggerErrorCalledWith(errorSpy, '[ALERT:FAWAZ_CURRENCY_API_GAP]')).toBe(true);
+
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    expect(response.find((r) => r.quoteCode === 'ETB')?.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER);
   });
 
   it('never stores the base currency as a quote (no USD->USD self-rate)', async () => {
@@ -138,11 +186,12 @@ describe('Exchange Rates Functionality', () => {
 
   it('reports a Sentry event (logger.error) when a fallback provider is degraded', async () => {
     const errorSpy = jest.spyOn(logger, 'error');
-    // Primary stays healthy; the comprehensive fallback fails its health check
-    // (500), so it is skipped by isAvailable(). The exotic long tail is then
-    // uncovered – surfaced as a degraded-sync alert independent of the
-    // primary-degraded path.
-    apiLayerOverride.setOverride({ status: 500 });
+    // Primary stays healthy; the comprehensive fallback (fawazahmed0) fails, so
+    // its fetch yields nothing and the exotic long tail lands in `failed` –
+    // surfaced as a degraded-sync alert independent of the primary-degraded path.
+    // Degrading ApiLayer alone would do nothing now: it is skipped whenever
+    // fawazahmed0 covers the enabled set, so fawazahmed0 is what must go down.
+    fawazOverride.setOverride({ status: 500 });
 
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
@@ -152,7 +201,9 @@ describe('Exchange Rates Functionality', () => {
   it('reports a Sentry event (logger.error) listing enabled currencies missing from the result', async () => {
     const date = format(new Date(), 'yyyy-MM-dd');
     const errorSpy = jest.spyOn(logger, 'error');
-    // Starve the comprehensive provider so the exotic long tail is uncovered.
+    // Starve BOTH fallbacks so the exotic long tail is uncovered: fawazahmed0 down,
+    // ApiLayer trimmed to a single currency. Only the primary's ~38 currencies land.
+    fawazOverride.setOverride({ status: 500 });
     apiLayerOverride.setOverride({ body: { base: 'USD', date, success: true, timestamp: 1, rates: { EUR: 0.9 } } });
 
     await helpers.syncExchangeRates();
@@ -161,43 +212,50 @@ describe('Exchange Rates Functionality', () => {
       ([arg]) => typeof arg === 'string' && arg.includes('Enabled currencies missing'),
     );
     expect(coverageCall).toBeTruthy();
-    // Starving the comprehensive provider leaves the whole exotic long tail
-    // uncovered – far more than a healthy run would ever miss.
+    // Starving both fallbacks leaves the whole exotic long tail uncovered –
+    // far more than a healthy run would ever miss.
     const { missingCurrencies } = (coverageCall![1] ?? {}) as { missingCurrencies?: string[] };
     expect(Array.isArray(missingCurrencies)).toBe(true);
     expect(missingCurrencies!.length).toBeGreaterThan(50);
   });
 
-  it('skips the provider fetch on a re-sync once ApiLayer has covered the date', async () => {
+  it('skips the provider fetch on a re-sync once a comprehensive provider has covered the date', async () => {
     const date = format(new Date(), 'yyyy-MM-dd');
 
     await expect(helpers.getExchangeRates({ date, raw: true })).resolves.toBe(null);
 
-    // First sync populates the date, including ApiLayer-sourced rows.
+    // First sync: currency-rates-api + fawazahmed0 populate the date. fawazahmed0 is
+    // a whole-basket provider, so its rows mark the date comprehensively fetched,
+    // and it fills the exotic tail — leaving ApiLayer nothing to add.
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
-    // Confirm ApiLayer actually contributed – otherwise the gate below is vacuous.
     const seeded = (await helpers.getExchangeRates({ date, raw: true }))!;
-    expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(true);
+    // fawazahmed0 ran (its rows exist) → the comprehensiveness gate is satisfied,
+    // and ApiLayer contributed nothing, so no paid-provider row was written.
+    expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API)).toBe(true);
+    expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(false);
 
-    // The comprehensiveness gate keys off an ApiLayer-sourced row existing for the
-    // date, so a second sync must short-circuit BEFORE hitting any provider.
+    // The comprehensiveness gate (a whole-basket provider ran) must short-circuit
+    // the second sync BEFORE hitting any provider.
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
 
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
     expect(currencyRatesApiCounter.count).toBe(0);
+    expect(fawazCounter.count).toBe(0);
     expect(apiLayerCounter.count).toBe(0);
   });
 
-  it('re-fetches a date that has rates but none sourced from ApiLayer', async () => {
+  it('re-fetches a date whose rows come from no whole-basket provider', async () => {
     const date = format(new Date(), 'yyyy-MM-dd');
     const today = startOfDay(new Date());
 
-    // Seed a NON-comprehensive date: one Currency Rates API-sourced row, no
-    // ApiLayer. Mirrors a historical-init date (only the ECB-based provider ran),
-    // where an on-demand lookup should still reach ApiLayer for the exotic tail.
+    // Seed a NON-comprehensive date: one Currency Rates API-sourced row, nothing
+    // else. No whole-basket provider (fawazahmed0 / api-layer) has a row for the
+    // date, so the gate is false and the sync must still run the providers to fill
+    // the tail.
     await connection.sequelize.query(
       `INSERT INTO "ExchangeRates" ("baseCode", "quoteCode", "date", "rate", "source")
        VALUES ('USD', 'EUR', :today, 0.9, :source)`,
@@ -205,25 +263,27 @@ describe('Exchange Rates Functionality', () => {
     );
 
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
 
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
-    // No ApiLayer-sourced row exists → the gate must NOT skip; providers run.
+    // Gate is not comprehensive → the gate must NOT skip; providers run.
     expect(currencyRatesApiCounter.count).toBeGreaterThanOrEqual(1);
 
-    // And ApiLayer now contributes, making the date comprehensive going forward.
+    // fawazahmed0 now fills the exotic tail that Currency Rates API leaves out.
     const after = (await helpers.getExchangeRates({ date, raw: true }))!;
-    expect(after.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(true);
+    expect(after.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API)).toBe(true);
   });
 
   it('re-fetches a date where ApiLayer returned nothing (no api-layer row was written)', async () => {
     const date = format(new Date(), 'yyyy-MM-dd');
 
-    // ApiLayer down but the primary succeeds: the date gets rows, yet NONE are
-    // api-layer-sourced. The comprehensiveness gate keys off an api-layer row
-    // existing, so a date ApiLayer skipped (down / rate-limited / no key) must
-    // NOT be treated as covered – the next sync has to run again.
+    // Both fallbacks down: only Currency Rates API succeeds (its ~38 currencies), so
+    // no whole-basket provider (fawazahmed0 / api-layer) wrote a row. Neither
+    // comprehensiveness signal holds, so a date the fallbacks skipped (down /
+    // rate-limited / no key) must NOT be treated as covered – the next sync re-runs.
+    fawazOverride.setOverride({ status: 500 });
     apiLayerOverride.setOverride({ status: 500 });
 
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
@@ -233,16 +293,44 @@ describe('Exchange Rates Functionality', () => {
     expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(false);
 
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
 
-    // No api-layer row → gate is not comprehensive → providers must run again
-    // (the opposite of the "ApiLayer already covered the date" skip above).
+    // Neither fully covered nor api-layer-marked → gate stays non-comprehensive →
+    // providers must run again (the opposite of the "date fully covered" skip above).
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
 
     expect(currencyRatesApiCounter.count).toBeGreaterThanOrEqual(1);
   });
 
-  it('should fallback to ApiLayer when Currency Rates API fails', async () => {
+  it('skips the re-sync when only api-layer rows mark the date comprehensively fetched', async () => {
+    const date = format(new Date(), 'yyyy-MM-dd');
+
+    // fawazahmed0 down for the first sync → ApiLayer fills the exotic tail, so the
+    // only whole-basket rows for the date are api-layer-sourced. Those alone must
+    // satisfy the comprehensiveness gate: an outage day must not cause re-fetch loops.
+    fawazOverride.setOverride({ status: 500 });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    const seeded = (await helpers.getExchangeRates({ date, raw: true }))!;
+    expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(true);
+    expect(seeded.some((r) => r.source === EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API)).toBe(false);
+
+    // fawazahmed0 recovers, but the gate must short-circuit before any provider call.
+    global.mswMockServer.resetHandlers();
+    currencyRatesApiCounter.reset();
+    fawazCounter.reset();
+    apiLayerCounter.reset();
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    expect(currencyRatesApiCounter.count).toBe(0);
+    expect(fawazCounter.count).toBe(0);
+    expect(apiLayerCounter.count).toBe(0);
+  });
+
+  it('falls back to fawazahmed0 when Currency Rates API fails', async () => {
     // Simulate Currency Rates API failure
     currencyRatesApiOverride.setOverride({ status: 500 });
 
@@ -253,8 +341,33 @@ describe('Exchange Rates Functionality', () => {
     expect(response).toBeInstanceOf(Array);
     expect(response.length).toBeGreaterThan(0);
 
-    // Verify fallback occurred: Currency Rates API was unavailable, ApiLayer was used.
+    // Primary down → fawazahmed0 (priority 2) supplies every stored rate, so the
+    // paid ApiLayer (priority 3) contributes nothing and no api-layer-sourced row
+    // is written. ApiLayer is still queried here: a permanently-unpriceable
+    // enabled currency (e.g. SSP, absent from every mock) keeps the coverage
+    // check from short-circuiting. In production, where fawazahmed0 covers the
+    // full enabled set, the paid call is skipped entirely.
     expect(currencyRatesApiCounter.count).toBeGreaterThanOrEqual(1);
+    expect(fawazCounter.count).toBeGreaterThanOrEqual(1);
+    expect(response.some((item) => item.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER)).toBe(false);
+    response.forEach((item) => {
+      expect(item.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API);
+    });
+  });
+
+  it('falls back to ApiLayer when both Currency Rates API and fawazahmed0 fail', async () => {
+    // Both free providers down → the chain must reach the paid last-resort.
+    currencyRatesApiOverride.setOverride({ status: 500 });
+    fawazOverride.setOverride({ status: 500 });
+
+    await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
+
+    const date = format(new Date(), 'yyyy-MM-dd');
+    const response = (await helpers.getExchangeRates({ date, raw: true }))!;
+    expect(response).toBeInstanceOf(Array);
+    expect(response.length).toBeGreaterThan(0);
+
+    // ApiLayer (priority 3) is the only provider left to cover the date.
     expect(apiLayerCounter.count).toBeGreaterThanOrEqual(1);
     response.forEach((item) => {
       expect(item.source).toBe(EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER);
@@ -274,7 +387,7 @@ describe('Exchange Rates Functionality', () => {
     expect(currencyRatesApiCounter.count).toBeGreaterThanOrEqual(2);
   });
 
-  it('should fallback to ApiLayer when Currency Rates API returns an invalid base currency', async () => {
+  it('falls back to fawazahmed0 when Currency Rates API returns an invalid base currency', async () => {
     currencyRatesApiOverride.setOneTimeOverride({
       body: {
         ...getCurrencyRatesApiResponseMock('2024-11-17'),
@@ -282,20 +395,22 @@ describe('Exchange Rates Functionality', () => {
       },
     });
     // With the merging registry, an invalid response from a provider drops it
-    // from contribution and the chain continues to the next one.
+    // from contribution and the chain continues – fawazahmed0 then fills the set.
     await expect(helpers.syncExchangeRates().then((r) => r.statusCode)).resolves.toEqual(200);
   });
 
   it('should return 502 when all providers fail', async () => {
     currencyRatesApiOverride.setOverride({ status: 500 });
+    fawazOverride.setOverride({ status: 500 });
     apiLayerOverride.setOverride({ status: 500 });
 
     await expect(helpers.syncExchangeRates().then((m) => m.statusCode)).resolves.toBe(502);
   });
 
   it('should handle ApiLayer 429 by trying next available key', async () => {
-    // Make primary provider fail so the chain reaches ApiLayer.
+    // Make both free providers fail so the chain reaches ApiLayer.
     currencyRatesApiOverride.setOverride({ status: 500 });
+    fawazOverride.setOverride({ status: 500 });
 
     // ApiLayer returns 429 for first key, should try next key
     apiLayerOverride.setOneTimeOverride({ status: 429 });

--- a/packages/backend/src/services/exchange-rates/ensure-rates-for-date.ts
+++ b/packages/backend/src/services/exchange-rates/ensure-rates-for-date.ts
@@ -4,6 +4,7 @@ import { logger } from '@js/utils';
 import ExchangeRates from '@models/exchange-rates.model';
 import { withDeduplication } from '@services/common/with-deduplication';
 import { format, startOfDay } from 'date-fns';
+import { Op } from 'sequelize';
 
 import { API_LAYER_BASE_CURRENCY_CODE, API_LAYER_DATE_FORMAT } from './constants';
 import { exchangeRateProviderRegistry } from './providers';
@@ -81,7 +82,7 @@ export const fetchAndStoreRatesForDate = withDeduplication(
 
 /**
  * Daily full-sync entry point (the cron). Fetches the whole basket for `date`
- * unless the comprehensive provider (ApiLayer) has already covered it – making a
+ * unless it's already been fetched as comprehensively as it can be – making a
  * same-day re-run a no-op.
  */
 export async function ensureRatesForDate(date: Date): Promise<void> {
@@ -89,7 +90,7 @@ export async function ensureRatesForDate(date: Date): Promise<void> {
 
   if (await isDateComprehensivelyFetched(normalizedDate)) {
     logger.info(
-      `[Exchange Rates] ${format(normalizedDate, API_LAYER_DATE_FORMAT)} already covered by ApiLayer, skipping provider fetch`,
+      `[Exchange Rates] ${format(normalizedDate, API_LAYER_DATE_FORMAT)} already comprehensively fetched, skipping provider fetch`,
     );
     return;
   }
@@ -98,15 +99,31 @@ export async function ensureRatesForDate(date: Date): Promise<void> {
 }
 
 /**
- * Has the comprehensive provider (ApiLayer) already supplied data for this date?
- * Detected via the presence of any ApiLayer-sourced row. ApiLayer answers
- * per-DATE (its whole ~150-currency basket), so a single such row proves the
- * date was comprehensively fetched – any currency still absent is genuinely
- * unavailable for the date, and re-fetching is futile.
+ * Has this date already been fetched as comprehensively as it can be? True when
+ * a row from a WHOLE-BASKET provider – fawazahmed0 or ApiLayer – exists for the
+ * date. Both answer per-DATE with their entire basket, so once either has run
+ * any currency still absent (e.g. one neither provider quotes) is genuinely
+ * unavailable for that date, and re-fetching is futile.
+ *
+ * currency-rates-api is deliberately NOT a signal here: it only ever supplies
+ * its ~38 currencies, so its rows never prove the exotic tail was attempted.
+ * Below fawazahmed0's 2024-03-02 floor it never runs, so ApiLayer is the sole
+ * comprehensiveness signal there – which is correct, as ApiLayer is the only
+ * source for old exotic dates.
+ *
+ * Accepted imprecision: if fawazahmed0 left a gap AND the ApiLayer attempt to
+ * fill it failed in the same run, the fawazahmed0 rows still mark the date
+ * "done" and the gap is never retried for that date. Requires two coincident
+ * failures, damages one currency for one date (readers fall back to the
+ * nearest-date rate), and the degraded-sync alert reports the ApiLayer failure
+ * – so this stays a simple row-existence check rather than a coverage audit.
  */
 export async function isDateComprehensivelyFetched(date: Date): Promise<boolean> {
   const count = await ExchangeRates.count({
-    where: { date, source: EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER },
+    where: {
+      date,
+      source: { [Op.in]: [EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API, EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER] },
+    },
   });
   return count > 0;
 }

--- a/packages/backend/src/services/exchange-rates/providers/api-layer/api-layer.provider.ts
+++ b/packages/backend/src/services/exchange-rates/providers/api-layer/api-layer.provider.ts
@@ -4,7 +4,8 @@
  * Comprehensive exchange rate service with 150+ currencies.
  * Requires API key(s) and has rate limiting.
  *
- * Priority: 2 (secondary - most comprehensive but costs money)
+ * Priority: 3 (third / last-resort - most comprehensive but costs money, so it
+ * only runs after the two free providers leave a gap)
  */
 import Currencies from '@models/currencies.model';
 import axios, { isAxiosError } from 'axios';
@@ -38,7 +39,7 @@ export class ApiLayerProvider extends BaseExchangeRateProvider {
     type: EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER,
     name: 'ApiLayer',
     description: 'Comprehensive exchange rate API with 150+ currencies (Fixer)',
-    priority: 2, // Secondary fallback after currency-rates-api
+    priority: 3, // Third / last-resort paid fallback, after the two free providers
     // ApiLayer supports many currencies, don't limit here
     supportedCurrencies: undefined,
   };

--- a/packages/backend/src/services/exchange-rates/providers/fawaz-currency-api/fawaz-currency-api.provider.ts
+++ b/packages/backend/src/services/exchange-rates/providers/fawaz-currency-api/fawaz-currency-api.provider.ts
@@ -1,0 +1,153 @@
+/**
+ * fawazahmed0 / exchange-api Provider
+ *
+ * Free, key-less currency rate CDN (jsDelivr primary, Cloudflare mirror as
+ * fallback). Same USD-per-quote convention as the other providers, but the base
+ * and quote keys arrive LOWERCASE. Single-date only — there is NO range
+ * endpoint — so it deliberately stays out of the historical backfill.
+ *
+ * Priority: 2 (secondary - free, covers the exotic long tail on fresh dates,
+ * but only from 2024-03-02 onward; earlier dates 404).
+ */
+import Currencies from '@models/currencies.model';
+import axios, { AxiosResponse } from 'axios';
+
+import { BaseExchangeRateProvider } from '../base-provider';
+import {
+  EXCHANGE_RATE_PROVIDER_TYPE,
+  ExchangeRateProviderMetadata,
+  ExchangeRateResult,
+  FetchRatesParams,
+} from '../types';
+
+/**
+ * fawazahmed0 single-date response. The base-currency key (e.g. `usd`) holds the
+ * quote->rate map; both the base key and the quote keys are lowercase.
+ */
+interface FawazResponse {
+  date: string;
+  [base: string]: string | Record<string, number>;
+}
+
+// Data floor: dates before this 404 on both mirrors, so we never hit the network below it.
+const FAWAZ_MIN_DATE = '2024-03-02';
+const REQUEST_TIMEOUT = 10000; // 10 seconds
+
+// Dated (immutable) endpoints. `@latest` is intentionally avoided — the CDN caches
+// it and can lag by a day. `date` = yyyy-MM-dd, `base` = lowercase currency code.
+const buildJsDelivrUrl = ({ date, base }: { date: string; base: string }): string =>
+  `https://cdn.jsdelivr.net/npm/@fawazahmed0/currency-api@${date}/v1/currencies/${base}.min.json`;
+const buildCloudflareUrl = ({ date, base }: { date: string; base: string }): string =>
+  `https://${date}.currency-api.pages.dev/v1/currencies/${base}.min.json`;
+
+export class FawazCurrencyApiProvider extends BaseExchangeRateProvider {
+  readonly metadata: ExchangeRateProviderMetadata = {
+    type: EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API,
+    name: 'Fawaz Currency API',
+    description: 'Free CDN rates, 200+ currencies incl. exotic tail, from 2024-03-02',
+    priority: 2, // Secondary - free, fills the exotic long tail on fresh dates
+    supportedCurrencies: undefined,
+    minHistoricalDate: FAWAZ_MIN_DATE,
+    // supportsHistoricalDataLoading intentionally unset: there is no range endpoint,
+    // so this provider is excluded from the startup historical backfill (like ApiLayer).
+  };
+
+  /**
+   * Always available: public CDN with no credentials to validate.
+   */
+  async isAvailable(): Promise<boolean> {
+    return true;
+  }
+
+  /**
+   * Deliberately NO yesterday-fallback here (unlike currency-rates-api): a stale
+   * whole-basket result would be stored under the requested date, satisfy the
+   * comprehensiveness gate, and suppress the ApiLayer fallback — silently pinning
+   * day-old rates. Returning null instead lets the chain reach ApiLayer, which
+   * serves the real requested date.
+   */
+  async fetchRatesForDate(params: FetchRatesParams): Promise<ExchangeRateResult | null> {
+    return this.fetchRatesForSingleDate(params);
+  }
+
+  /**
+   * Fetch rates for a single specific date (no fallback). Tries the jsDelivr CDN
+   * first and falls back to the Cloudflare mirror on any failure.
+   */
+  private async fetchRatesForSingleDate(params: FetchRatesParams): Promise<ExchangeRateResult | null> {
+    const formattedDate = this.formatDate(params.date);
+
+    // Below the data floor every request is a guaranteed 404, so skip the network
+    // entirely — this keeps ApiLayer the sole source for pre-2024 dates.
+    if (formattedDate < FAWAZ_MIN_DATE) {
+      this.logInfo(`Date ${formattedDate} is before the data floor ${FAWAZ_MIN_DATE}, skipping fetch`);
+      return null;
+    }
+
+    const base = this.getBaseCurrency(params).toLowerCase();
+
+    // jsDelivr is primary; the Cloudflare mirror is the README-recommended fallback.
+    const candidateUrls = [
+      buildJsDelivrUrl({ date: formattedDate, base }),
+      buildCloudflareUrl({ date: formattedDate, base }),
+    ];
+
+    this.logInfo(`Fetching rates for ${formattedDate}`);
+
+    let response: AxiosResponse<FawazResponse> | null = null;
+    let lastError: unknown = null;
+    for (const url of candidateUrls) {
+      try {
+        response = await axios.get<FawazResponse>(url, {
+          timeout: REQUEST_TIMEOUT,
+          responseType: 'json',
+        });
+        break;
+      } catch (error) {
+        // Warn per mirror so a dead primary CDN stays visible even while the
+        // fallback mirror keeps the provider working.
+        this.logWarn(`Fetch failed from ${url}`, {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        lastError = error;
+      }
+    }
+
+    if (!response) {
+      this.handleFetchError({ error: lastError, date: formattedDate });
+      return null;
+    }
+
+    const rateMap = response.data?.[base] as Record<string, number> | undefined;
+    if (!rateMap) {
+      this.logInfo(`Invalid response for date ${formattedDate}`);
+      return null;
+    }
+
+    // Keep only currencies we track; upcase keys to our canonical form and drop
+    // the base's own self-rate.
+    const validCodes = new Set((await Currencies.findAll()).map((c) => c.code));
+    const baseUpper = base.toUpperCase();
+    const filteredRates: Record<string, number> = {};
+    for (const [code, rate] of Object.entries(rateMap)) {
+      const upperCode = code.toUpperCase();
+      if (validCodes.has(upperCode) && upperCode !== baseUpper) {
+        filteredRates[upperCode] = rate;
+      }
+    }
+
+    // Apply the optional target-currency filter on top of the tracked-currency filter.
+    const rates = this.filterRatesByCurrencies({
+      rates: filteredRates,
+      targetCurrencies: params.targetCurrencies,
+    });
+
+    this.logInfo(`Fetched ${Object.keys(rates).length} rates for ${formattedDate}`);
+
+    return {
+      date: response.data.date ?? formattedDate,
+      baseCurrency: baseUpper,
+      rates,
+    };
+  }
+}

--- a/packages/backend/src/services/exchange-rates/providers/fawaz-currency-api/index.ts
+++ b/packages/backend/src/services/exchange-rates/providers/fawaz-currency-api/index.ts
@@ -1,0 +1,1 @@
+export * from './fawaz-currency-api.provider';

--- a/packages/backend/src/services/exchange-rates/providers/index.ts
+++ b/packages/backend/src/services/exchange-rates/providers/index.ts
@@ -12,4 +12,5 @@ export * from './initialize-providers';
 
 // Individual providers
 export * from './currency-rates-api';
+export * from './fawaz-currency-api';
 export * from './api-layer';

--- a/packages/backend/src/services/exchange-rates/providers/initialize-providers.ts
+++ b/packages/backend/src/services/exchange-rates/providers/initialize-providers.ts
@@ -3,7 +3,8 @@
  *
  * Providers are registered in priority order:
  * 1. Currency Rates API (custom service) - Priority 1
- * 2. ApiLayer (comprehensive, paid) - Priority 2
+ * 2. fawazahmed0 Currency API (free CDN) - Priority 2
+ * 3. ApiLayer (comprehensive, paid) - Priority 3
  *
  * To disable a provider, simply comment out its registration line.
  */
@@ -11,6 +12,7 @@ import { logger } from '@js/utils';
 
 import { ApiLayerProvider } from './api-layer';
 import { CurrencyRatesApiProvider } from './currency-rates-api';
+import { FawazCurrencyApiProvider } from './fawaz-currency-api';
 import { exchangeRateProviderRegistry } from './registry';
 
 /**
@@ -23,7 +25,10 @@ export function initializeExchangeRateProviders(): void {
   // Priority 1: Custom Currency Rates API (try first)
   exchangeRateProviderRegistry.register(new CurrencyRatesApiProvider());
 
-  // Priority 2: ApiLayer (comprehensive, paid fallback for the exotic long tail)
+  // Priority 2: fawazahmed0 Currency API (free CDN, fills the exotic long tail on fresh dates)
+  exchangeRateProviderRegistry.register(new FawazCurrencyApiProvider());
+
+  // Priority 3: ApiLayer (comprehensive, paid last-resort fallback)
   exchangeRateProviderRegistry.register(new ApiLayerProvider());
 
   logger.info(`Initialized ${exchangeRateProviderRegistry.getCount()} exchange rate providers`);

--- a/packages/backend/src/services/exchange-rates/providers/registry.ts
+++ b/packages/backend/src/services/exchange-rates/providers/registry.ts
@@ -141,9 +141,13 @@ class ExchangeRateProviderRegistry {
    * Each provider is queried and its rates are merged into the result, but a
    * lower-priority provider only fills currencies the higher-priority ones did
    * NOT supply. This is a gap-filling merge, not first-success-wins: the primary
-   * provider (currency-rates-api) covers ~38 currencies, so the chain MUST
-   * continue to the comprehensive fallback (ApiLayer) to refresh the long tail
-   * of exotic currencies — otherwise those rates go permanently stale.
+   * (currency-rates-api) covers ~38 currencies, so the chain continues to the
+   * free fawazahmed0 provider to refresh the exotic long tail — otherwise those
+   * rates go permanently stale.
+   *
+   * The chain early-stops once every enabled currency is covered, so the paid
+   * last-resort (ApiLayer) is only queried when the free providers leave a gap
+   * (mostly pre-2024 exotic dates, which fawazahmed0 can't serve).
    *
    * @param params - Fetch parameters
    * @returns Merged exchange rates with per-currency attribution, or null if
@@ -170,11 +174,55 @@ class ExchangeRateProviderRegistry {
     }
 
     const baseCurrency = params.baseCurrency ?? DEFAULT_BASE_CURRENCY;
+
+    // Fetch the enabled currency set once, tolerating a DB failure. Reused for the
+    // per-provider early-stop check, the fawazahmed0-gap alert, and the degraded-sync
+    // coverage report — so it is never queried more than once per run.
+    let enabledCodes: string[] | null = null;
+    try {
+      enabledCodes = (await getAllCurrencies()).map((c) => c.code);
+    } catch (error) {
+      // Without the enabled set, the ApiLayer early-stop and both coverage
+      // alerts are disabled for this run — must stay visible in logs.
+      logger.error('[exchange-rates] Could not load enabled currencies; coverage checks disabled for this run', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    const requestedDate = params.date.toISOString().slice(0, 10);
     const providerRates: ProviderRatesInput[] = [];
     const failed: ProviderFailure[] = [];
     let resultDate: string | undefined;
 
     for (const provider of available) {
+      // Early-stop: once the higher-priority (free) providers already cover every
+      // enabled currency, skip the remaining lower-priority ones. This keeps the
+      // paid ApiLayer fetch from firing when there is nothing left to fill.
+      if (enabledCodes && enabledCodes.length > 0 && providerRates.length > 0) {
+        const { rates: coveredSoFar } = mergeProviderRates({ providerRates, baseCurrency });
+        const stillMissing = findMissingCurrencies({
+          expected: enabledCodes,
+          covered: Object.keys(coveredSoFar),
+          baseCurrency,
+        });
+        if (stillMissing.length === 0) {
+          logger.info(
+            `[exchange-rates] All enabled currencies covered before ${provider.metadata.name}; skipping remaining lower-priority providers`,
+          );
+          break;
+        }
+      }
+
+      // A provider whose data floor is above the requested date has nothing to
+      // serve by design (e.g. fawazahmed0 starts 2024-03-02). Skip it without
+      // recording a failure so the degraded-sync alert only reports real problems.
+      if (provider.metadata.minHistoricalDate && requestedDate < provider.metadata.minHistoricalDate) {
+        logger.info(
+          `[exchange-rates] ${provider.metadata.name} skipped: ${requestedDate} predates its data floor ${provider.metadata.minHistoricalDate}`,
+        );
+        continue;
+      }
+
       try {
         logger.info(`Attempting to fetch rates from ${provider.metadata.name}`);
         const result = await provider.fetchRatesForDate(params);
@@ -211,7 +259,33 @@ class ExchangeRateProviderRegistry {
       rates,
     };
 
-    await this.reportDegradedSync({ failed, unavailable, providersUsed, merged });
+    // fawazahmed0 MUST have data for any date >= its floor, so an enabled currency
+    // ApiLayer had to fill on such a date is a data anomaly worth a Sentry signal.
+    // Deliberately narrow: a fawaz fetch FAILURE is already reported by the
+    // degraded-sync alert, and a currency missing entirely by the coverage alert —
+    // this one only flags "fawaz ran but lacked a rate the paid fallback had".
+    // The floor compares the REQUESTED date, not merged.date (a provider's own
+    // stale-date fallback must not shift the check). Runs on BOTH the daily and
+    // the on-demand paths since both route through here.
+    const fawaz = available.find((p) => p.metadata.type === EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API);
+    const fawazFailed = failed.some((p) => p.type === EXCHANGE_RATE_PROVIDER_TYPE.FAWAZ_CURRENCY_API);
+    if (
+      fawaz &&
+      !fawazFailed &&
+      enabledCodes &&
+      fawaz.metadata.minHistoricalDate &&
+      requestedDate >= fawaz.metadata.minHistoricalDate
+    ) {
+      const gap = enabledCodes.filter((code) => merged.rates[code]?.source === EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER);
+      if (gap.length > 0) {
+        logger.error('[ALERT:FAWAZ_CURRENCY_API_GAP] fawazahmed0 missing post-2024 rate(s); filled by ApiLayer', {
+          gapCurrencies: gap,
+          date: requestedDate,
+        });
+      }
+    }
+
+    await this.reportDegradedSync({ failed, unavailable, providersUsed, merged, enabledCodes });
 
     return { merged, providersUsed };
   }
@@ -230,11 +304,13 @@ class ExchangeRateProviderRegistry {
     unavailable,
     providersUsed,
     merged,
+    enabledCodes,
   }: {
     failed: ProviderFailure[];
     unavailable: ProviderFailure[];
     providersUsed: ProviderContribution[];
     merged: MergedRatesForDate;
+    enabledCodes: string[] | null;
   }): Promise<void> {
     const degradedProviders = [...failed, ...unavailable];
 
@@ -252,24 +328,22 @@ class ExchangeRateProviderRegistry {
       });
     }
 
-    // Compare against the currencies users can actually select.
-    try {
-      const enabled = (await getAllCurrencies()).map((c) => c.code);
-      const missingCurrencies = findMissingCurrencies({
-        expected: enabled,
-        covered: Object.keys(merged.rates),
-        baseCurrency: merged.baseCurrency,
-      });
-      if (missingCurrencies.length > 0) {
-        logger.error('[exchange-rates] Enabled currencies missing from sync result', {
-          missingCurrencies,
-          missingCount: missingCurrencies.length,
-          date: merged.date,
-        });
-      }
-    } catch (error) {
-      logger.warn('Could not check currency coverage for sync result', {
-        error: error instanceof Error ? error.message : String(error),
+    // Compare against the currencies users can actually select. `enabledCodes` is
+    // pre-fetched by the caller (one query per run); if it couldn't be loaded, skip
+    // the coverage check.
+    if (!enabledCodes) {
+      return;
+    }
+    const missingCurrencies = findMissingCurrencies({
+      expected: enabledCodes,
+      covered: Object.keys(merged.rates),
+      baseCurrency: merged.baseCurrency,
+    });
+    if (missingCurrencies.length > 0) {
+      logger.error('[exchange-rates] Enabled currencies missing from sync result', {
+        missingCurrencies,
+        missingCount: missingCurrencies.length,
+        date: merged.date,
       });
     }
   }

--- a/packages/backend/src/services/user-exchange-rate/get-user-exchange-rates.e2e.ts
+++ b/packages/backend/src/services/user-exchange-rate/get-user-exchange-rates.e2e.ts
@@ -3,7 +3,11 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, jest } from '@j
 import { logger } from '@js/utils';
 import { connection } from '@models/index';
 import * as helpers from '@tests/helpers';
-import { API_LAYER_ENDPOINT_REGEX, CURRENCY_RATES_API_ENDPOINT_REGEX } from '@tests/mocks/exchange-rates/endpoints';
+import {
+  API_LAYER_ENDPOINT_REGEX,
+  CURRENCY_RATES_API_ENDPOINT_REGEX,
+  FAWAZ_CURRENCY_API_ENDPOINT_REGEX,
+} from '@tests/mocks/exchange-rates/endpoints';
 import { createCallsCounter, createOverride } from '@tests/mocks/helpers';
 import { startOfDay, subYears } from 'date-fns';
 
@@ -59,16 +63,20 @@ const deleteRatesFor = async (quoteCode: string) => {
 
 describe('getUserExchangeRates (cross-rate cache + fallback semantics)', () => {
   let currencyRatesApiOverride: ReturnType<typeof createOverride>;
+  let fawazOverride: ReturnType<typeof createOverride>;
   let apiLayerOverride: ReturnType<typeof createOverride>;
 
   let currencyRatesApiCounter: ReturnType<typeof createCallsCounter>;
+  let fawazCounter: ReturnType<typeof createCallsCounter>;
   let apiLayerCounter: ReturnType<typeof createCallsCounter>;
 
   beforeAll(() => {
     currencyRatesApiOverride = createOverride(global.mswMockServer, CURRENCY_RATES_API_ENDPOINT_REGEX);
+    fawazOverride = createOverride(global.mswMockServer, FAWAZ_CURRENCY_API_ENDPOINT_REGEX);
     apiLayerOverride = createOverride(global.mswMockServer, API_LAYER_ENDPOINT_REGEX);
 
     currencyRatesApiCounter = createCallsCounter(global.mswMockServer, CURRENCY_RATES_API_ENDPOINT_REGEX);
+    fawazCounter = createCallsCounter(global.mswMockServer, FAWAZ_CURRENCY_API_ENDPOINT_REGEX);
     apiLayerCounter = createCallsCounter(global.mswMockServer, API_LAYER_ENDPOINT_REGEX);
   });
 
@@ -82,6 +90,7 @@ describe('getUserExchangeRates (cross-rate cache + fallback semantics)', () => {
   afterEach(async () => {
     global.mswMockServer.resetHandlers();
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
     jest.restoreAllMocks();
     await deleteRatesFor(EXOTIC);
@@ -94,6 +103,9 @@ describe('getUserExchangeRates (cross-rate cache + fallback semantics)', () => {
 
   const failAllProviders = () => {
     currencyRatesApiOverride.setOverride({ status: 500 });
+    // fawazahmed0 covers XAF for today, so it must go down too or the "providers
+    // down" tests would get a live rate for EXOTIC and never hit the fallback path.
+    fawazOverride.setOverride({ status: 500 });
     apiLayerOverride.setOverride({ status: 500 });
   };
 
@@ -177,12 +189,14 @@ describe('getUserExchangeRates (cross-rate cache + fallback semantics)', () => {
     });
 
     currencyRatesApiCounter.reset();
+    fawazCounter.reset();
     apiLayerCounter.reset();
 
     const rate = await readExoticRate();
 
     expect(rate).toBeGreaterThan(0);
     expect(currencyRatesApiCounter.count).toBe(0);
+    expect(fawazCounter.count).toBe(0);
     expect(apiLayerCounter.count).toBe(0);
   });
 });

--- a/packages/backend/src/tests/mocks/exchange-rates/data.ts
+++ b/packages/backend/src/tests/mocks/exchange-rates/data.ts
@@ -227,6 +227,19 @@ export const getApiLayerResposeMock = (date: string) => ({
   customMock: true,
 });
 
+// fawazahmed0 response shape: { date, usd: { <lowercased-code>: rate } }.
+// Built from the ApiLayer basket with lowercased keys and identical values, so
+// this provider covers the exact same full set — which is what lets it fill the
+// exotic tail and keep ApiLayer skipped on a happy-path sync.
+export const getFawazCurrencyApiResponseMock = (date: string) => {
+  const { rates } = getApiLayerResposeMock(date);
+  const usd: Record<string, number> = {};
+  for (const [code, rate] of Object.entries(rates)) {
+    usd[code.toLowerCase()] = rate;
+  }
+  return { date, usd };
+};
+
 export const getCurrencyRatesApiResponseMock = (date: string) => ({
   amount: 1,
   base: 'USD',

--- a/packages/backend/src/tests/mocks/exchange-rates/endpoints.ts
+++ b/packages/backend/src/tests/mocks/exchange-rates/endpoints.ts
@@ -5,3 +5,6 @@
  */
 export const API_LAYER_ENDPOINT_REGEX = /https:\/\/api.apilayer.com\/fixer/;
 export const CURRENCY_RATES_API_ENDPOINT_REGEX = /http:\/\/currency-rates-api:8080/;
+// fawazahmed0 CDN: jsDelivr primary + Cloudflare Pages mirror.
+export const FAWAZ_CURRENCY_API_ENDPOINT_REGEX =
+  /(cdn\.jsdelivr\.net\/npm\/@fawazahmed0\/currency-api|currency-api\.pages\.dev)/;

--- a/packages/backend/src/tests/mocks/exchange-rates/use-mock-api.ts
+++ b/packages/backend/src/tests/mocks/exchange-rates/use-mock-api.ts
@@ -1,7 +1,11 @@
-import { API_LAYER_ENDPOINT_REGEX, CURRENCY_RATES_API_ENDPOINT_REGEX } from '@tests/mocks/exchange-rates/endpoints';
+import {
+  API_LAYER_ENDPOINT_REGEX,
+  CURRENCY_RATES_API_ENDPOINT_REGEX,
+  FAWAZ_CURRENCY_API_ENDPOINT_REGEX,
+} from '@tests/mocks/exchange-rates/endpoints';
 import { HttpResponse, http } from 'msw';
 
-import { getApiLayerResposeMock, getCurrencyRatesApiResponseMock } from './data';
+import { getApiLayerResposeMock, getCurrencyRatesApiResponseMock, getFawazCurrencyApiResponseMock } from './data';
 
 export const exchangeRatesHandlers = [
   // Currency Rates API handler (priority 1 - tried first)
@@ -46,7 +50,22 @@ export const exchangeRatesHandlers = [
       status: 400,
     });
   }),
-  // ApiLayer handler (priority 2 - secondary fallback)
+  // fawazahmed0 handler (priority 2 - free CDN, covers the exotic tail).
+  // Required even though it's a default: the MSW server bypasses unhandled
+  // requests, so without this tests would hit the real jsDelivr CDN. The date
+  // sits in the path for jsDelivr (@YYYY-MM-DD) and in the subdomain for the
+  // Cloudflare mirror (YYYY-MM-DD.currency-api.pages.dev) — one regex catches both.
+  http.get(FAWAZ_CURRENCY_API_ENDPOINT_REGEX, ({ request }) => {
+    const url = request.url;
+    const dateMatch = url.match(/\d{4}-\d{2}-\d{2}/);
+    if (dateMatch) {
+      return HttpResponse.json(getFawazCurrencyApiResponseMock(dateMatch[0]));
+    }
+    return new HttpResponse(JSON.stringify({ error: 'Invalid date in URL' }), {
+      status: 400,
+    });
+  }),
+  // ApiLayer handler (priority 3 - last-resort fallback)
   http.get(API_LAYER_ENDPOINT_REGEX, ({ request }) => {
     const url = request.url;
     const dateMatch = url.match(/\d{4}-\d{2}-\d{2}/);

--- a/packages/shared/src/types/enums.ts
+++ b/packages/shared/src/types/enums.ts
@@ -57,14 +57,13 @@ export type DeactivationReason = (typeof DEACTIVATION_REASON)[keyof typeof DEACT
 
 /**
  * Identifies the exchange rate provider that supplied a given rate.
- * Persisted as the `source` column on the `ExchangeRates` table.
- *
- * NOTE: keep in sync with the CHECK constraint maintained by migrations under
- * `packages/backend/src/migrations/` (currently the
- * `20260608000000-drop-frankfurter-provider.ts` migration owns the latest set).
+ * Persisted as the free-form `VARCHAR` `source` column on the `ExchangeRates`
+ * table. This enum is the SOLE source of truth for valid values — so adding a
+ * provider is a code-only change with no migration.
  */
 export enum EXCHANGE_RATE_PROVIDER_TYPE {
   CURRENCY_RATES_API = 'currency-rates-api',
+  FAWAZ_CURRENCY_API = 'fawaz-currency-api',
   API_LAYER = 'api-layer',
   /**
    * Catch-all for rows whose origin cannot be determined.


### PR DESCRIPTION
Adds a new `fawazahmed0/exchange-api` data provider that supports 200+ currencies with a limited historical data up to 2024y