### PR TITLE
Lock the app during base currency changing process

### DIFF
--- a/packages/backend/src/controllers/currencies/change-base-currency-status.controller.ts
+++ b/packages/backend/src/controllers/currencies/change-base-currency-status.controller.ts
@@ -1,0 +1,13 @@
+import { createController } from '@controllers/helpers/controller-factory';
+import { getBaseCurrencyChangeStatus } from '@services/currencies/base-currency-change-status.service';
+import { z } from 'zod';
+
+const schema = z.object({});
+
+export default createController(schema, async ({ user, res }) => {
+  // Polled every 2s to drive the blocking overlay — an ETag/conditional-cache hit
+  // here could freeze a client on a stale status, so opt out of HTTP caching.
+  res.setHeader('Cache-Control', 'no-store');
+  const status = await getBaseCurrencyChangeStatus({ userId: user.id });
+  return { data: status };
+});

--- a/packages/backend/src/controllers/currencies/change-base-currency.controller.ts
+++ b/packages/backend/src/controllers/currencies/change-base-currency.controller.ts
@@ -2,7 +2,7 @@ import { currencyCode } from '@common/lib/zod/custom-types';
 import { createController } from '@controllers/helpers/controller-factory';
 import { t } from '@i18n/index';
 import { ValidationError } from '@js/errors';
-import { changeBaseCurrency } from '@root/services/currencies/change-base-currency.service';
+import { enqueueBaseCurrencyChange } from '@services/currencies/base-currency-change-queue';
 import { exchangeRateProviderRegistry } from '@services/exchange-rates/providers';
 import { z } from 'zod';
 
@@ -13,7 +13,8 @@ const schema = z.object({
 });
 
 export default createController(schema, async ({ user, body }) => {
-  // Validate that the currency is supported by providers that handle historical data
+  // Historical-rate coverage is checked before enqueue so an unsupported currency
+  // never takes the lock or spins up a job that would only fail on first conversion.
   if (!exchangeRateProviderRegistry.isCurrencySupportedForHistoricalData(body.newCurrencyCode)) {
     const supportedCurrencies = exchangeRateProviderRegistry.getSupportedCurrenciesForHistoricalData();
     throw new ValidationError({
@@ -24,13 +25,16 @@ export default createController(schema, async ({ user, body }) => {
     });
   }
 
-  const result = await changeBaseCurrency({
+  // The recalculation runs as a background job. Remaining validation (share
+  // blockers, same-currency) and the enqueue-time lock live in the queue service;
+  // share-blocker rejections still surface synchronously here.
+  const { jobId, state } = await enqueueBaseCurrencyChange({
     userId: user.id,
     newCurrencyCode: body.newCurrencyCode,
   });
 
   return {
-    data: result,
-    statusCode: 200,
+    data: { jobId, state },
+    statusCode: 202,
   };
 });

--- a/packages/backend/src/i18n/locales/en.json
+++ b/packages/backend/src/i18n/locales/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
-    "processAlreadyLocked": "Sync process for \"{{lockKey}}\" is already locked."
+    "processAlreadyLocked": "Sync process for \"{{lockKey}}\" is already locked.",
+    "serviceTemporarilyUnavailable": "Service temporarily unavailable. Please try again."
   },
   "accounts": {
     "groupNotFound": "Group or account not found",
@@ -283,6 +284,10 @@
     "alreadyBaseCurrency": "The selected currency is already a base currency",
     "baseCurrencyLockedByShares": "Cannot change base currency while you have active shared resources. Revoke or leave them first.",
     "baseCurrencyLockedByHousehold": "Cannot change base currency while you are part of an active household. Revoke or leave your household membership first.",
+    "baseCurrencyChangeInProgress": "Base currency change is in progress. Please wait until it completes.",
+    "baseCurrencyChangeSyncInProgress": "A bank sync is still finishing. Please try changing your base currency again in a few minutes.",
+    "baseCurrencyChangeDrainCheckFailed": "Could not verify bank syncs are idle. Please try again.",
+    "baseCurrencyChangeInProgressOtherUser": "The other participant is currently changing their base currency. Please try again once their migration finishes.",
     "cannotFindForRefAmount": "Cannot find currency to calculate ref amount!",
     "cannotCalculateRefAmount": "Cannot calculate ref amount",
     "currencyNotConnected": "Asked currency is not connected",

--- a/packages/backend/src/middlewares/check-base-currency-lock.ts
+++ b/packages/backend/src/middlewares/check-base-currency-lock.ts
@@ -1,8 +1,9 @@
 import { API_ERROR_CODES, API_RESPONSE_STATUS } from '@bt/shared/types';
+import { t } from '@i18n/index';
 import { ERROR_CODES } from '@js/errors';
+import { logger } from '@js/utils/logger';
 import Users from '@models/users.model';
-import { redisClient } from '@root/redis-client';
-import { buildLockKey } from '@root/services/currencies/change-base-currency.service';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import type { NextFunction, Request, Response } from 'express';
 
 /**
@@ -31,14 +32,31 @@ export const checkBaseCurrencyLock = async (
     });
   }
 
-  // Check if base currency change is in progress for this user
-  const lockExists = await redisClient.get(buildLockKey(userId));
+  // Fail closed on a Redis hiccup. Express 4 doesn't catch async rejections, so an
+  // unhandled throw here would hang the request forever with no response — respond
+  // 503 and let the client retry instead.
+  let lockExists: boolean;
+  try {
+    lockExists = await isBaseCurrencyChangeLocked({ userId });
+  } catch (error) {
+    logger.error({
+      message: 'Base currency lock check failed',
+      error: error instanceof Error ? error : new Error(String(error)),
+    });
+    return res.status(ERROR_CODES.ServiceUnavailable).json({
+      status: API_RESPONSE_STATUS.error,
+      response: {
+        message: t({ key: 'common.serviceTemporarilyUnavailable' }),
+        code: API_ERROR_CODES.serviceUnavailable,
+      },
+    });
+  }
 
   if (lockExists) {
     return res.status(ERROR_CODES.Locked).json({
       status: API_RESPONSE_STATUS.error,
       response: {
-        message: 'Base currency change is in progress. Please wait until it completes.',
+        message: t({ key: 'currencies.baseCurrencyChangeInProgress' }),
         code: API_ERROR_CODES.baseCurrencyChangeInProgress,
       },
     });

--- a/packages/backend/src/routes/account-groups.ts
+++ b/packages/backend/src/routes/account-groups.ts
@@ -1,5 +1,6 @@
 import * as accountGroupController from '@controllers/account-groups';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -8,6 +9,7 @@ const router = Router();
 router.post(
   '/',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.createAccountGroup.schema),
   accountGroupController.createAccountGroup.handler,
 );
@@ -22,6 +24,7 @@ router.get(
 router.put(
   '/:groupId',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.updateGroup.schema),
   accountGroupController.updateGroup.handler,
 );
@@ -29,6 +32,7 @@ router.put(
 router.delete(
   '/:groupId',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.deleteGroup.schema),
   accountGroupController.deleteGroup.handler,
 );
@@ -36,6 +40,7 @@ router.delete(
 router.post(
   '/:groupId/add-account/:accountId',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.addAccountToGroup.schema),
   accountGroupController.addAccountToGroup.handler,
 );
@@ -43,6 +48,7 @@ router.post(
 router.delete(
   '/:groupId/accounts',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.removeAccountFromGroup.schema),
   accountGroupController.removeAccountFromGroup.handler,
 );
@@ -50,6 +56,7 @@ router.delete(
 router.put(
   '/:groupId/move',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(accountGroupController.moveAccountToGroup.schema),
   accountGroupController.moveAccountToGroup.handler,
 );

--- a/packages/backend/src/routes/accounts.route.ts
+++ b/packages/backend/src/routes/accounts.route.ts
@@ -41,18 +41,21 @@ router.delete(
 router.post(
   '/:id/unlink',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(unlinkAccountFromBankConnection.schema),
   unlinkAccountFromBankConnection.handler,
 );
 router.post(
   '/:id/link',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(linkAccountToBankConnection.schema),
   linkAccountToBankConnection.handler,
 );
 router.post(
   '/:id/balance-adjustment',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(balanceAdjustment.schema),
   balanceAdjustment.handler,
 );

--- a/packages/backend/src/routes/bank-data-providers.route.ts
+++ b/packages/backend/src/routes/bank-data-providers.route.ts
@@ -20,6 +20,7 @@ import getSyncStatus from '@controllers/bank-data-providers/sync/get-sync-status
 import triggerSync from '@controllers/bank-data-providers/sync/trigger-sync';
 import { authenticateSession } from '@middlewares/better-auth';
 import { blockDemoUsers } from '@middlewares/block-demo-users';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import express from 'express';
 
@@ -50,6 +51,7 @@ router.post(
   '/:providerType/connect',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(connectProvider.schema),
   connectProvider.handler,
 );
@@ -57,6 +59,7 @@ router.delete(
   '/connections/:connectionId',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(disconnectProvider.schema),
   disconnectProvider.handler,
 );
@@ -64,6 +67,7 @@ router.post(
   '/connections/:connectionId/reauthorize',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(reauthorizeConnection.schema),
   reauthorizeConnection.handler,
 );
@@ -71,6 +75,7 @@ router.patch(
   '/connections/:connectionId',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(updateConnectionDetails.schema),
   updateConnectionDetails.handler,
 );
@@ -87,6 +92,7 @@ router.post(
   '/connections/:connectionId/sync-selected-accounts',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(connectSelectedAccounts.schema),
   connectSelectedAccounts.handler,
 );
@@ -96,6 +102,7 @@ router.post(
   '/connections/:connectionId/sync-transactions',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(syncTransactionsForAccount.schema),
   syncTransactionsForAccount.handler,
 );
@@ -103,6 +110,7 @@ router.post(
   '/connections/:connectionId/reconcile-duplicates',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(reconcileDuplicatesForAccount.schema),
   reconcileDuplicatesForAccount.handler,
 );
@@ -110,6 +118,7 @@ router.post(
   '/connections/:connectionId/load-transactions-for-period',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(loadTransactionsForPeriod.schema),
   loadTransactionsForPeriod.handler,
 );
@@ -132,6 +141,7 @@ router.post(
   '/sync/trigger',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(triggerSync.schema),
   triggerSync.handler,
 );
@@ -148,6 +158,7 @@ router.post(
   '/enablebanking/countries',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(listCountries.schema),
   listCountries.handler,
 );
@@ -155,6 +166,7 @@ router.post(
   '/enablebanking/banks',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(listBanks.schema),
   listBanks.handler,
 );
@@ -162,6 +174,7 @@ router.post(
   '/enablebanking/oauth-callback',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(oauthCallback.schema),
   oauthCallback.handler,
 );

--- a/packages/backend/src/routes/base-currency-guard-coverage.e2e.ts
+++ b/packages/backend/src/routes/base-currency-guard-coverage.e2e.ts
@@ -1,0 +1,297 @@
+import { API_ERROR_CODES, RESOURCE_TYPES, SHARE_PERMISSIONS } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import { ERROR_CODES } from '@js/errors';
+import { app } from '@root/app';
+import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
+import * as helpers from '@tests/helpers';
+import { ErrorResponse } from '@tests/helpers/common';
+
+const AUTH_MIDDLEWARE = 'authenticateSession';
+const GUARD_MIDDLEWARE = 'checkBaseCurrencyLock';
+const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const LOCK_CODE = API_ERROR_CODES.baseCurrencyChangeInProgress;
+const OTHER_USER_LOCK_CODE = API_ERROR_CODES.baseCurrencyChangeInProgressOtherUser;
+
+/** Hold the user's base-currency lock for the duration of `fn`, then release it. */
+async function withUserLock<T>({ userId, fn }: { userId: number; fn: () => Promise<T> }): Promise<T> {
+  await redisClient.set(buildLockKey(userId), 'test-lock');
+  try {
+    return await fn();
+  } finally {
+    await redisClient.del(buildLockKey(userId));
+  }
+}
+
+/**
+ * Routes that are authenticated (`authenticateSession`) and mutating yet intentionally
+ * run WITHOUT `checkBaseCurrencyLock`. Everything else in that category must carry the
+ * guard — the invariant test below fails when a new route slips through. Keep sorted
+ * within each group; the `${METHOD} ${fullPath}` key must match the reconstructed path.
+ */
+const GUARD_EXEMPT_ROUTES = new Set<string>([
+  // The enqueue route: its NX lock acquisition is its own dedupe and returns the 423.
+  'POST /api/v1/user/currencies/change-base',
+
+  // better-auth extensions — account credential management, no monetary data.
+  'POST /api/v1/auth/set-password',
+
+  // Notifications read-marking — high-frequency, non-monetary state.
+  'POST /api/v1/notifications/read-all',
+  'POST /api/v1/notifications/:id/read',
+
+  // User profile / settings / AI settings / data-export — authenticated but touch no
+  // monetary data; blocking them for the duration of a migration is user-hostile.
+  'DELETE /api/v1/user/settings/ai/api-keys',
+  'DELETE /api/v1/user/settings/ai/api-keys/all',
+  'DELETE /api/v1/user/settings/ai/features/:feature',
+  'DELETE /api/v1/user/settings/mcp/connected-apps/:clientId',
+  'PATCH /api/v1/user/settings',
+  'POST /api/v1/user/data-export',
+  'PUT /api/v1/user/settings',
+  'PUT /api/v1/user/settings/ai/api-keys',
+  'PUT /api/v1/user/settings/ai/api-keys/default',
+  'PUT /api/v1/user/settings/ai/custom-instructions',
+  'PUT /api/v1/user/settings/ai/features/:feature',
+  'PUT /api/v1/user/settings/onboarding',
+  'PUT /api/v1/user/update',
+
+  // Admin-only investment price maintenance — these write GLOBAL SecurityPricing
+  // reference data, not any user's ref amounts, so a per-user base-currency
+  // migration has no bearing on them.
+  'POST /api/v1/investments/securities/price-upload-info',
+  'POST /api/v1/investments/securities/prices/bulk-upload',
+  'POST /api/v1/investments/sync/securities-prices',
+]);
+
+interface DiscoveredRoute {
+  method: string;
+  path: string;
+  middlewares: string[];
+}
+
+/**
+ * Reconstruct a router's mount prefix from the Express 4 mount `layer.regexp`. Mount
+ * paths here are all static literals, so the leading run of path characters after the
+ * `^` anchor is the prefix; the trailing optional-slash + lookahead the router adds is
+ * dropped by cutting at the first non-path character.
+ */
+function mountPrefixFromRegexp(layer: { regexp?: RegExp & { fast_slash?: boolean } }): string {
+  const regexp = layer.regexp;
+  if (!regexp || regexp.fast_slash) return '';
+
+  const unescaped = regexp.source.replace(/^\^/, '').replace(/\\\//g, '/').replace(/\\\./g, '.');
+  const match = unescaped.match(/^[/\w.-]+/);
+  let prefix = match ? match[0] : '';
+  if (prefix.length > 1 && prefix.endsWith('/')) prefix = prefix.slice(0, -1);
+  return prefix;
+}
+
+/**
+ * Walk the Express app router stack and return every concrete route with the ordered
+ * names of the middlewares mounted on it. Only router layers (`app.use(prefix, router)`)
+ * are traversed; app-level handlers (health, auth proxies, `.well-known`) carry no
+ * `authenticateSession` and are irrelevant to the guard invariant.
+ */
+function collectRoutes(): DiscoveredRoute[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const appRouter = (app as any)._router ?? (app as any).router;
+  if (!appRouter?.stack) {
+    throw new Error('Express app router stack not available — cannot verify guard coverage');
+  }
+
+  const routes: DiscoveredRoute[] = [];
+
+  for (const appLayer of appRouter.stack) {
+    if (appLayer.name !== 'router' || !appLayer.handle?.stack) continue;
+    const prefix = mountPrefixFromRegexp(appLayer);
+
+    // Router-level middleware (`router.use(fn)`) shares this stack with the routes
+    // but carries no `.route`. Auth mounted that way (investments, venture) never
+    // lands on an individual route's own stack, so accumulate the named blanket
+    // layers as we walk and prepend them to every route that follows. Every real
+    // usage is pathless, so no path gating is needed.
+    const routerMiddlewares: string[] = [];
+
+    for (const routeLayer of appLayer.handle.stack) {
+      const route = routeLayer.route;
+      if (!route) {
+        if (routeLayer.name && routeLayer.name !== '<anonymous>') {
+          routerMiddlewares.push(routeLayer.name);
+        }
+        continue;
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const middlewares: string[] = [...routerMiddlewares, ...route.stack.map((entry: any) => entry.name)];
+      const routePaths = Array.isArray(route.path) ? route.path : [route.path];
+      const methods = Object.keys(route.methods)
+        .filter((method) => route.methods[method] && method !== '_all')
+        .map((method) => method.toUpperCase());
+
+      for (const routePath of routePaths) {
+        for (const method of methods) {
+          let full = `${prefix}${routePath}`.replace(/\/{2,}/g, '/');
+          if (full.length > 1 && full.endsWith('/')) full = full.slice(0, -1);
+          routes.push({ method, path: full, middlewares });
+        }
+      }
+    }
+  }
+
+  return routes;
+}
+
+describe('Base-currency guard coverage', () => {
+  it('detects auth + guard middleware by name on a known route (sanity)', () => {
+    const routes = collectRoutes();
+    // A large stack is expected; a near-empty result means the walk broke and every
+    // assertion below would pass vacuously.
+    expect(routes.length).toBeGreaterThan(50);
+
+    const createTransaction = routes.find((route) => route.method === 'POST' && route.path === '/api/v1/transactions');
+    expect(createTransaction).toBeDefined();
+    expect(createTransaction!.middlewares).toContain(AUTH_MIDDLEWARE);
+    expect(createTransaction!.middlewares).toContain(GUARD_MIDDLEWARE);
+  });
+
+  it('guards every authenticated mutating route (or allowlists it)', () => {
+    const offenders = collectRoutes()
+      .filter((route) => MUTATING_METHODS.has(route.method))
+      .filter((route) => route.middlewares.includes(AUTH_MIDDLEWARE))
+      .filter((route) => !route.middlewares.includes(GUARD_MIDDLEWARE))
+      .map((route) => `${route.method} ${route.path}`)
+      .filter((key) => !GUARD_EXEMPT_ROUTES.has(key))
+      .sort();
+
+    const message = offenders.length
+      ? `Found ${offenders.length} authenticated mutating route(s) missing checkBaseCurrencyLock ` +
+        `(add the guard, or allowlist in GUARD_EXEMPT_ROUTES if genuinely non-monetary):\n  ${offenders.join('\n  ')}`
+      : '';
+
+    expect(message).toBe('');
+  });
+
+  it('never lets checkBaseCurrencyLock land on a GET route', () => {
+    // A GET carrying the guard is a deadlock: a locked client polling GET
+    // /user/currencies/change-base/status would get 423 and never see the
+    // change finish, so the overlay that reads it could never unblock.
+    const offenders = collectRoutes()
+      .filter((route) => route.method === 'GET')
+      .filter((route) => route.middlewares.includes(GUARD_MIDDLEWARE))
+      .map((route) => `${route.method} ${route.path}`)
+      .sort();
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('Base-currency lock returns 423 on guarded routes', () => {
+  function expectLocked(response: { statusCode: number; body: { response: unknown } }) {
+    expect(response.statusCode).toBe(ERROR_CODES.Locked);
+    expect((response.body.response as ErrorResponse).code).toBe(LOCK_CODE);
+  }
+
+  it('blocks PUT /user/currency/rates', async () => {
+    const user = await helpers.getUserInfo({ raw: true });
+    const response = await withUserLock({
+      userId: user.id,
+      fn: () => helpers.makeRequest({ method: 'put', url: '/user/currency/rates', payload: { pairs: [] } }),
+    });
+    expectLocked(response);
+  });
+
+  it('blocks POST /import/csv/execute', async () => {
+    const user = await helpers.getUserInfo({ raw: true });
+    const response = await withUserLock({
+      userId: user.id,
+      fn: () => helpers.makeRequest({ method: 'post', url: '/import/csv/execute', payload: { rows: [] } }),
+    });
+    expectLocked(response);
+  });
+
+  it('blocks POST /accounts/:id/balance-adjustment', async () => {
+    const account = await helpers.createAccount({ raw: true });
+    const response = await withUserLock({
+      userId: account.userId,
+      fn: () =>
+        helpers.makeRequest({
+          method: 'post',
+          url: `/accounts/${account.id}/balance-adjustment`,
+          payload: { amount: 100 },
+        }),
+    });
+    expectLocked(response);
+  });
+
+  it('blocks POST /categories', async () => {
+    const user = await helpers.getUserInfo({ raw: true });
+    const response = await withUserLock({
+      userId: user.id,
+      fn: () => helpers.makeRequest({ method: 'post', url: '/categories', payload: { name: 'Blocked category' } }),
+    });
+    expectLocked(response);
+  });
+
+  it('still serves GET /user/currencies/change-base/status while locked (200, not 423)', async () => {
+    // The overlay polls this endpoint to learn the change finished; if the lock
+    // blocked it, a locked client could never observe the unblock.
+    const user = await helpers.getUserInfo({ raw: true });
+    const response = await withUserLock({
+      userId: user.id,
+      fn: () => helpers.getBaseCurrencyChangeStatus({ raw: false }),
+    });
+    expect(response.statusCode).toBe(200);
+  });
+});
+
+describe('Share-accept refuses while either party holds the base-currency lock', () => {
+  async function setUpPendingAccountShare() {
+    const owner = await helpers.getUserInfo({ raw: true });
+    const account = await helpers.createAccount({ raw: true });
+    const recipient = await helpers.provisionSecondUserWithBaseCurrency();
+    const recipientApp = await helpers.findAppUserByEmail({ email: recipient.email });
+
+    const invitation = await helpers.createShareInvitation({
+      inviteeEmail: recipient.email,
+      resourceType: RESOURCE_TYPES.account,
+      resourceId: account.id,
+      permission: SHARE_PERMISSIONS.read,
+      raw: true,
+    });
+
+    return { ownerId: owner.id, recipient, recipientId: recipientApp.id, token: invitation.token };
+  }
+
+  it('returns 423 with the other-party code when the resource owner is locked', async () => {
+    const { ownerId, recipient, token } = await setUpPendingAccountShare();
+
+    const response = await withUserLock({
+      userId: ownerId,
+      fn: () =>
+        helpers.asUser({
+          cookies: recipient.cookies,
+          fn: () => helpers.acceptShareInvitation({ token }),
+        }),
+    });
+    expect(response.statusCode).toBe(ERROR_CODES.Locked);
+    // The acceptor themselves is not migrating, so this must NOT be the app-blocking
+    // own-lock code — the other party's migration should not freeze their whole app.
+    expect((response.body.response as unknown as ErrorResponse).code).toBe(OTHER_USER_LOCK_CODE);
+  });
+
+  it('returns 423 when the acceptor is locked', async () => {
+    const { recipient, recipientId, token } = await setUpPendingAccountShare();
+
+    const response = await withUserLock({
+      userId: recipientId,
+      fn: () =>
+        helpers.asUser({
+          cookies: recipient.cookies,
+          fn: () => helpers.acceptShareInvitation({ token }),
+        }),
+    });
+    expect(response.statusCode).toBe(ERROR_CODES.Locked);
+    expect((response.body.response as unknown as ErrorResponse).code).toBe(LOCK_CODE);
+  });
+});

--- a/packages/backend/src/routes/budgets.route.ts
+++ b/packages/backend/src/routes/budgets.route.ts
@@ -10,6 +10,7 @@ import removeTransactionsFromBudget from '@controllers/budgets/remove-transactio
 import toggleArchive from '@controllers/budgets/toggle-archive';
 import { authenticateSession } from '@middlewares/better-auth';
 import { blockDemoUsers } from '@middlewares/block-demo-users';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -30,21 +31,44 @@ router.get(
   validateEndpoint(getCategoryBudgetTransactions.schema),
   getCategoryBudgetTransactions.handler,
 );
-router.post('/', authenticateSession, blockDemoUsers, validateEndpoint(createBudget.schema), createBudget.handler);
-router.put('/:id', authenticateSession, blockDemoUsers, validateEndpoint(editBudget.schema), editBudget.handler);
+router.post(
+  '/',
+  authenticateSession,
+  blockDemoUsers,
+  checkBaseCurrencyLock,
+  validateEndpoint(createBudget.schema),
+  createBudget.handler,
+);
+router.put(
+  '/:id',
+  authenticateSession,
+  blockDemoUsers,
+  checkBaseCurrencyLock,
+  validateEndpoint(editBudget.schema),
+  editBudget.handler,
+);
 router.patch(
   '/:id/archive',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(toggleArchive.schema),
   toggleArchive.handler,
 );
-router.delete('/:id', authenticateSession, blockDemoUsers, validateEndpoint(deleteBudget.schema), deleteBudget.handler);
+router.delete(
+  '/:id',
+  authenticateSession,
+  blockDemoUsers,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteBudget.schema),
+  deleteBudget.handler,
+);
 
 router.post(
   '/:id/transactions',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(addTransactionsToBudget.schema),
   addTransactionsToBudget.handler,
 );
@@ -52,6 +76,7 @@ router.delete(
   '/:id/transactions',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(removeTransactionsFromBudget.schema),
   removeTransactionsFromBudget.handler,
 );

--- a/packages/backend/src/routes/categories.route.ts
+++ b/packages/backend/src/routes/categories.route.ts
@@ -4,15 +4,34 @@ import getCategories from '@controllers/categories.controller/get-categories';
 import getCategoryTransactionCount from '@controllers/categories.controller/get-category-transaction-count';
 import editCategory from '@controllers/categories.controller/update-category';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
 const router = Router({});
 
 router.get('/', authenticateSession, validateEndpoint(getCategories.schema), getCategories.handler);
-router.post('/', authenticateSession, validateEndpoint(createCategory.schema), createCategory.handler);
-router.put('/:id', authenticateSession, validateEndpoint(editCategory.schema), editCategory.handler);
-router.delete('/:id', authenticateSession, validateEndpoint(deleteCategory.schema), deleteCategory.handler);
+router.post(
+  '/',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createCategory.schema),
+  createCategory.handler,
+);
+router.put(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(editCategory.schema),
+  editCategory.handler,
+);
+router.delete(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteCategory.schema),
+  deleteCategory.handler,
+);
 router.get(
   '/:id/transaction-count',
   authenticateSession,

--- a/packages/backend/src/routes/import-export/budget-bakers-wallet.route.ts
+++ b/packages/backend/src/routes/import-export/budget-bakers-wallet.route.ts
@@ -3,6 +3,7 @@ import { detectBudgetBakersWalletDuplicatesController } from '@controllers/impor
 import { executeBudgetBakersWalletController } from '@controllers/import-export/budget-bakers-wallet/execute-budget-bakers-wallet.controller';
 import { parseBudgetBakersWalletController } from '@controllers/import-export/budget-bakers-wallet/parse-budget-bakers-wallet.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { csvImportRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -12,6 +13,7 @@ const router = Router({});
 router.post(
   '/budget-bakers-wallet/parse',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(parseBudgetBakersWalletController.schema),
   parseBudgetBakersWalletController.handler,
@@ -20,6 +22,7 @@ router.post(
 router.post(
   '/budget-bakers-wallet/detect-duplicates',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(detectBudgetBakersWalletDuplicatesController.schema),
   detectBudgetBakersWalletDuplicatesController.handler,
@@ -28,6 +31,7 @@ router.post(
 router.post(
   '/budget-bakers-wallet/execute',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(executeBudgetBakersWalletController.schema),
   executeBudgetBakersWalletController.handler,

--- a/packages/backend/src/routes/import-export/csv.route.ts
+++ b/packages/backend/src/routes/import-export/csv.route.ts
@@ -4,6 +4,7 @@ import { executeImportController } from '@controllers/import-export/execute-impo
 import { extractUniqueValuesController } from '@controllers/import-export/extract-unique-values.controller';
 import { parseCsv } from '@controllers/import-export/parse-csv.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { csvImportRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -11,12 +12,20 @@ import { Router } from 'express';
 const router = Router({});
 
 // Parse CSV file and return preview
-router.post('/csv/parse', authenticateSession, csvImportRateLimit, validateEndpoint(parseCsv.schema), parseCsv.handler);
+router.post(
+  '/csv/parse',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  csvImportRateLimit,
+  validateEndpoint(parseCsv.schema),
+  parseCsv.handler,
+);
 
 // Extract unique accounts/categories from full dataset
 router.post(
   '/csv/extract-unique-values',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(extractUniqueValuesController.schema),
   extractUniqueValuesController.handler,
@@ -26,6 +35,7 @@ router.post(
 router.post(
   '/csv/detect-duplicates',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(detectDuplicatesController.schema),
   detectDuplicatesController.handler,
@@ -36,6 +46,7 @@ router.post(
 router.post(
   '/csv/execute',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(executeImportController.schema),
   executeImportController.handler,

--- a/packages/backend/src/routes/import-export/text-source.route.ts
+++ b/packages/backend/src/routes/import-export/text-source.route.ts
@@ -5,6 +5,7 @@ import {
   extractController,
 } from '@controllers/statement-parser';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -21,6 +22,7 @@ const router = Router({});
 router.post(
   '/text-source/estimate-cost',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(estimateCostController.schema),
   estimateCostController.handler,
 );
@@ -36,6 +38,7 @@ router.post(
 router.post(
   '/text-source/extract',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(extractController.schema),
   extractController.handler,
 );
@@ -51,6 +54,7 @@ router.post(
 router.post(
   '/text-source/detect-duplicates',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(detectDuplicatesController.schema),
   detectDuplicatesController.handler,
 );
@@ -66,6 +70,7 @@ router.post(
 router.post(
   '/text-source/execute',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(executeImportController.schema),
   executeImportController.handler,
 );

--- a/packages/backend/src/routes/import-export/ynab.route.ts
+++ b/packages/backend/src/routes/import-export/ynab.route.ts
@@ -2,6 +2,7 @@ import { executeYnabController } from '@controllers/import-export/ynab/execute-y
 import { parseYnabController } from '@controllers/import-export/ynab/parse-ynab.controller';
 import { ynabStatusController } from '@controllers/import-export/ynab/ynab-status.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { csvImportRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -11,6 +12,7 @@ const router = Router({});
 router.post(
   '/ynab/parse',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(parseYnabController.schema),
   parseYnabController.handler,
@@ -19,6 +21,7 @@ router.post(
 router.post(
   '/ynab/execute',
   authenticateSession,
+  checkBaseCurrencyLock,
   csvImportRateLimit,
   validateEndpoint(executeYnabController.schema),
   executeYnabController.handler,

--- a/packages/backend/src/routes/investments.route.ts
+++ b/packages/backend/src/routes/investments.route.ts
@@ -260,11 +260,13 @@ router.put(
  */
 router.post(
   '/transactions-import/estimate-cost',
+  checkBaseCurrencyLock,
   validateEndpoint(importEstimateCostController.schema),
   importEstimateCostController.handler,
 );
 router.post(
   '/transactions-import/extract',
+  checkBaseCurrencyLock,
   validateEndpoint(importExtractController.schema),
   importExtractController.handler,
 );

--- a/packages/backend/src/routes/loans.route.ts
+++ b/packages/backend/src/routes/loans.route.ts
@@ -8,6 +8,7 @@ import linkPayments from '@controllers/loans/link-payments';
 import unlinkPayment from '@controllers/loans/unlink-payment';
 import updateLoan from '@controllers/loans/update-loan';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -21,11 +22,41 @@ router.get(
   validateEndpoint(getBalanceHistory.schema),
   getBalanceHistory.handler,
 );
-router.post('/', authenticateSession, validateEndpoint(createLoan.schema), createLoan.handler);
-router.patch('/:id', authenticateSession, validateEndpoint(updateLoan.schema), updateLoan.handler);
-router.delete('/:id', authenticateSession, validateEndpoint(deleteLoan.schema), deleteLoan.handler);
-router.post('/:id/events', authenticateSession, validateEndpoint(appendNoteEvent.schema), appendNoteEvent.handler);
-router.post('/:id/link-payments', authenticateSession, validateEndpoint(linkPayments.schema), linkPayments.handler);
-router.post('/:id/unlink-payment', authenticateSession, validateEndpoint(unlinkPayment.schema), unlinkPayment.handler);
+router.post('/', authenticateSession, checkBaseCurrencyLock, validateEndpoint(createLoan.schema), createLoan.handler);
+router.patch(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(updateLoan.schema),
+  updateLoan.handler,
+);
+router.delete(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteLoan.schema),
+  deleteLoan.handler,
+);
+router.post(
+  '/:id/events',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(appendNoteEvent.schema),
+  appendNoteEvent.handler,
+);
+router.post(
+  '/:id/link-payments',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(linkPayments.schema),
+  linkPayments.handler,
+);
+router.post(
+  '/:id/unlink-payment',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(unlinkPayment.schema),
+  unlinkPayment.handler,
+);
 
 export default router;

--- a/packages/backend/src/routes/notifications.route.ts
+++ b/packages/backend/src/routes/notifications.route.ts
@@ -8,6 +8,7 @@ import {
   markAsRead,
 } from '@controllers/notifications.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -23,7 +24,13 @@ router.get('/unread-count', authenticateSession, validateEndpoint(getUnreadCount
 router.get('/:id', authenticateSession, validateEndpoint(getNotificationById.schema), getNotificationById.handler);
 
 // Create a notification (primarily for internal/admin use, but exposed for testing)
-router.post('/', authenticateSession, validateEndpoint(createNotification.schema), createNotification.handler);
+router.post(
+  '/',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createNotification.schema),
+  createNotification.handler,
+);
 
 // Mark a specific notification as read
 router.post('/:id/read', authenticateSession, validateEndpoint(markAsRead.schema), markAsRead.handler);
@@ -35,6 +42,7 @@ router.post('/read-all', authenticateSession, validateEndpoint(markAllAsRead.sch
 router.post(
   '/:id/dismiss',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(dismissNotification.schema),
   dismissNotification.handler,
 );

--- a/packages/backend/src/routes/payees.route.ts
+++ b/packages/backend/src/routes/payees.route.ts
@@ -16,13 +16,14 @@ import {
   updatePayee,
 } from '@controllers/payees';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
 const router = Router({});
 
 router.get('/', authenticateSession, validateEndpoint(listPayees.schema), listPayees.handler);
-router.post('/', authenticateSession, validateEndpoint(createPayee.schema), createPayee.handler);
+router.post('/', authenticateSession, checkBaseCurrencyLock, validateEndpoint(createPayee.schema), createPayee.handler);
 
 // Full minimal payee set for id→name/logo resolution. Must precede `/:id` so
 // Express doesn't capture the literal `lookup` segment as a Payee id.
@@ -34,6 +35,7 @@ router.get('/lookup', authenticateSession, validateEndpoint(lookupPayees.schema)
 router.patch(
   '/bulk-categorization-mode',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(bulkUpdateCategorizationMode.schema),
   bulkUpdateCategorizationMode.handler,
 );
@@ -41,31 +43,70 @@ router.patch(
 // Ignored-names sub-resource. Routes precede `/:id` patterns so Express's
 // path matcher doesn't capture the literal segment as a Payee id.
 router.get('/ignored-names', authenticateSession, validateEndpoint(listIgnoredNames.schema), listIgnoredNames.handler);
-router.post('/ignored-names', authenticateSession, validateEndpoint(addIgnoredName.schema), addIgnoredName.handler);
+router.post(
+  '/ignored-names',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(addIgnoredName.schema),
+  addIgnoredName.handler,
+);
 router.delete(
   '/ignored-names/:id',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(removeIgnoredName.schema),
   removeIgnoredName.handler,
 );
 
 router.get('/:id', authenticateSession, validateEndpoint(getPayee.schema), getPayee.handler);
-router.patch('/:id', authenticateSession, validateEndpoint(updatePayee.schema), updatePayee.handler);
-router.delete('/:id', authenticateSession, validateEndpoint(deletePayee.schema), deletePayee.handler);
-router.post('/:id/merge', authenticateSession, validateEndpoint(mergePayees.schema), mergePayees.handler);
+router.patch(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(updatePayee.schema),
+  updatePayee.handler,
+);
+router.delete(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deletePayee.schema),
+  deletePayee.handler,
+);
+router.post(
+  '/:id/merge',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(mergePayees.schema),
+  mergePayees.handler,
+);
 router.post(
   '/:id/apply-tags',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(applyTagsToExisting.schema),
   applyTagsToExisting.handler,
 );
-router.post('/:id/aliases', authenticateSession, validateEndpoint(createPayeeAlias.schema), createPayeeAlias.handler);
+router.post(
+  '/:id/aliases',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createPayeeAlias.schema),
+  createPayeeAlias.handler,
+);
 router.delete(
   '/:id/aliases/:aliasId',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(deletePayeeAlias.schema),
   deletePayeeAlias.handler,
 );
-router.post('/:id/reset-logo', authenticateSession, validateEndpoint(resetLogo.schema), resetLogo.handler);
+router.post(
+  '/:id/reset-logo',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(resetLogo.schema),
+  resetLogo.handler,
+);
 
 export default router;

--- a/packages/backend/src/routes/share.route.ts
+++ b/packages/backend/src/routes/share.route.ts
@@ -13,6 +13,7 @@ import revokeMember from '@controllers/share/revoke-member';
 import updateMember from '@controllers/share/update-member';
 import { authenticateSession } from '@middlewares/better-auth';
 import { blockDemoUsers } from '@middlewares/block-demo-users';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { shareInvitationSendRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -23,6 +24,7 @@ router.post(
   '/invitations',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   shareInvitationSendRateLimit,
   validateEndpoint(createInvitation.schema),
   createInvitation.handler,
@@ -43,6 +45,7 @@ router.post(
   '/invitations/:token/accept',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(acceptInvitation.schema),
   acceptInvitation.handler,
 );
@@ -50,6 +53,7 @@ router.post(
   '/invitations/:token/decline',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(declineInvitation.schema),
   declineInvitation.handler,
 );
@@ -57,6 +61,7 @@ router.post(
   '/invitations/:id/resend',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(resendInvitation.schema),
   resendInvitation.handler,
 );
@@ -64,6 +69,7 @@ router.delete(
   '/invitations/:id',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(cancelInvitation.schema),
   cancelInvitation.handler,
 );
@@ -71,6 +77,7 @@ router.post(
   '/invitations/:id/back-invite',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   shareInvitationSendRateLimit,
   validateEndpoint(backInviteFromInvitation.schema),
   backInviteFromInvitation.handler,
@@ -86,6 +93,7 @@ router.patch(
   '/resources/:resourceType/:resourceId/members/:userId',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(updateMember.schema),
   updateMember.handler,
 );
@@ -93,6 +101,7 @@ router.delete(
   '/resources/:resourceType/:resourceId/members/:userId',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(revokeMember.schema),
   revokeMember.handler,
 );
@@ -102,6 +111,7 @@ router.post(
   '/shared-with-me/:resourceType/:resourceId/leave',
   authenticateSession,
   blockDemoUsers,
+  checkBaseCurrencyLock,
   validateEndpoint(leaveShare.schema),
   leaveShare.handler,
 );

--- a/packages/backend/src/routes/subscriptions.route.ts
+++ b/packages/backend/src/routes/subscriptions.route.ts
@@ -20,6 +20,7 @@ import unlinkPeriodTransaction from '@controllers/subscriptions/unlink-transacti
 import unlinkTransactions from '@controllers/subscriptions/unlink-transactions';
 import updateSubscription from '@controllers/subscriptions/update-subscription';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -45,34 +46,68 @@ router.get('/candidates', authenticateSession, validateEndpoint(getCandidates.sc
 router.post(
   '/candidates/:id/accept',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(acceptCandidate.schema),
   acceptCandidate.handler,
 );
 router.post(
   '/candidates/:id/dismiss',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(dismissCandidate.schema),
   dismissCandidate.handler,
 );
 router.get('/:id', authenticateSession, validateEndpoint(getSubscriptionById.schema), getSubscriptionById.handler);
 
-router.post('/', authenticateSession, validateEndpoint(createSubscription.schema), createSubscription.handler);
-router.put('/:id', authenticateSession, validateEndpoint(updateSubscription.schema), updateSubscription.handler);
-router.delete('/:id', authenticateSession, validateEndpoint(deleteSubscription.schema), deleteSubscription.handler);
+router.post(
+  '/',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createSubscription.schema),
+  createSubscription.handler,
+);
+router.put(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(updateSubscription.schema),
+  updateSubscription.handler,
+);
+router.delete(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteSubscription.schema),
+  deleteSubscription.handler,
+);
 
-router.patch('/:id/toggle-active', authenticateSession, validateEndpoint(toggleActive.schema), toggleActive.handler);
+router.patch(
+  '/:id/toggle-active',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(toggleActive.schema),
+  toggleActive.handler,
+);
 
-router.post('/:id/reset-logo', authenticateSession, validateEndpoint(resetLogo.schema), resetLogo.handler);
+router.post(
+  '/:id/reset-logo',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(resetLogo.schema),
+  resetLogo.handler,
+);
 
 router.post(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(linkTransactions.schema),
   linkTransactions.handler,
 );
 router.delete(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(unlinkTransactions.schema),
   unlinkTransactions.handler,
 );
@@ -90,24 +125,28 @@ router.get('/:id/periods', authenticateSession, validateEndpoint(getPeriods.sche
 router.post(
   '/:id/periods/:periodId/pay',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(markPeriodPaid.schema),
   markPeriodPaid.handler,
 );
 router.post(
   '/:id/periods/:periodId/skip',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(skipPeriod.schema),
   skipPeriod.handler,
 );
 router.post(
   '/:id/periods/:periodId/unlink',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(unlinkPeriodTransaction.schema),
   unlinkPeriodTransaction.handler,
 );
 router.post(
   '/:id/periods/:periodId/revert',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(revertPeriod.schema),
   revertPeriod.handler,
 );

--- a/packages/backend/src/routes/tags.route.ts
+++ b/packages/backend/src/routes/tags.route.ts
@@ -15,6 +15,7 @@ import {
   updateTag,
 } from '@controllers/tags';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -22,19 +23,27 @@ const router = Router({});
 
 router.get('/', authenticateSession, validateEndpoint(getTags.schema), getTags.handler);
 router.get('/:id', authenticateSession, validateEndpoint(getTagById.schema), getTagById.handler);
-router.post('/', authenticateSession, validateEndpoint(createTag.schema), createTag.handler);
-router.put('/:id', authenticateSession, validateEndpoint(updateTag.schema), updateTag.handler);
-router.delete('/:id', authenticateSession, validateEndpoint(deleteTag.schema), deleteTag.handler);
+router.post('/', authenticateSession, checkBaseCurrencyLock, validateEndpoint(createTag.schema), createTag.handler);
+router.put('/:id', authenticateSession, checkBaseCurrencyLock, validateEndpoint(updateTag.schema), updateTag.handler);
+router.delete(
+  '/:id',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteTag.schema),
+  deleteTag.handler,
+);
 
 router.post(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(addTransactionsToTag.schema),
   addTransactionsToTag.handler,
 );
 router.delete(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(removeTransactionsFromTag.schema),
   removeTransactionsFromTag.handler,
 );
@@ -52,16 +61,24 @@ router.get(
   validateEndpoint(getReminderById.schema),
   getReminderById.handler,
 );
-router.post('/:tagId/reminders', authenticateSession, validateEndpoint(createReminder.schema), createReminder.handler);
+router.post(
+  '/:tagId/reminders',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createReminder.schema),
+  createReminder.handler,
+);
 router.put(
   '/:tagId/reminders/:id',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(updateReminder.schema),
   updateReminder.handler,
 );
 router.delete(
   '/:tagId/reminders/:id',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(deleteReminder.schema),
   deleteReminder.handler,
 );

--- a/packages/backend/src/routes/transaction-groups.route.ts
+++ b/packages/backend/src/routes/transaction-groups.route.ts
@@ -8,6 +8,7 @@ import {
   updateTransactionGroup,
 } from '@controllers/transaction-groups';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
 
@@ -20,16 +21,24 @@ router.get(
   validateEndpoint(getTransactionGroupById.schema),
   getTransactionGroupById.handler,
 );
-router.post('/', authenticateSession, validateEndpoint(createTransactionGroup.schema), createTransactionGroup.handler);
+router.post(
+  '/',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(createTransactionGroup.schema),
+  createTransactionGroup.handler,
+);
 router.put(
   '/:id',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(updateTransactionGroup.schema),
   updateTransactionGroup.handler,
 );
 router.delete(
   '/:id',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(deleteTransactionGroup.schema),
   deleteTransactionGroup.handler,
 );
@@ -37,12 +46,14 @@ router.delete(
 router.post(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(addTransactionsToGroup.schema),
   addTransactionsToGroup.handler,
 );
 router.delete(
   '/:id/transactions',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(removeTransactionsFromGroup.schema),
   removeTransactionsFromGroup.handler,
 );

--- a/packages/backend/src/routes/transactions.route.ts
+++ b/packages/backend/src/routes/transactions.route.ts
@@ -49,12 +49,14 @@ router.get(
 router.post(
   '/transfer-recommendations/bulk-scan',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(bulkScanTransferRecommendations.schema),
   bulkScanTransferRecommendations.handler,
 );
 router.post(
   '/transfer-recommendations/dismiss',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(dismissTransferSuggestion.schema),
   dismissTransferSuggestion.handler,
 );

--- a/packages/backend/src/routes/user.route.ts
+++ b/packages/backend/src/routes/user.route.ts
@@ -1,4 +1,5 @@
 import addUserCurrencies from '@controllers/currencies/add-user-currencies';
+import changeBaseCurrencyStatus from '@controllers/currencies/change-base-currency-status.controller';
 import changeBaseCurrency from '@controllers/currencies/change-base-currency.controller';
 import editCurrencyExchangeRate from '@controllers/currencies/edit-currency-exchange-rate';
 import { exportDataController } from '@controllers/data-export/export-data.controller';
@@ -39,6 +40,7 @@ import {
   wipeUserData,
 } from '@controllers/user.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import { dataExportRateLimit } from '@middlewares/rate-limit';
 import { validateEndpoint } from '@middlewares/validations';
 import { Router } from 'express';
@@ -47,8 +49,20 @@ const router = Router({});
 
 router.get('/', authenticateSession, validateEndpoint(getUser.schema), getUser.handler);
 router.put('/update', authenticateSession, validateEndpoint(updateUser.schema), updateUser.handler);
-router.delete('/delete', authenticateSession, validateEndpoint(deleteUser.schema), deleteUser.handler);
-router.post('/wipe-data', authenticateSession, validateEndpoint(wipeUserData.schema), wipeUserData.handler);
+router.delete(
+  '/delete',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(deleteUser.schema),
+  deleteUser.handler,
+);
+router.post(
+  '/wipe-data',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(wipeUserData.schema),
+  wipeUserData.handler,
+);
 router.post(
   '/data-export',
   authenticateSession,
@@ -71,24 +85,48 @@ router.get(
   getCurrenciesExchangeRates.handler,
 );
 
-router.post('/currencies', authenticateSession, validateEndpoint(addUserCurrencies.schema), addUserCurrencies.handler);
+router.post(
+  '/currencies',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(addUserCurrencies.schema),
+  addUserCurrencies.handler,
+);
 router.post(
   '/currencies/base',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(setBaseUserCurrency.schema),
   setBaseUserCurrency.handler,
 );
+// The enqueue route owns its own dedupe: its NX lock acquisition returns the proper 423,
+// so guarding it here would reject the request that is supposed to start the change.
 router.post(
   '/currencies/change-base',
   authenticateSession,
   validateEndpoint(changeBaseCurrency.schema),
   changeBaseCurrency.handler,
 );
+// Read-only status any device polls to drive the blocking overlay; GET routes are
+// never lock-guarded.
+router.get(
+  '/currencies/change-base/status',
+  authenticateSession,
+  validateEndpoint(changeBaseCurrencyStatus.schema),
+  changeBaseCurrencyStatus.handler,
+);
 
-router.put('/currency', authenticateSession, validateEndpoint(editUserCurrency.schema), editUserCurrency.handler);
+router.put(
+  '/currency',
+  authenticateSession,
+  checkBaseCurrencyLock,
+  validateEndpoint(editUserCurrency.schema),
+  editUserCurrency.handler,
+);
 router.put(
   '/currency/rates',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(editCurrencyExchangeRate.schema),
   editCurrencyExchangeRate.handler,
 );
@@ -96,12 +134,14 @@ router.put(
 router.delete(
   '/currency',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(deleteUserCurrency.schema),
   deleteUserCurrency.handler,
 );
 router.delete(
   '/currency/rates',
   authenticateSession,
+  checkBaseCurrencyLock,
   validateEndpoint(removeUserCurrencyExchangeRate.schema),
   removeUserCurrencyExchangeRate.handler,
 );

--- a/packages/backend/src/routes/venture.route.ts
+++ b/packages/backend/src/routes/venture.route.ts
@@ -29,9 +29,24 @@ router.use(authenticateSession);
 // Platforms
 router.get('/platforms', validateEndpoint(listPlatformsController.schema), listPlatformsController.handler);
 router.get('/platforms/:id', validateEndpoint(getPlatformController.schema), getPlatformController.handler);
-router.post('/platforms', validateEndpoint(createPlatformController.schema), createPlatformController.handler);
-router.put('/platforms/:id', validateEndpoint(updatePlatformController.schema), updatePlatformController.handler);
-router.delete('/platforms/:id', validateEndpoint(deletePlatformController.schema), deletePlatformController.handler);
+router.post(
+  '/platforms',
+  checkBaseCurrencyLock,
+  validateEndpoint(createPlatformController.schema),
+  createPlatformController.handler,
+);
+router.put(
+  '/platforms/:id',
+  checkBaseCurrencyLock,
+  validateEndpoint(updatePlatformController.schema),
+  updatePlatformController.handler,
+);
+router.delete(
+  '/platforms/:id',
+  checkBaseCurrencyLock,
+  validateEndpoint(deletePlatformController.schema),
+  deletePlatformController.handler,
+);
 
 // Deals
 router.get('/deals', validateEndpoint(listDealsController.schema), listDealsController.handler);

--- a/packages/backend/src/services/accounts/remeasure-ref-balances.ts
+++ b/packages/backend/src/services/accounts/remeasure-ref-balances.ts
@@ -6,6 +6,7 @@ import Balances from '@models/balances.model';
 import { namespace } from '@models/connection';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { withTransaction } from '@services/common/with-transaction';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import { DatabaseError } from 'sequelize';
 
 /**
@@ -83,10 +84,19 @@ export async function remeasureRefBalances({ userId }: { userId?: number } = {})
   const ambientTransaction = namespace.get('transaction');
   const hasAmbientTransaction = !!ambientTransaction && !ambientTransaction.finished;
 
+  // The all-users cron sweep skips users mid-base-currency-migration — the recalc
+  // owns those ref* amounts. isBaseCurrencyChangeLocked is a sub-ms Redis GET, so
+  // it re-checks per account; targeted per-user calls are guarded at their route.
+  const isGlobalSweep = userId === undefined;
+
   let updated = 0;
   let failed = 0;
 
   for (const account of accounts) {
+    if (isGlobalSweep && (await isBaseCurrencyChangeLocked({ userId: account.userId }))) {
+      continue;
+    }
+
     try {
       const status = await remeasureAccountRefBalances({ account });
       if (status === 'updated') updated += 1;

--- a/packages/backend/src/services/bank-data-providers/base-provider.ts
+++ b/packages/backend/src/services/bank-data-providers/base-provider.ts
@@ -6,6 +6,7 @@ import { ForbiddenError } from '@js/errors';
 import { logger } from '@js/utils';
 import Accounts from '@models/accounts.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 
 import { SyncStatus, setAccountSyncStatus } from './sync/sync-status-tracker';
 import {
@@ -33,6 +34,20 @@ interface AuthTrackingMetadata {
  * to stop us hammering the upstream with bad credentials.
  */
 const AUTH_FAILURE_DEACTIVATION_THRESHOLD = 2;
+
+/**
+ * Thrown from a provider's per-row persist loop to unwind an inline sync when a
+ * base-currency recalculation acquires the user's lock mid-run. runSyncWithStatus
+ * catches it and marks the account FAILED — a terminal state, so the recalc's
+ * drain (which waits while any of the user's accounts are QUEUED/SYNCING) stops
+ * waiting. The next auto-sync re-fetches the skipped, deduped rows.
+ */
+class BaseCurrencyChangeLockedError extends Error {
+  constructor() {
+    super(t({ key: 'currencies.baseCurrencyChangeInProgress' }));
+    this.name = 'BaseCurrencyChangeLockedError';
+  }
+}
 
 /**
  * Abstract base class for all bank data providers.
@@ -198,6 +213,36 @@ export abstract class BaseBankDataProvider implements IBankDataProvider {
   // ============================================================================
   // Sync Lifecycle Scaffolding
   // ============================================================================
+
+  /**
+   * Abort an inline sync mid-run if a base-currency recalculation holds the
+   * user's lock. Called at row-batch boundaries inside the per-row persist loops
+   * (every ~25 createTransaction calls) so a sync that started just before the
+   * lock landed stops committing old-base rows past the recalc's snapshot.
+   * Throws {@link BaseCurrencyChangeLockedError}, which runSyncWithStatus turns
+   * into a terminal FAILED status.
+   */
+  protected async abortSyncIfBaseCurrencyChangeLocked({ userId }: { userId: number }): Promise<void> {
+    if (await isBaseCurrencyChangeLocked({ userId })) {
+      throw new BaseCurrencyChangeLockedError();
+    }
+  }
+
+  /**
+   * Returns a checkpoint to call once per row inside a persist loop. It bails out
+   * the moment a base-currency change takes the lock, so rows stop landing against
+   * the old base past the recalc's snapshot. The lock is only read every 25 rows to
+   * bound the Redis GET; the returned closure owns that counter.
+   */
+  protected createBaseCurrencyLockCheckpoint({ userId }: { userId: number }): () => Promise<void> {
+    let processedInLoop = 0;
+    return async () => {
+      if (processedInLoop % 25 === 0) {
+        await this.abortSyncIfBaseCurrencyChangeLocked({ userId });
+      }
+      processedInLoop += 1;
+    };
+  }
 
   /**
    * Wrap a provider's inline sync work with the shared status lifecycle:

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -733,8 +733,11 @@ export class EnableBankingProvider extends BaseBankDataProvider {
           // Process each transaction and collect created/updated transaction IDs
           const createdTransactionIds: string[] = [];
           let updatedCount = 0;
+          const checkpoint = this.createBaseCurrencyLockCheckpoint({ userId });
 
           for (const tx of providerTransactions) {
+            await checkpoint();
+
             // Match an existing tx using a tiered strategy that survives hash drift:
             //   1. by entry_reference (ASPSP-promised stable id, may appear later)
             //   2. by current originalId (the legacy hash)

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
@@ -315,8 +315,11 @@ export class LunchFlowProvider extends BaseBankDataProvider {
 
         const defaultCategoryId = await getUserDefaultCategory({ id: connection.userId });
         const createdTransactionIds: string[] = [];
+        const checkpoint = this.createBaseCurrencyLockCheckpoint({ userId });
 
         for (const tx of postedTransactions) {
+          await checkpoint();
+
           // Primary dedup: check by originalId (covers normal re-sync)
           const existingTx = await Transactions.findOne({
             where: {

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -17,6 +17,7 @@ import Transactions from '@models/transactions.model';
 import * as UserMerchantCategoryCodes from '@models/user-merchant-category-codes.model';
 import * as Users from '@models/users.model';
 import { redisClient } from '@root/redis-client';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import * as transactionsService from '@services/transactions';
 import { Job, Queue, UnrecoverableError, Worker } from 'bullmq';
 import crypto from 'crypto';
@@ -118,6 +119,20 @@ function buildJobProcessor(queueName: string) {
         logger.info(
           `[WORKER] Processing Monobank transaction sync batch ${batchIndex + 1}/${totalBatches} for account ${accountId} (externalId: ${externalAccountId})`,
         );
+
+        // A base-currency recalculation is draining in-flight writers before it
+        // snapshots rows; committing more old-base transactions now would corrupt
+        // the migration. Abort this batch before any write and mark the account
+        // COMPLETED so the recalc's drain — which blocks while any of the user's
+        // accounts sit QUEUED/SYNCING — stops waiting on it. The skipped, deduped
+        // date range is re-fetched by the next auto-sync.
+        if (await isBaseCurrencyChangeLocked({ userId })) {
+          await setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId });
+          logger.info(
+            `[WORKER] Skipping Monobank batch ${batchIndex + 1}/${totalBatches} for account ${accountId}: base currency change in progress`,
+          );
+          return { success: false, batchIndex, totalBatches, transactionCount: 0 };
+        }
 
         // Set status to SYNCING when worker starts (only for first batch)
         if (batchIndex === 0) {
@@ -837,21 +852,56 @@ export async function getActiveJobsForUser(userId: number): Promise<
  * tables of a user that no longer exists. 'active' jobs are locked by their
  * worker and intentionally skipped — they finish on their own.
  */
-export async function removePendingJobsForUser({ userId }: { userId: number }): Promise<void> {
+/**
+ * Force a fresh recovery scan, bypassing the memoized `ensureMonobankQueueRecovery`,
+ * so per-token bundles created since boot — including by another process — are
+ * discovered. The base-currency drain calls this before counting a user's
+ * in-flight sync jobs.
+ */
+export async function refreshMonobankBundleDiscovery(): Promise<void> {
+  await recoverExistingQueues();
+}
+
+/**
+ * Count a user's not-yet-finished sync jobs (active + waiting + delayed) across
+ * every per-token queue. `delayed` is included because jobs sit delayed between
+ * 60s rate-limited batches — an active-only count would report "clear" while a
+ * batch is still pending. Reads the currently-known bundles; call
+ * {@link refreshMonobankBundleDiscovery} first to pick up bundles from other processes.
+ */
+export async function countUnfinishedMonobankJobsForUser({ userId }: { userId: number }): Promise<number> {
+  const allBundles = getAllMonobankQueueBundles();
+  const jobsPerBundle = await Promise.all(allBundles.map((b) => b.queue.getJobs(['active', 'waiting', 'delayed'])));
+  return jobsPerBundle.flat().filter((job) => job.data.userId === userId).length;
+}
+
+export async function removePendingJobsForUser({
+  userId,
+}: {
+  userId: number;
+}): Promise<{ removedAccountIds: string[] }> {
   await ensureMonobankQueueRecovery();
 
   const allBundles = getAllMonobankQueueBundles();
   const jobsPerBundle = await Promise.all(allBundles.map((b) => b.queue.getJobs(['waiting', 'delayed'])));
   const userJobs = jobsPerBundle.flat().filter((job) => job.data.userId === userId);
 
+  const removedAccountIds = new Set<string>();
   await Promise.all(
     userJobs.map((job) =>
-      job.remove().catch((error) => {
-        // Job may have become active between getJobs and remove - ignore lock errors,
-        // but log the actual error so we can spot non-lock failures (Redis disconnect,
-        // etc.) instead of misattributing every miss to a transient lock race.
-        logger.warn(`Could not remove job during user deletion. jobId: ${job.id}`, { error: error as Error });
-      }),
+      job
+        .remove()
+        .then(() => {
+          removedAccountIds.add(String(job.data.accountId));
+        })
+        .catch((error) => {
+          // Job may have become active between getJobs and remove - ignore lock errors,
+          // but log the actual error so we can spot non-lock failures (Redis disconnect,
+          // etc.) instead of misattributing every miss to a transient lock race.
+          logger.warn(`Could not remove job during user deletion. jobId: ${job.id}`, { error: error as Error });
+        }),
     ),
   );
+
+  return { removedAccountIds: [...removedAccountIds] };
 }

--- a/packages/backend/src/services/bank-data-providers/simplefin/simplefin-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/simplefin/simplefin-flow.e2e.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
 import Balances from '@models/balances.model';
 import Transactions from '@models/transactions.model';
+import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
 import * as helpers from '@tests/helpers';
 import {
   SIMPLEFIN_ACCOUNT_1,
@@ -372,6 +374,33 @@ describe('SimpleFIN Data Provider E2E', () => {
       const today = new Date().toISOString().slice(0, 10);
       expect(balances1.some((b) => new Date(b.date).toISOString().slice(0, 10) === today)).toBe(true);
       expect(balances2.some((b) => new Date(b.date).toISOString().slice(0, 10) === today)).toBe(true);
+    });
+  });
+
+  describe('Base-currency lock', () => {
+    it('rejects a sync while the user holds the base-currency lock and writes no transactions', async () => {
+      const { id: userId } = await helpers.getUserInfo({ raw: true });
+      const { connectionId, accountId } = await connectAndImport(getMockedSimplefinTransactions(3));
+      expect(await Transactions.count({ where: { accountId } })).toBe(3);
+
+      // Fresh (new-id) transactions the sync would otherwise import.
+      global.mswMockServer.use(
+        getSimplefinAccountsMock({
+          response: getMockedSimplefinAccountSet({ account1Transactions: getMockedSimplefinTransactions(4) }),
+        }),
+      );
+
+      await redisClient.set(buildLockKey(userId), 'test-lock');
+      let response;
+      try {
+        response = await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId });
+      } finally {
+        await redisClient.del(buildLockKey(userId));
+      }
+
+      expect(response.statusCode).toBe(ERROR_CODES.Locked);
+      // No new rows landed against the old base.
+      expect(await Transactions.count({ where: { accountId } })).toBe(3);
     });
   });
 

--- a/packages/backend/src/services/bank-data-providers/simplefin/simplefin.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/simplefin/simplefin.provider.ts
@@ -752,8 +752,11 @@ export class SimplefinProvider extends BaseBankDataProvider {
     const transactions = rawTransactions.toSorted((a, b) => a.posted - b.posted);
     const defaultCategoryId = await getUserDefaultCategory({ id: connection.userId });
     const createdIds: string[] = [];
+    const checkpoint = this.createBaseCurrencyLockCheckpoint({ userId: connection.userId });
 
     for (const tx of transactions) {
+      await checkpoint();
+
       // Primary dedup: normal re-sync.
       const existingTx = await Transactions.findOne({ where: { accountId: account.id, originalId: tx.id } });
       if (existingTx) continue;

--- a/packages/backend/src/services/bank-data-providers/sync/sync-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/sync/sync-flow.e2e.ts
@@ -1,6 +1,7 @@
 import { ACCOUNT_STATUSES, BANK_PROVIDER_TYPE, DEACTIVATION_REASON } from '@bt/shared/types';
 import { describe, expect, it } from '@jest/globals';
 import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
 import * as helpers from '@tests/helpers';
 import { VALID_MONOBANK_TOKEN } from '@tests/mocks/monobank/mock-api';
 
@@ -120,6 +121,44 @@ describe('Sync Flow E2E', () => {
       expect(response.body.response.syncTriggered).toBe(true);
       expect(response.body.response).toHaveProperty('totalAccounts');
       expect(response.body.response.totalAccounts).toBeGreaterThan(0);
+    });
+
+    it('does not trigger auto-sync while a base-currency change holds the lock', async () => {
+      const { id: userId } = await helpers.getUserInfo({ raw: true });
+      const connectionResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken: VALID_MONOBANK_TOKEN },
+        raw: true,
+      });
+
+      const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+        connectionId: connectionResult.connectionId,
+        raw: true,
+      });
+
+      await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectionResult.connectionId,
+        accountExternalIds: [externalAccounts[0]!.externalId],
+        raw: true,
+      });
+
+      // No prior sync — a lock-free /check would trigger. The lock must suppress it.
+      await redisClient.del(REDIS_KEYS.userLastAutoSync(userId));
+
+      await redisClient.set(buildLockKey(userId), 'test-lock');
+      let lockedResponse;
+      try {
+        lockedResponse = await helpers.makeRequest({ method: 'get', url: '/bank-data-providers/sync/check' });
+      } finally {
+        await redisClient.del(buildLockKey(userId));
+      }
+
+      expect(lockedResponse.status).toBe(200);
+      expect(lockedResponse.body.response.syncTriggered).toBe(false);
+
+      // Once the lock clears, the same setup triggers — proving the lock was the only blocker.
+      const afterUnlock = await helpers.makeRequest({ method: 'get', url: '/bank-data-providers/sync/check' });
+      expect(afterUnlock.body.response.syncTriggered).toBe(true);
     });
 
     it.skip('should not trigger sync when last sync was within 4 hours', async () => {

--- a/packages/backend/src/services/bank-data-providers/sync/sync-manager.ts
+++ b/packages/backend/src/services/bank-data-providers/sync/sync-manager.ts
@@ -1,5 +1,6 @@
 import { BANK_PROVIDER_TYPE } from '@bt/shared/types';
 import { logger } from '@js/utils/logger';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import Bottleneck from 'bottleneck';
 
 import { syncTransactionsForAccount } from '../connection/sync-transactions-for-account';
@@ -121,6 +122,13 @@ export async function syncAllUserAccounts(userId: number): Promise<SyncResult> {
  * Returns sync result if sync was triggered, null if skipped
  */
 export async function checkAndTriggerAutoSync(userId: number): Promise<SyncResult | null> {
+  // A base-currency recalculation is rewriting this user's ref* amounts; kicking
+  // a fresh sync now would race the migration and commit old-base rows. Skip —
+  // the next /sync/check tick after the lock clears triggers it.
+  if (await isBaseCurrencyChangeLocked({ userId })) {
+    return null;
+  }
+
   const shouldSync = await shouldTriggerAutoSync(userId);
 
   if (!shouldSync) {

--- a/packages/backend/src/services/bank-data-providers/walutomat/walutomat.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/walutomat/walutomat.provider.ts
@@ -333,8 +333,11 @@ export class WalutomatProvider extends BaseBankDataProvider {
 
         const defaultCategoryId = await getUserDefaultCategory({ id: connection.userId });
         const createdTransactionIds: string[] = [];
+        const checkpoint = this.createBaseCurrencyLockCheckpoint({ userId });
 
         for (const item of historyItems) {
+          await checkpoint();
+
           // Primary dedup: check by originalId
           const existingTx = await Transactions.findOne({
             where: {

--- a/packages/backend/src/services/currencies/base-currency-change-drain.ts
+++ b/packages/backend/src/services/currencies/base-currency-change-drain.ts
@@ -1,0 +1,125 @@
+import type { RecordId } from '@bt/shared/types';
+import { t } from '@i18n/index';
+import { logger } from '@js/utils/logger';
+import Accounts from '@models/accounts.model';
+import {
+  countUnfinishedMonobankJobsForUser,
+  refreshMonobankBundleDiscovery,
+  removePendingJobsForUser,
+} from '@services/bank-data-providers/monobank/transaction-sync-queue';
+import {
+  SyncStatus,
+  getMultipleAccountsSyncStatus,
+  setAccountSyncStatus,
+} from '@services/bank-data-providers/sync/sync-status-tracker';
+import { budgetBakersWalletImportQueue } from '@services/import-export/budget-bakers-wallet-import';
+import { csvImportQueue } from '@services/import-export/csv-import/csv-import-queue';
+import { ynabImportQueue } from '@services/import-export/ynab-import';
+import { Queue } from 'bullmq';
+
+// Real drain windows in prod, compressed in tests so the e2e suites that enqueue a
+// genuine job don't each pay the full grace/timeout. The 5s grace covers in-flight
+// HTTP writes and cron iterations, which resolve FX from the DB and commit sub-second.
+const IS_TEST = process.env.NODE_ENV === 'test';
+const POLL_INTERVAL_MS = IS_TEST ? 250 : 2000;
+const GRACE_MS = IS_TEST ? 100 : 5000;
+const TIMEOUT_MS = IS_TEST ? 3000 : 5 * 60 * 1000;
+const REDISCOVERY_RETRY_DELAY_MS = IS_TEST ? 100 : 2000;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// Typed as the base `Queue` so the three importers' distinct generic data types
+// collapse to one callable `getJobs` signature.
+const importQueues: Queue[] = [csvImportQueue, ynabImportQueue, budgetBakersWalletImportQueue];
+
+/** Import workers write transactions row-by-row; an active job for this user could
+ *  commit rows against the old base. Count active jobs across every importer. */
+async function countActiveImportJobsForUser({ userId }: { userId: number }): Promise<number> {
+  const jobsPerQueue = await Promise.all(importQueues.map((queue) => queue.getJobs(['active'])));
+  return jobsPerQueue.flat().filter((job) => (job.data as { userId?: number }).userId === userId).length;
+}
+
+/** The only visibility into the fire-and-forget direct-provider syncs: a bank
+ *  account left QUEUED/SYNCING means one is still writing transactions. */
+async function hasAccountMidSync({ userId }: { userId: number }): Promise<boolean> {
+  const accounts = await Accounts.findAll({ where: { userId }, attributes: ['id'], raw: true });
+  if (accounts.length === 0) return false;
+  const statuses = await getMultipleAccountsSyncStatus(accounts.map((account) => account.id));
+  return statuses.some((status) => status.status === SyncStatus.QUEUED || status.status === SyncStatus.SYNCING);
+}
+
+/**
+ * Block until no in-flight writer can still commit an amount computed against the
+ * old base currency, then wait a fixed grace. Called first thing in the worker,
+ * before the recalc opens its DB transaction.
+ *
+ * Bulk-removes the user's not-yet-started monobank batches up front so the drain
+ * doesn't wait one-per-60s for the rate limiter to release them, then polls every
+ * few seconds for: monobank batches (active + waiting + delayed), active import
+ * jobs, and any bank account the direct-provider syncs left QUEUED/SYNCING. On
+ * timeout it throws — nothing has been mutated and the worker's `finally` releases
+ * the lock, so the user simply retries.
+ */
+export async function drainUserWriters({ userId }: { userId: number }): Promise<void> {
+  // Fresh scan (bypassing the memoized boot recovery) so bundles created since
+  // startup — including by another process — are discovered before we remove/count.
+  // A cross-process monobank sync that stays undiscovered would keep writing old-base
+  // rows invisibly to the drain, so a failed scan is retried once and then fails the
+  // job — the worker's `finally` releases the lock and the user retries.
+  try {
+    await refreshMonobankBundleDiscovery();
+  } catch (firstErr) {
+    logger.warn(`[Base Currency Change Drain] Monobank bundle rediscovery failed, retrying: ${String(firstErr)}`);
+    await sleep(REDISCOVERY_RETRY_DELAY_MS);
+    try {
+      await refreshMonobankBundleDiscovery();
+    } catch (retryErr) {
+      logger.error({
+        message: '[Base Currency Change Drain] Monobank bundle rediscovery failed after retry',
+        error: retryErr instanceof Error ? retryErr : new Error(String(retryErr)),
+      });
+      throw new Error(t({ key: 'currencies.baseCurrencyChangeDrainCheckFailed' }), { cause: retryErr });
+    }
+  }
+  const { removedAccountIds } = await removePendingJobsForUser({ userId });
+  // Accounts whose only work was the batches we just deleted. Their tracker
+  // status is left QUEUED/SYNCING with no worker remaining to ever settle it,
+  // which hasAccountMidSync would otherwise poll on until the drain times out.
+  const orphanedAccountIds = new Set(removedAccountIds);
+
+  const deadline = Date.now() + TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const [monobankPending, activeImports, midSync] = await Promise.all([
+      countUnfinishedMonobankJobsForUser({ userId }),
+      countActiveImportJobsForUser({ userId }),
+      hasAccountMidSync({ userId }),
+    ]);
+
+    // Once no unfinished monobank job remains, no worker will ever settle the
+    // statuses of the accounts we removed jobs from — settle them ourselves.
+    // Waiting for the pending count to hit zero first avoids racing a batch-0
+    // SYNCING write. COMPLETED (not FAILED) mirrors the worker's lock-abort:
+    // the skipped, deduped date range is re-fetched by the next auto-sync.
+    if (monobankPending === 0 && orphanedAccountIds.size > 0) {
+      const statuses = await getMultipleAccountsSyncStatus([...orphanedAccountIds] as RecordId[]);
+      await Promise.all(
+        statuses
+          .filter((s) => s.status === SyncStatus.QUEUED || s.status === SyncStatus.SYNCING)
+          .map((s) => setAccountSyncStatus({ accountId: s.accountId, status: SyncStatus.COMPLETED, userId })),
+      );
+      orphanedAccountIds.clear();
+    }
+
+    if (monobankPending === 0 && activeImports === 0 && !midSync) {
+      // Fixed grace so in-flight HTTP writes / cron iterations that already passed
+      // their lock check commit before the recalc snapshots rows.
+      await sleep(GRACE_MS);
+      return;
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(t({ key: 'currencies.baseCurrencyChangeSyncInProgress' }));
+}

--- a/packages/backend/src/services/currencies/base-currency-change-queue.ts
+++ b/packages/backend/src/services/currencies/base-currency-change-queue.ts
@@ -1,0 +1,235 @@
+import {
+  API_ERROR_CODES,
+  type BaseCurrencyChangeStatus,
+  type RecalculateResult,
+  SSE_EVENT_TYPES,
+} from '@bt/shared/types';
+import { t } from '@i18n/index';
+import { LockedError } from '@js/errors';
+import { logger } from '@js/utils/logger';
+import { redisClient } from '@root/redis-client';
+import { sseManager } from '@services/common/sse';
+import { Job, Queue, Worker } from 'bullmq';
+import { randomUUID } from 'crypto';
+
+import { drainUserWriters } from './base-currency-change-drain';
+import {
+  acquireBaseCurrencyLock,
+  extendBaseCurrencyLockTtlIfOwned,
+  releaseBaseCurrencyLockIfOwned,
+} from './base-currency-lock';
+import { changeBaseCurrencyImpl, validateBaseCurrencyChange } from './change-base-currency.service';
+
+interface BaseCurrencyChangeJobData {
+  userId: number;
+  newCurrencyCode: string;
+}
+
+// Redis connection for BullMQ. Mirrors the resilient settings the other queues
+// use to avoid "Connection is closed." errors in CI. BullMQ requires
+// `maxRetriesPerRequest: null`.
+const connection = {
+  host: process.env.APPLICATION_REDIS_HOST,
+  maxRetriesPerRequest: null,
+  connectTimeout: 20000,
+  keepAlive: 10000,
+  retryStrategy: (times: number) => Math.min(times * 100, 3000),
+};
+
+// Namespace the queue by Jest worker id in tests so parallel workers don't share
+// a queue. No shared helper exists for this, so it's inline like the sibling queues.
+const queueName =
+  process.env.NODE_ENV === 'test' && process.env.JEST_WORKER_ID
+    ? `base-currency-change-${process.env.JEST_WORKER_ID}`
+    : 'base-currency-change';
+
+const CONNECTION_CLOSED_ERROR_MSG = 'Connection is closed.';
+
+function isConnectionClosedError(err: Error): boolean {
+  return err.message === CONNECTION_CLOSED_ERROR_MSG;
+}
+
+/**
+ * Per-user pointer to the most recent change-base job. The status endpoint reads
+ * the jobId from here — there are no URL params. `-` separators keep it consistent
+ * with the jobId (BullMQ forbids `:` in custom job ids). The main `redisClient`
+ * namespaces it per Jest worker via `REDIS_KEY_PREFIX`.
+ */
+export const buildLastJobPointerKey = (userId: number): string => `base-currency-change-last-job-${userId}`;
+
+// Heartbeat cadence for extending the lock TTL while a long recalc runs, so the
+// lock never lapses mid-rewrite and reopens the guarded routes.
+const LOCK_HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
+
+export const baseCurrencyChangeQueue = new Queue<BaseCurrencyChangeJobData, RecalculateResult>(queueName, {
+  connection,
+  defaultJobOptions: {
+    attempts: 1, // One user-triggered recalc; never auto-retry a partial-looking failure.
+    removeOnComplete: { age: 24 * 3600 }, // Keep a day so /status can still report the result.
+    removeOnFail: { age: 7 * 24 * 3600 },
+  },
+});
+
+baseCurrencyChangeQueue.on('error', (err) => {
+  if (!isConnectionClosedError(err)) {
+    logger.error({ message: '[Base Currency Change Queue] Queue error', error: err });
+  }
+});
+
+function emitStatus({ userId, status }: { userId: number; status: BaseCurrencyChangeStatus }): void {
+  sseManager.sendToUser({ userId, event: SSE_EVENT_TYPES.BASE_CURRENCY_CHANGE_STATUS, data: status });
+}
+
+export const baseCurrencyChangeWorker = new Worker<BaseCurrencyChangeJobData, RecalculateResult>(
+  queueName,
+  async (job: Job<BaseCurrencyChangeJobData>) => {
+    const { userId, newCurrencyCode } = job.data;
+    const jobId = job.id!;
+
+    // Keep the lock alive for the whole recalc: a run past the TTL would otherwise
+    // let the lock expire and every guarded route stop 423ing while rows still change.
+    const heartbeat = setInterval(() => {
+      extendBaseCurrencyLockTtlIfOwned({ userId, jobId }).catch((err) => {
+        logger.error({
+          message: `[Base Currency Change Worker] Lock TTL heartbeat failed for job ${jobId}`,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    }, LOCK_HEARTBEAT_INTERVAL_MS);
+
+    try {
+      emitStatus({ userId, status: { state: 'running', jobId, startedAt: job.processedOn ?? Date.now() } });
+
+      // Wait for in-flight writers to finish (or abort) before the recalc snapshots
+      // rows, then re-validate and rewrite every ref* amount. The lock is already
+      // held (taken at enqueue); this worker never acquires one.
+      await drainUserWriters({ userId });
+
+      return await changeBaseCurrencyImpl({
+        userId,
+        newCurrencyCode,
+        onProgress: async ({ step }) => {
+          // Best-effort: a committed step must not roll back because persisting
+          // progress or the SSE push threw. The 8 steps are naturally spaced (each
+          // sweeps a table), so every step emits — no throttle needed.
+          try {
+            await job.updateProgress({ step });
+            emitStatus({ userId, status: { state: 'running', jobId, step, startedAt: job.processedOn ?? Date.now() } });
+          } catch (err) {
+            logger.error({
+              message: `[Base Currency Change Worker] Progress update failed for job ${jobId}`,
+              error: err instanceof Error ? err : new Error(String(err)),
+            });
+          }
+        },
+      });
+    } finally {
+      clearInterval(heartbeat);
+      // A crashed worker skips this; the status endpoint's reconciliation is the
+      // backstop that releases an orphaned lock.
+      await releaseBaseCurrencyLockIfOwned({ userId, jobId }).catch((err) => {
+        logger.error({
+          message: `[Base Currency Change Worker] Lock release failed for job ${jobId}`,
+          error: err instanceof Error ? err : new Error(String(err)),
+        });
+      });
+    }
+  },
+  {
+    connection,
+    concurrency: 1,
+  },
+);
+
+baseCurrencyChangeWorker.on('completed', (job, result) => {
+  emitStatus({
+    userId: job.data.userId,
+    status: { state: 'completed', jobId: job.id!, finishedAt: job.finishedOn ?? Date.now(), result },
+  });
+});
+
+baseCurrencyChangeWorker.on('failed', (job, err) => {
+  logger.error({ message: `[Base Currency Change Worker] Job ${job?.id} failed`, error: err });
+  if (!job) return;
+  emitStatus({
+    userId: job.data.userId,
+    status: { state: 'failed', jobId: job.id!, finishedAt: job.finishedOn ?? undefined, error: err.message },
+  });
+});
+
+baseCurrencyChangeWorker.on('error', (err) => {
+  if (!isConnectionClosedError(err)) {
+    logger.error({ message: '[Base Currency Change Worker] Worker error', error: err });
+  }
+});
+
+/**
+ * Validate, take the lock at enqueue time, and queue the recalculation.
+ *
+ * Order is load-bearing: validate BEFORE the lock so a trivial rejection never
+ * holds the 4h lock; take the lock BEFORE queueing so the guard middleware starts
+ * returning 423 the instant this resolves (closing the enqueue→pickup window). The
+ * NX lock is the dedupe — a second call for the same user 423s here rather than
+ * queueing a duplicate. On a failed `queue.add`, the lock and pointer are rolled back.
+ */
+export async function enqueueBaseCurrencyChange({
+  userId,
+  newCurrencyCode,
+}: BaseCurrencyChangeJobData): Promise<{ jobId: string; state: 'queued' }> {
+  await validateBaseCurrencyChange({ userId, newCurrencyCode });
+
+  // Non-deterministic id: a deterministic one would be silently dropped by
+  // `queue.add` while a same-id completed job is still retained (24h).
+  const jobId = `base-currency-change-${userId}-${randomUUID()}`;
+
+  const acquired = await acquireBaseCurrencyLock({ userId, jobId });
+  if (!acquired) {
+    // A change is already in flight — surface it (and the current status) so the
+    // requesting device flips its blocking overlay on. Imported dynamically: the
+    // status service imports this queue, so a static import would be a module cycle.
+    const { getBaseCurrencyChangeStatus } = await import('./base-currency-change-status.service');
+
+    // A failed status read (Redis/BullMQ hiccup) must still yield the 423, not a 500.
+    // The FE seeds the overlay from its own placeholder when the status seed is absent.
+    let status: BaseCurrencyChangeStatus | undefined;
+    try {
+      status = await getBaseCurrencyChangeStatus({ userId });
+    } catch (statusError) {
+      logger.warn(`[Base Currency Change] Status read failed while rejecting duplicate enqueue for user ${userId}`, {
+        error: statusError instanceof Error ? statusError : new Error(String(statusError)),
+      });
+    }
+
+    throw new LockedError({
+      code: API_ERROR_CODES.baseCurrencyChangeInProgress,
+      message: t({ key: 'currencies.baseCurrencyChangeInProgress' }),
+      details: status ? { status } : undefined,
+    });
+  }
+
+  // Pointer write sits inside the rollback try: if it (or the add) throws after
+  // the lock SET committed, the lock must be released here — the status service
+  // finds jobs via this pointer, so a lock without one is unrecoverable until TTL.
+  try {
+    await redisClient.set(buildLastJobPointerKey(userId), jobId, 'EX', 24 * 3600);
+    await baseCurrencyChangeQueue.add('change-base-currency', { userId, newCurrencyCode }, { jobId });
+  } catch (error) {
+    // Roll back the lock and pointer, but never mask the original throw. A failed
+    // rollback would strand the user behind the full lock TTL, so log it loudly.
+    await releaseBaseCurrencyLockIfOwned({ userId, jobId }).catch((rollbackError) => {
+      logger.error({
+        message: `[Base Currency Change] Lock rollback failed after enqueue error for job ${jobId}`,
+        error: rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
+      });
+    });
+    await redisClient.del(buildLastJobPointerKey(userId)).catch((rollbackError) => {
+      logger.error({
+        message: `[Base Currency Change] Pointer rollback failed after enqueue error for job ${jobId}`,
+        error: rollbackError instanceof Error ? rollbackError : new Error(String(rollbackError)),
+      });
+    });
+    throw error;
+  }
+
+  return { jobId, state: 'queued' };
+}

--- a/packages/backend/src/services/currencies/base-currency-change-status.service.ts
+++ b/packages/backend/src/services/currencies/base-currency-change-status.service.ts
@@ -1,0 +1,79 @@
+import {
+  BASE_CURRENCY_CHANGE_STEPS,
+  type BaseCurrencyChangeStatus,
+  type BaseCurrencyChangeStep,
+} from '@bt/shared/types';
+import { redisClient } from '@root/redis-client';
+
+import { baseCurrencyChangeQueue, buildLastJobPointerKey } from './base-currency-change-queue';
+import { releaseBaseCurrencyLockIfOwned } from './base-currency-lock';
+
+/**
+ * Resolve the user's current base-currency-change status from the per-user pointer
+ * key and the BullMQ job it points at. Never 404s: the frontend calls this on every
+ * boot, so "no job" is a 200 `idle`.
+ *
+ * Also the crash-recovery path: whenever the resolved state is terminal (or the job
+ * aged out) and the lock still holds this jobId — a worker killed before its
+ * `finally` ran — the lock is released here before responding, so a polling client
+ * naturally unblocks every mutating route instead of waiting out the 4h TTL.
+ */
+export async function getBaseCurrencyChangeStatus({ userId }: { userId: number }): Promise<BaseCurrencyChangeStatus> {
+  const jobId = await redisClient.get(buildLastJobPointerKey(userId));
+  // Rule: no pointer → never ran (or the pointer was cleared) → idle.
+  if (!jobId) return { state: 'idle' };
+
+  const job = await baseCurrencyChangeQueue.getJob(jobId);
+  // Rule: job aged out of retention while the pointer lingers → idle, but first
+  // release the lock in case a crashed worker left it holding this jobId.
+  if (!job) {
+    await releaseBaseCurrencyLockIfOwned({ userId, jobId });
+    return { state: 'idle' };
+  }
+
+  // Rule: defense-in-depth — a pointer must only ever resolve its own user's job.
+  if (job.data.userId !== userId) return { state: 'idle' };
+
+  const state = await job.getState();
+  // The job's progress blob is untyped; only surface `step` when it's a real
+  // recalc phase so a malformed value never leaks through as a bogus step.
+  const rawStep = ((job.progress ?? {}) as { step?: string }).step;
+  const step: BaseCurrencyChangeStep | undefined = BASE_CURRENCY_CHANGE_STEPS.includes(
+    rawStep as BaseCurrencyChangeStep,
+  )
+    ? (rawStep as BaseCurrencyChangeStep)
+    : undefined;
+  const startedAt = job.processedOn ?? undefined;
+
+  if (state === 'completed') {
+    const result = job.returnvalue;
+    // Rule (returnvalue-visibility race): state flipped to completed but the
+    // returnvalue blob isn't visible yet — report running so the client doesn't
+    // fire its completion handler without a result. The next poll gets the payload.
+    if (!result) {
+      return { state: 'running', jobId, step, startedAt };
+    }
+    await releaseBaseCurrencyLockIfOwned({ userId, jobId });
+    return { state: 'completed', jobId, finishedAt: job.finishedOn ?? Date.now(), result };
+  }
+
+  if (state === 'failed') {
+    // Rule (failedReason race): the snapshot's failedReason can lag the state flip —
+    // re-fetch once, then settle on a generic message. Never report running for a
+    // failed job, or a poll-only client (SSE down) would spin forever.
+    let error = job.failedReason;
+    if (!error) {
+      const settled = (await baseCurrencyChangeQueue.getJob(jobId)) ?? job;
+      error = settled.failedReason || 'Base currency change failed';
+    }
+    await releaseBaseCurrencyLockIfOwned({ userId, jobId });
+    return { state: 'failed', jobId, finishedAt: job.finishedOn ?? undefined, error };
+  }
+
+  // Rule (state mapping): active → running; waiting/delayed (and any other
+  // not-yet-terminal state) → queued.
+  if (state === 'active') {
+    return { state: 'running', jobId, step, startedAt };
+  }
+  return { state: 'queued', jobId };
+}

--- a/packages/backend/src/services/currencies/base-currency-lock.ts
+++ b/packages/backend/src/services/currencies/base-currency-lock.ts
@@ -1,0 +1,120 @@
+import { API_ERROR_CODES } from '@bt/shared/types';
+import { t } from '@i18n/index';
+import { LockedError } from '@js/errors';
+import { redisClient } from '@root/redis-client';
+
+/**
+ * How long the base-currency lock lives before Redis expires it. Long enough to
+ * cover a full recalc on a large dataset; a job still running past it heartbeats
+ * the TTL so the lock never lapses mid-recalc.
+ */
+const LOCK_TTL_SECONDS = 4 * 3600;
+
+/** The one key both the 423 route guard and every background writer read. */
+export const buildLockKey = (userId: number) => `change-base-currency:user:${userId}`;
+
+// Delete the lock only when it still holds this jobId. A plain GET-then-DEL
+// release is not atomic — a job whose lock expired and was re-acquired by a
+// newer job would otherwise delete the newer job's lock. Run as one Lua step.
+const RELEASE_LOCK_IF_OWNED = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end`;
+
+// Extend the TTL only when the lock still holds this jobId, so a heartbeat from a
+// stale job can't keep a newer owner's lock alive. Compare-and-expire in one step.
+const EXTEND_LOCK_TTL_IF_OWNED = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("expire", KEYS[1], ARGV[2])
+else
+  return 0
+end`;
+
+/**
+ * True while a base-currency recalculation holds the user's lock. Background
+ * writers — bank syncs, import jobs, crons, and refreshes triggered by GET
+ * requests — call this to self-abort or skip. The 423 route middleware only
+ * covers authenticated mutating HTTP routes; queue workers, cron ticks, and
+ * lazy GET writes are invisible to it, so each reads the same lock key the
+ * middleware does and stops writing while the recalc rewrites every ref* amount.
+ */
+export const isBaseCurrencyChangeLocked = async ({ userId }: { userId: number }): Promise<boolean> => {
+  const lockValue = await redisClient.get(buildLockKey(userId));
+  return lockValue !== null;
+};
+
+/**
+ * Take the lock for this job. `SET NX` is the dedupe: a second concurrent change
+ * for the same user fails to acquire and is rejected upstream rather than queued.
+ */
+export async function acquireBaseCurrencyLock({ userId, jobId }: { userId: number; jobId: string }): Promise<boolean> {
+  const result = await redisClient.set(buildLockKey(userId), jobId, 'EX', LOCK_TTL_SECONDS, 'NX');
+  return result !== null;
+}
+
+/**
+ * Release the base-currency lock only if it is still held by this job. Used by the
+ * worker's `finally` and by the status endpoint's orphan-lock reconciliation.
+ */
+export async function releaseBaseCurrencyLockIfOwned({
+  userId,
+  jobId,
+}: {
+  userId: number;
+  jobId: string;
+}): Promise<void> {
+  await redisClient.eval(RELEASE_LOCK_IF_OWNED, 1, buildLockKey(userId), jobId);
+}
+
+/**
+ * Push the lock's expiry back out to the full TTL, but only while this job still
+ * owns it. The worker heartbeats this so a recalc running past the TTL never lets
+ * the lock lapse and reopen the guarded routes mid-rewrite.
+ */
+export async function extendBaseCurrencyLockTtlIfOwned({
+  userId,
+  jobId,
+}: {
+  userId: number;
+  jobId: string;
+}): Promise<void> {
+  await redisClient.eval(EXTEND_LOCK_TTL_IF_OWNED, 1, buildLockKey(userId), jobId, LOCK_TTL_SECONDS);
+}
+
+/**
+ * Throw if the requester or any other party is mid base-currency migration. Callers
+ * that touch more than one user's data (share accept, back-invite) check every party,
+ * since the route guard only inspects the requester's lock.
+ *
+ * The requester's own lock uses the app-blocking code so their global 423 handler
+ * raises the full-app overlay; another party's lock uses a distinct code so the
+ * requester only sees a retryable error, not a frozen app for someone else's migration.
+ */
+export async function assertUsersNotBaseCurrencyLocked({
+  requesterUserId,
+  otherUserIds,
+}: {
+  requesterUserId: number;
+  otherUserIds: number[];
+}): Promise<void> {
+  const [requesterLocked, ...othersLocked] = await Promise.all([
+    isBaseCurrencyChangeLocked({ userId: requesterUserId }),
+    ...otherUserIds.map((userId) => isBaseCurrencyChangeLocked({ userId })),
+  ]);
+
+  if (requesterLocked) {
+    throw new LockedError({
+      code: API_ERROR_CODES.baseCurrencyChangeInProgress,
+      message: t({ key: 'currencies.baseCurrencyChangeInProgress' }),
+    });
+  }
+
+  if (othersLocked.some(Boolean)) {
+    throw new LockedError({
+      code: API_ERROR_CODES.baseCurrencyChangeInProgressOtherUser,
+      message: t({ key: 'currencies.baseCurrencyChangeInProgressOtherUser' }),
+    });
+  }
+}

--- a/packages/backend/src/services/currencies/change-base-currency-status.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency-status.e2e.ts
@@ -1,0 +1,161 @@
+import { API_ERROR_CODES, TRANSACTION_TYPES } from '@bt/shared/types';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { ERROR_CODES } from '@js/errors';
+import Transactions from '@models/transactions.model';
+import { redisClient } from '@root/redis-client';
+import { REDIS_KEYS, SyncStatus } from '@services/bank-data-providers/sync/sync-status-tracker';
+import * as helpers from '@tests/helpers';
+
+/**
+ * GET /user/currencies/change-base/status. The change runs as a background job any
+ * device polls to drive the blocking overlay. These tests drive the full lifecycle
+ * (idle → queued/running → completed) through the HTTP helpers, plus the
+ * double-enqueue 423 and a deterministic failure.
+ */
+describe('Base-currency change status endpoint', () => {
+  beforeEach(async () => {
+    // Pin base to GBP (matching the sibling suites — the seed carries GBP/EUR→USD
+    // historical rates), then connect EUR (the account currency) and USD (the target).
+    await helpers.makeRequest({ method: 'post', url: '/user/currencies/base', payload: { currencyCode: 'GBP' } });
+    await helpers.addUserCurrencies({ currencyCodes: ['EUR', 'USD'], raw: true });
+  });
+
+  // Mark one of the user's accounts as actively syncing so the worker's drain never
+  // clears — used to deterministically fail the job on drain timeout.
+  const holdAccountSyncing = async ({ accountId }: { accountId: string }) => {
+    await redisClient.set(
+      REDIS_KEYS.accountSyncStatus(accountId),
+      JSON.stringify({
+        accountId,
+        status: SyncStatus.SYNCING,
+        startedAt: new Date().toISOString(),
+        completedAt: null,
+        error: null,
+      }),
+    );
+  };
+
+  it('reports idle for a user who has never changed base currency', async () => {
+    const status = await helpers.getBaseCurrencyChangeStatus({ raw: true });
+    expect(status.state).toEqual('idle');
+  });
+
+  it('walks idle → queued/running → completed and actually changes refAmounts', async () => {
+    const account = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ currencyCode: 'EUR', initialBalance: 10000 }),
+      raw: true,
+    });
+    const [tx] = await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: 5000,
+        transactionType: TRANSACTION_TYPES.expense,
+        time: new Date('2024-01-15').toISOString(),
+      }),
+      raw: true,
+    });
+    const originalRefAmount = tx.refAmount;
+
+    const before = await helpers.getBaseCurrencyChangeStatus({ raw: true });
+    expect(before.state).toEqual('idle');
+
+    const enqueue = await helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
+    expect(enqueue.statusCode).toEqual(202);
+    expect(enqueue.body.response.jobId).toBeTruthy();
+    expect(enqueue.body.response.state).toEqual('queued');
+
+    // The 5s (test: 100ms) drain grace keeps the job non-terminal long enough to
+    // observe it in-flight right after enqueue.
+    const inFlight = await helpers.getBaseCurrencyChangeStatus({ raw: true });
+    expect(['queued', 'running']).toContain(inFlight.state);
+
+    const settled = await helpers.waitForBaseCurrencyChangeSettled();
+    helpers.expectBaseCurrencyChangeCompleted(settled);
+    expect(settled.result.transactionsUpdated).toBeGreaterThan(0);
+    expect(settled.jobId).toEqual(enqueue.body.response.jobId);
+
+    // refAmount was actually rewritten into the new base (EUR→USD ≠ EUR→AED).
+    // No `raw: true` here — it would bypass the Money getter and yield cents,
+    // making the inequality against the API's decimal trivially (vacuously) true.
+    const updatedTx = await Transactions.findByPk(tx.id);
+    expect(updatedTx!.refCurrencyCode).toEqual('USD');
+    expect(updatedTx!.refAmount.toNumber()).not.toEqual(originalRefAmount);
+  });
+
+  it('holds the job non-terminal while an account syncs, then completes once the sync clears', async () => {
+    const account = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ currencyCode: 'EUR', initialBalance: 10000 }),
+      raw: true,
+    });
+    await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: 5000,
+        transactionType: TRANSACTION_TYPES.expense,
+        time: new Date('2024-01-15').toISOString(),
+      }),
+      raw: true,
+    });
+
+    // A syncing account keeps the worker's drain looping — the job cannot reach
+    // its recalc while this holds.
+    await holdAccountSyncing({ accountId: account.id });
+
+    const enqueue = await helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
+    expect(enqueue.statusCode).toEqual(202);
+
+    // While the sync is held, the job stays non-terminal. Poll a short window
+    // (well inside the 3s test drain timeout) to prove it never completes early.
+    for (let i = 0; i < 3; i++) {
+      await helpers.sleep(150);
+      const status = await helpers.getBaseCurrencyChangeStatus({ raw: true });
+      expect(['queued', 'running']).toContain(status.state);
+    }
+
+    // Clearing the sync lets the next drain poll pass; the job then completes.
+    await redisClient.del(REDIS_KEYS.accountSyncStatus(account.id));
+
+    const settled = await helpers.waitForBaseCurrencyChangeSettled();
+    helpers.expectBaseCurrencyChangeCompleted(settled);
+    expect(settled.result.transactionsUpdated).toBeGreaterThan(0);
+    expect(settled.jobId).toEqual(enqueue.body.response.jobId);
+  });
+
+  it('rejects a second enqueue while a change is already in progress', async () => {
+    const first = await helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
+    expect(first.statusCode).toEqual(202);
+
+    // The lock is taken synchronously at enqueue (before the job is even queued),
+    // so a second enqueue is rejected immediately — no wait for worker pickup.
+    const second = await helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
+    expect(second.statusCode).toEqual(ERROR_CODES.Locked);
+    expect((second.body.response as unknown as { code: string }).code).toEqual(
+      API_ERROR_CODES.baseCurrencyChangeInProgress,
+    );
+
+    // Drain the first job to terminal so it doesn't run against the next test's
+    // truncated DB.
+    const settled = await helpers.waitForBaseCurrencyChangeSettled();
+    helpers.expectBaseCurrencyChangeCompleted(settled);
+  });
+
+  it('reports failed with an error message when a sync blocks the drain past its timeout', async () => {
+    // A bank account left SYNCING blocks the worker's drain; the job fails on
+    // timeout without mutating anything, and the lock is released in `finally`.
+    const account = await helpers.createAccount({ raw: true });
+    await holdAccountSyncing({ accountId: account.id });
+
+    try {
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeFailed(status);
+      expect(status.error).toBeTruthy();
+    } finally {
+      await redisClient.del(REDIS_KEYS.accountSyncStatus(account.id));
+    }
+
+    // The lock was released on failure, so a subsequent enqueue isn't rejected.
+    const retry = await helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
+    expect(retry.statusCode).toEqual(202);
+    await helpers.waitForBaseCurrencyChangeSettled();
+  });
+});

--- a/packages/backend/src/services/currencies/change-base-currency.loans.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.loans.e2e.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES, API_RESPONSE_STATUS, LOAN_TYPE } from '@bt/shared/types';
+import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES, LOAN_TYPE } from '@bt/shared/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import Accounts from '@models/accounts.model';
 import * as helpers from '@tests/helpers';
@@ -21,12 +21,7 @@ describe('Change Base Currency — loans keep their own currency', () => {
     await helpers.addUserCurrencies({ currencyCodes: ['EUR', 'USD'], raw: true });
   });
 
-  const changeBaseTo = (newCurrencyCode: string) =>
-    helpers.makeRequest({
-      method: 'post',
-      url: '/user/currencies/change-base',
-      payload: { newCurrencyCode },
-    });
+  const changeBaseTo = (newCurrencyCode: string) => helpers.changeBaseCurrencyAndWait({ newCurrencyCode });
 
   it('preserves a foreign-currency loan currency while recalculating its ref amounts', async () => {
     // Loan in EUR, distinct from both the old base (GBP) and the new base (USD).
@@ -54,10 +49,9 @@ describe('Change Base Currency — loans keep their own currency', () => {
     const accountBefore = await Accounts.findByPk(loan.id, { raw: true });
     const refInitialBalanceBefore = accountBefore!.refInitialBalance;
 
-    const response = await changeBaseTo('USD');
-    expect(response.statusCode).toEqual(200);
-    expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
-    expect(response.body.response.loanDetailsUpdated).toBeGreaterThan(0);
+    const status = await changeBaseTo('USD');
+    helpers.expectBaseCurrencyChangeCompleted(status);
+    expect(status.result.loanDetailsUpdated).toBeGreaterThan(0);
 
     // Base currency actually flipped.
     const newBaseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
@@ -102,8 +96,8 @@ describe('Change Base Currency — loans keep their own currency', () => {
       raw: true,
     });
 
-    const response = await changeBaseTo('USD');
-    expect(response.statusCode).toEqual(200);
+    const status = await changeBaseTo('USD');
+    helpers.expectBaseCurrencyChangeCompleted(status);
 
     const loanAfter = await helpers.getLoanById({ id: loan.id, raw: true });
     // Currency untouched.
@@ -135,8 +129,8 @@ describe('Change Base Currency — loans keep their own currency', () => {
       }),
     ]);
 
-    const response = await changeBaseTo('USD');
-    expect(response.statusCode).toEqual(200);
+    const status = await changeBaseTo('USD');
+    helpers.expectBaseCurrencyChangeCompleted(status);
 
     const [eurAfter, usdAfter, gbpAfter] = await Promise.all([
       helpers.getLoanById({ id: eurLoan.id, raw: true }),

--- a/packages/backend/src/services/currencies/change-base-currency.service.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.service.e2e.ts
@@ -1,4 +1,4 @@
-import { ACCOUNT_CATEGORIES, API_RESPONSE_STATUS, TRANSACTION_TYPES } from '@bt/shared/types';
+import { ACCOUNT_CATEGORIES, TRANSACTION_TYPES } from '@bt/shared/types';
 import { INVESTMENT_TRANSACTION_CATEGORY } from '@bt/shared/types/investments';
 import { Money } from '@common/types/money';
 import { faker } from '@faker-js/faker';
@@ -13,7 +13,7 @@ import PortfolioTransfers from '@models/investments/portfolio-transfers.model';
 import Transactions from '@models/transactions.model';
 import { redisClient } from '@root/redis-client';
 import { calculateRefAmountFromParams } from '@services/calculate-ref-amount.service';
-import { buildLockKey } from '@services/currencies/change-base-currency.service';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
 import * as userExchangeRateService from '@services/user-exchange-rate';
 import * as helpers from '@tests/helpers';
 
@@ -30,6 +30,18 @@ describe('Change Base Currency', () => {
     await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
   });
   describe('POST /user/currencies/change-base', () => {
+    it('rejects an unknown currency code and takes no lock', async () => {
+      const { id: userId } = await helpers.getUserInfo({ raw: true });
+      const res = await helpers.changeBaseCurrency({ newCurrencyCode: 'ZZZ' });
+      expect(res.statusCode).toBeGreaterThanOrEqual(400);
+      expect(res.statusCode).toBeLessThan(500);
+
+      // Validation runs before the enqueue that acquires the lock, so no lock key
+      // may be left behind — otherwise the user would be blocked by a phantom change.
+      const lock = await redisClient.get(buildLockKey(userId));
+      expect(lock).toBeNull();
+    });
+
     it('should successfully change base currency and recalculate all amounts', async () => {
       // Create an account in EUR (base currency)
       const account = await helpers.createAccount({
@@ -70,18 +82,10 @@ describe('Change Base Currency', () => {
       const originalTx2RefAmount = tx2[0].refAmount;
 
       // Change base currency from EUR to USD
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
-
-      expect(response.statusCode).toEqual(200);
-      expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
-      expect(response.body.response.transactionsUpdated).toBeGreaterThan(0);
-      expect(response.body.response.accountsUpdated).toBeGreaterThan(0);
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
+      expect(status.result.transactionsUpdated).toBeGreaterThan(0);
+      expect(status.result.accountsUpdated).toBeGreaterThan(0);
 
       // Verify base currency was changed
       const newBaseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
@@ -117,13 +121,7 @@ describe('Change Base Currency', () => {
     it('should return error when trying to change to the same currency', async () => {
       const baseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
 
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: baseCurrency.currencyCode,
-        },
-      });
+      const response = await helpers.changeBaseCurrency({ newCurrencyCode: baseCurrency.currencyCode });
 
       expect(response.statusCode).toEqual(ERROR_CODES.ValidationError);
     });
@@ -179,16 +177,9 @@ describe('Change Base Currency', () => {
       ]);
 
       // Change base currency to USD
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
-
-      expect(response.statusCode).toEqual(200);
-      expect(response.body.response.accountsUpdated).toEqual(2);
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
+      expect(status.result.accountsUpdated).toEqual(2);
 
       // Verify all accounts were recalculated
       const [updatedUahAccount, updatedEurAccount] = await Promise.all([
@@ -228,13 +219,8 @@ describe('Change Base Currency', () => {
       const originalCurrencyCode = originalTx!.currencyCode;
 
       // Change base currency
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
 
       // Verify original amount and currency are preserved
       const updatedTx = await Transactions.findByPk(tx[0].id);
@@ -264,13 +250,8 @@ describe('Change Base Currency', () => {
       const originalRefCreditLimit = originalAccount!.refCreditLimit;
 
       // Change base currency
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
 
       // Verify credit limit was recalculated
       const updatedAccount = await Accounts.findByPk(account.id);
@@ -309,13 +290,8 @@ describe('Change Base Currency', () => {
       const originalRefCommission = originalTx!.refCommissionRate;
 
       // Change base currency
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
 
       // Verify commission was recalculated
       const updatedTx = await Transactions.findByPk(baseTx.id, { raw: true });
@@ -368,13 +344,8 @@ describe('Change Base Currency', () => {
       ]);
 
       // Change base currency
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
 
       // Verify balances were rebuilt
       const balancesAfter = await Balances.findAll({
@@ -406,15 +377,8 @@ describe('Change Base Currency', () => {
       });
 
       // Change base currency
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
-
-      expect(response.statusCode).toEqual(200);
+      const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(status);
 
       // Verify account was still updated
       const updatedAccount = await Accounts.findByPk(account.id);
@@ -576,19 +540,11 @@ describe('Change Base Currency', () => {
 
       // ========== STEP 5: Change base currency to USD ==========
 
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
-
-      expect(response.statusCode).toEqual(200);
-      expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
+      const changeStatus = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(changeStatus);
 
       // Verify response statistics
-      const result = response.body.response;
+      const result = changeStatus.result;
       expect(result.transactionsUpdated).toBeGreaterThanOrEqual(30); // 30 transactions created
       expect(result.accountsUpdated).toEqual(3); // Our 3 accounts
       expect(result.investmentTransactionsUpdated).toBeGreaterThanOrEqual(1);
@@ -844,11 +800,8 @@ describe('Change Base Currency', () => {
       expect(balancesBeforeData[0].amount).toEqual(accountWithInitialBalance.refInitialBalance);
 
       // Change base currency to USD
-      await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: { newCurrencyCode: 'USD' },
-      });
+      const changeStatus = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(changeStatus);
 
       // Fetch the balance row plus per-account and combined balance-history snapshots in parallel
       const [balanceAfterChange, balanceHistoryAfter, combinedBalanceHistory] = await Promise.all([
@@ -881,120 +834,64 @@ describe('Change Base Currency', () => {
       expect(accountBalances.length).toBeGreaterThan(0);
     });
 
-    it('should prevent concurrent base currency change requests using Redis lock', async () => {
+    it('should prevent concurrent base currency change requests using the enqueue lock', async () => {
       // Add USD currency to change to
       await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
 
-      // Start first request and immediately start second before first completes
-      // We'll use Promise.race to detect which one fails
+      // Fire two enqueues concurrently: the NX lock lets exactly one through (202),
+      // the other loses the race and is rejected as locked (423).
       const requests = await Promise.allSettled([
-        helpers.makeRequest({
-          method: 'post',
-          url: '/user/currencies/change-base',
-          payload: { newCurrencyCode: 'USD' },
-        }),
-        helpers.makeRequest({
-          method: 'post',
-          url: '/user/currencies/change-base',
-          payload: { newCurrencyCode: 'USD' },
-        }),
+        helpers.changeBaseCurrency({ newCurrencyCode: 'USD' }),
+        helpers.changeBaseCurrency({ newCurrencyCode: 'USD' }),
       ]);
 
-      // One should succeed (200) and one should be locked (423)
       const statuses = requests.map((r) => (r.status === 'fulfilled' ? r.value.statusCode : null));
 
-      // Should have one success and one locked error
-      expect(statuses).toContain(200);
+      expect(statuses).toContain(202);
       expect(statuses).toContain(ERROR_CODES.Locked);
+
+      // Let the winning job finish (poll — don't re-enqueue) so it doesn't run
+      // against the next test's truncated DB.
+      await helpers.waitForBaseCurrencyChangeSettled();
     });
 
     it('should automatically release lock after successful operation', async () => {
       // Add USD currency to change to
       await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
 
-      // First request should succeed
-      const firstResponse = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'USD',
-        },
-      });
+      // First change succeeds and releases the lock on completion.
+      const first = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+      helpers.expectBaseCurrencyChangeCompleted(first);
 
-      expect(firstResponse.statusCode).toEqual(200);
-
-      // Second request to change back should also succeed (lock was released)
-      const secondResponse = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'GBP',
-        },
-      });
-
-      expect(secondResponse.statusCode).toEqual(200);
+      // Second change back also succeeds — the lock was released, so the enqueue
+      // isn't rejected as locked.
+      const second = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'GBP' });
+      helpers.expectBaseCurrencyChangeCompleted(second);
     });
 
-    it('should release lock even if operation fails', async () => {
+    it('rejects a trivially-invalid change before taking the lock, leaving later changes unblocked', async () => {
       // Get current base currency
       const baseCurrency = (await helpers.getUserCurrencies()).find((i) => i.isDefaultCurrency)!;
 
-      // Try to change to the same currency (will fail with ValidationError)
-      const response = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: baseCurrency.currencyCode,
-        },
-      });
-
-      // Should fail with validation error
+      // Same-currency is rejected synchronously at enqueue, before the lock is taken.
+      const response = await helpers.changeBaseCurrency({ newCurrencyCode: baseCurrency.currencyCode });
       expect(response.statusCode).toEqual(ERROR_CODES.ValidationError);
 
-      // Subsequent request should work (lock was released)
+      // A subsequent valid change still works (no lock was ever held).
       await helpers.addUserCurrencies({ currencyCodes: ['EUR'], raw: true });
-      const retryResponse = await helpers.makeRequest({
-        method: 'post',
-        url: '/user/currencies/change-base',
-        payload: {
-          newCurrencyCode: 'EUR',
-        },
-      });
-
-      expect(retryResponse.statusCode).toEqual(200);
+      const retry = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'EUR' });
+      helpers.expectBaseCurrencyChangeCompleted(retry);
     });
 
-    // TODO: find a way how to test it. It's in fact applies the lock, yet it's difficult to catch it in the test
-    it.skip('should block creating accounts/transactions/investments during base currency change', async () => {
-      // Add EUR currency to test with
-      await helpers.addUserCurrencies({ currencyCodes: ['EUR'], raw: true });
-
-      // Create some test data first to make the operation take longer
-      const account = await helpers.createAccount({
-        payload: {
-          name: 'Test Account',
-          currencyCode: 'GBP',
-          initialBalance: 10000,
-          creditLimit: 0,
-          accountCategory: ACCOUNT_CATEGORIES.general,
-        },
-        raw: true,
-      });
-
-      // Get userId from the account to build lock key
-      const userId = account.userId;
+    // Deterministic version of the 423 window: SET the lock key directly instead of
+    // racing the real change-base job, which commits too fast to observe mid-flight.
+    it('blocks a guarded mutating route while the base-currency lock is held', async () => {
+      const userId = (await helpers.getUserCurrencies())[0]!.userId;
       const lockKey = buildLockKey(userId);
 
-      // Start the base currency change but don't await it
-      const [changeCurrencyResponse, createAccountResponse] = await Promise.all([
-        helpers.makeRequest({
-          method: 'post',
-          url: '/user/currencies/change-base',
-          payload: {
-            newCurrencyCode: 'EUR',
-          },
-        }),
-        helpers.makeRequest({
+      await redisClient.set(lockKey, 'test-lock');
+      try {
+        const createAccountResponse = await helpers.makeRequest({
           method: 'post',
           url: '/accounts',
           payload: {
@@ -1004,21 +901,15 @@ describe('Change Base Currency', () => {
             creditLimit: 0,
             accountCategory: ACCOUNT_CATEGORIES.general,
           },
-        }),
-      ]);
+        });
 
-      // Should be blocked with the specific error code
-      expect(createAccountResponse.statusCode).toEqual(ERROR_CODES.Locked);
-      expect(createAccountResponse.body.response.code).toEqual('BASE_CURRENCY_CHANGE_IN_PROGRESS');
+        expect(createAccountResponse.statusCode).toEqual(ERROR_CODES.Locked);
+        expect(createAccountResponse.body.response.code).toEqual('BASE_CURRENCY_CHANGE_IN_PROGRESS');
+      } finally {
+        await redisClient.del(lockKey);
+      }
 
-      // Wait for currency change to complete
-      expect(changeCurrencyResponse.statusCode).toEqual(200);
-
-      // Verify lock was released
-      const lockAfter = await redisClient.get(lockKey);
-      expect(lockAfter).toBeNull();
-
-      // Now creating an account should work
+      // Lock cleared → the same request now succeeds.
       const createAccountRetryResponse = await helpers.makeRequest({
         method: 'post',
         url: '/accounts',

--- a/packages/backend/src/services/currencies/change-base-currency.service.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.service.ts
@@ -3,6 +3,8 @@ import {
   ACCOUNT_TYPES,
   API_ERROR_CODES,
   type BaseCurrencyBlocker,
+  type BaseCurrencyChangeStep,
+  type RecalculateResult,
   RESOURCE_TYPES,
 } from '@bt/shared/types';
 import { Money } from '@common/types/money';
@@ -10,6 +12,7 @@ import { t } from '@i18n/index';
 import { ConflictError, ValidationError } from '@js/errors';
 import { CacheClient } from '@js/utils/cache';
 import { logger } from '@js/utils/logger';
+import { captureException } from '@js/utils/sentry';
 import Accounts from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import Holdings from '@models/investments/holdings.model';
@@ -22,7 +25,6 @@ import ResourceShares from '@models/resource-shares.model';
 import Transactions from '@models/transactions.model';
 import { getBaseCurrency, updateCurrencies } from '@models/users-currencies.model';
 import { calculateRefAmountFromParams } from '@services/calculate-ref-amount.service';
-import { withLock } from '@services/common/lock';
 import * as userExchangeRateService from '@services/user-exchange-rate';
 import { Op, QueryTypes, Transaction as SequelizeTransaction } from 'sequelize';
 
@@ -88,36 +90,29 @@ interface ChangeBaseCurrencyParams {
   newCurrencyCode: string;
 }
 
-interface RecalculateResult {
-  transactionsUpdated: number;
-  accountsUpdated: number;
-  loanDetailsUpdated: number;
-  balancesRebuilt: number;
-  investmentTransactionsUpdated: number;
-  portfolioTransfersUpdated: number;
-  holdingsUpdated: number;
-  portfolioBalancesUpdated: number;
-}
+/** Called before each table sweep so the worker can persist the step on the job
+ *  and fan it out over SSE. Awaited so a slow progress write can't let the next
+ *  step start reporting before the current one is recorded. */
+type BaseCurrencyChangeProgress = (params: { step: BaseCurrencyChangeStep }) => void | Promise<void>;
 
 /**
- * Internal implementation of changeBaseCurrency.
- * This is wrapped by the exported function with a distributed lock.
+ * Transaction-free pre-checks that gate a base-currency change: no active
+ * share/household (both ends of a share must agree on one base currency, or the
+ * recipient's aggregated stats silently mix `refAmount`s under different
+ * ref-currency assumptions), a base currency already exists, and the target
+ * differs from the current base.
+ *
+ * Runs at enqueue time — before the lock is taken, so a trivial rejection never
+ * holds the 4h lock — and again inside the job, since shares may have changed
+ * between enqueue and pickup. Returns the current base so callers skip re-querying.
  */
-async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise<RecalculateResult> {
-  const { userId, newCurrencyCode } = params;
-
-  // Refuse the change while the user has any active share — both ends of an
-  // accepted share must agree on a base currency, otherwise the recipient's
-  // aggregated stats mix the owner's `refAmount` with their own under different
-  // ref-currency assumptions and the totals diverge silently. Pending invitations
-  // don't lock; they're handled by the accept-time currency-match check, which
-  // surfaces a clean error instead.
-  //
+export async function validateBaseCurrencyChange({ userId, newCurrencyCode }: ChangeBaseCurrencyParams) {
   // Two parallel counts so the response can tell the user precisely which kind
   // of relationship is blocking — household memberships are user-scoped (one
   // revoke covers many accounts), per-resource shares are resource-scoped (each
   // must be revoked individually). The frontend renders multi-step guidance off
-  // the `blockers` array.
+  // the `blockers` array. Pending invitations don't lock; they're handled by the
+  // accept-time currency-match check, which surfaces a clean error instead.
   const [householdBlockingCount, perResourceBlockingCount] = await Promise.all([
     ResourceShares.count({
       where: {
@@ -157,7 +152,6 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
     });
   }
 
-  // Get current base currency
   const oldBaseCurrency = await getBaseCurrency({ userId });
 
   if (!oldBaseCurrency) {
@@ -172,38 +166,60 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
     });
   }
 
+  return { oldBaseCurrency };
+}
+
+/**
+ * Rewrites every `ref*` amount the user owns into the new base currency inside one
+ * atomic DB transaction, flips the `UsersCurrencies` default, and clears the
+ * `ref_amount:{userId}:*` cache. Re-runs {@link validateBaseCurrencyChange} first
+ * (in-job re-check), then sweeps the eight tables in order, invoking `onProgress`
+ * before each so the running job reports its current step.
+ *
+ * Runs in the base-currency-change worker with the lock already held — it does NOT
+ * acquire one itself. Progress reporting is best-effort and must never throw here,
+ * or a Redis hiccup would roll back the whole recalculation.
+ */
+export async function changeBaseCurrencyImpl({
+  userId,
+  newCurrencyCode,
+  onProgress,
+}: ChangeBaseCurrencyParams & { onProgress?: BaseCurrencyChangeProgress }): Promise<RecalculateResult> {
+  const { oldBaseCurrency } = await validateBaseCurrencyChange({ userId, newCurrencyCode });
+
   // Start database transaction for atomicity
   const result = await Transactions.sequelize!.transaction(async (dbTransaction: SequelizeTransaction) => {
     logger.info(
       `Starting base currency change for user ${userId} from ${oldBaseCurrency.currencyCode} to ${newCurrencyCode}`,
     );
 
-    // Step 1: Recalculate all transactions
+    await onProgress?.({ step: 'transactions' });
     const transactionsUpdated = await rebuildTransactions({
       userId,
       newCurrencyCode,
       transaction: dbTransaction,
     });
 
-    // Step 2: Recalculate all accounts
+    await onProgress?.({ step: 'accounts' });
     const accountsUpdated = await recalculateAccounts({
       userId,
       newCurrencyCode,
       transaction: dbTransaction,
     });
 
-    // Step 2b: Recalculate loan-detail ref amounts. The loan's Account row is
-    // handled by recalculateAccounts above, but LoanDetails carries its own
-    // ref* copies (refOriginalPrincipal, refMinPayment, refPlannedPayment) that
-    // the list-page aggregates read in base currency — recompute them here so a
-    // base switch doesn't leave the monthly-obligation total in the old base.
+    // The loan's Account row is handled by recalculateAccounts above, but
+    // LoanDetails carries its own ref* copies (refOriginalPrincipal, refMinPayment,
+    // refPlannedPayment) that the list-page aggregates read in base currency —
+    // recompute them here so a base switch doesn't leave the monthly-obligation
+    // total in the old base.
+    await onProgress?.({ step: 'loanDetails' });
     const loanDetailsUpdated = await recalculateLoanDetails({
       userId,
       newCurrencyCode,
       transaction: dbTransaction,
     });
 
-    // Step 3: Rebuild balance history
+    await onProgress?.({ step: 'balances' });
     const balancesRebuilt = await rebuildBalances({
       userId,
       oldCurrencyCode: oldBaseCurrency.currencyCode,
@@ -211,9 +227,9 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
       transaction: dbTransaction,
     });
 
-    // Pre-fetch portfolios once for steps 4, 6, 7. Include soft-deleted ones
-    // (paranoid:false) so refAmounts stay consistent if the user later
-    // restores a portfolio that was in the trash during a base-currency switch.
+    // Pre-fetch portfolios once for the investment steps. Include soft-deleted ones
+    // (paranoid:false) so refAmounts stay consistent if the user later restores a
+    // portfolio that was in the trash during a base-currency switch.
     const portfolios = await Portfolios.findAll({
       where: { userId },
       paranoid: false,
@@ -221,7 +237,7 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
     });
     const portfolioIds = portfolios.map((p) => p.id);
 
-    // Step 4: Recalculate investment transactions
+    await onProgress?.({ step: 'investmentTransactions' });
     const investmentTransactionsUpdated = await recalculateInvestmentTransactions({
       userId,
       newCurrencyCode,
@@ -229,14 +245,14 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
       transaction: dbTransaction,
     });
 
-    // Step 5: Recalculate portfolio transfers
+    await onProgress?.({ step: 'portfolioTransfers' });
     const portfolioTransfersUpdated = await recalculatePortfolioTransfers({
       userId,
       newCurrencyCode,
       transaction: dbTransaction,
     });
 
-    // Step 6: Recalculate holdings
+    await onProgress?.({ step: 'holdings' });
     const holdingsUpdated = await recalculateHoldings({
       userId,
       newCurrencyCode,
@@ -244,7 +260,7 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
       transaction: dbTransaction,
     });
 
-    // Step 7: Recalculate portfolio balances
+    await onProgress?.({ step: 'portfolioBalances' });
     const portfolioBalancesUpdated = await recalculatePortfolioBalances({
       userId,
       newCurrencyCode,
@@ -252,7 +268,7 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
       transaction: dbTransaction,
     });
 
-    // Step 8: Update the base currency flag
+    // Flip the base currency flag onto the new currency.
     await updateCurrencies({
       userId,
       isDefaultCurrency: false,
@@ -264,7 +280,7 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
       isDefaultCurrency: true,
     });
 
-    // Step 9: Clear Redis cache for this user
+    // Cached ref_amount values were computed against the OLD base — drop them.
     await clearUserCache(userId);
 
     logger.info(`Base currency change completed for user ${userId}`);
@@ -283,25 +299,6 @@ async function changeBaseCurrencyImpl(params: ChangeBaseCurrencyParams): Promise
 
   return result;
 }
-
-export const buildLockKey = (userId: number) => `change-base-currency:user:${userId}`;
-
-/**
- * Changes the user's base currency and recalculates all ref- amounts using historical exchange rates.
- * This operation is atomic - either all changes succeed or all are rolled back.
- *
- * Protected by a distributed Redis lock to prevent concurrent executions for the same user.
- * The lock has a TTL of 4 hour to handle long-running operations.
- *
- * @param params - Object containing userId and newCurrencyCode
- * @returns Promise<RecalculateResult> - Statistics about the recalculation
- * @throws ValidationError if the currency is already the base currency
- * @throws LockedError if another base currency change operation is already in progress for this user
- */
-export const changeBaseCurrency = (params: ChangeBaseCurrencyParams): Promise<RecalculateResult> => {
-  const lockedFn = withLock(buildLockKey(params.userId), changeBaseCurrencyImpl, { ttl: 60 * 60 * 4 }); // 4 hour TTL
-  return lockedFn(params);
-};
 
 const localCalculateRefAmount = async ({
   amount,
@@ -786,7 +783,10 @@ async function clearUserCache(userId: number): Promise<void> {
 
     logger.info(`Successfully cleared ref_amount cache for user ${userId}`);
   } catch (error) {
+    // Stale ref_amount cache after a base change silently serves old-base values
+    // until each key's TTL. Never throws (the recalc already committed), but the
+    // failure must be visible, so it goes to Sentry as well as the logs.
     logger.error({ message: `Error clearing cache for user ${userId}`, error: error as Error });
-    // Don't throw - cache clearing failure shouldn't break the main operation
+    captureException({ error, context: { scope: 'change-base-currency:clearUserCache', userId } });
   }
 }

--- a/packages/backend/src/services/currencies/change-base-currency.shared-boundary.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.shared-boundary.e2e.ts
@@ -107,12 +107,8 @@ describe('Change base currency — shared-account ledger boundary is author-blin
     });
 
     // Owner switches base AED → USD.
-    const changeRes = await helpers.makeRequest({
-      method: 'post',
-      url: '/user/currencies/change-base',
-      payload: { newCurrencyCode: 'USD' },
-    });
-    expect(changeRes.statusCode).toBe(200);
+    const changeStatus = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+    helpers.expectBaseCurrencyChangeCompleted(changeStatus);
 
     // refInitialBalance = opening 200 EUR × EUR→USD at the recipient tx's boundary
     // date (2.0) = 400 USD. The boundary is account-scoped (not author-scoped),

--- a/packages/backend/src/services/currencies/change-base-currency.shares.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.shares.e2e.ts
@@ -19,12 +19,10 @@ describe('Change Base Currency — active share guard', () => {
     await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
   });
 
-  const callChangeBase = () =>
-    helpers.makeRequest({
-      method: 'post',
-      url: '/user/currencies/change-base',
-      payload: { newCurrencyCode: 'USD' },
-    });
+  // Share-blocker rejections still surface synchronously at enqueue, so these tests
+  // read the immediate response. The "allows" cases enqueue a real job and poll it
+  // to completion via changeBaseCurrencyAndWait instead.
+  const callChangeBase = () => helpers.changeBaseCurrency({ newCurrencyCode: 'USD' });
 
   it('rejects the change when the caller is the owner of an accepted share', async () => {
     const account = await helpers.createAccount({ raw: true });
@@ -47,7 +45,7 @@ describe('Change Base Currency — active share guard', () => {
     const res = await callChangeBase();
 
     expect(res.statusCode).toBe(409);
-    const err = res.body.response as ErrorResponse;
+    const err = res.body.response as unknown as ErrorResponse;
     expect(err.code).toBe(API_ERROR_CODES.baseCurrencyLockedByShares);
   });
 
@@ -80,7 +78,7 @@ describe('Change Base Currency — active share guard', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    const err = res.body.response as ErrorResponse;
+    const err = res.body.response as unknown as ErrorResponse;
     expect(err.code).toBe(API_ERROR_CODES.baseCurrencyLockedByShares);
   });
 
@@ -96,15 +94,13 @@ describe('Change Base Currency — active share guard', () => {
       raw: true,
     });
 
-    const res = await callChangeBase();
-
-    expect(res.statusCode).toBe(200);
+    const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+    helpers.expectBaseCurrencyChangeCompleted(status);
   });
 
   it('allows the change when the user has no shares at all', async () => {
-    const res = await callChangeBase();
-
-    expect(res.statusCode).toBe(200);
+    const status = await helpers.changeBaseCurrencyAndWait({ newCurrencyCode: 'USD' });
+    helpers.expectBaseCurrencyChangeCompleted(status);
   });
 
   it('rejects with BASE_CURRENCY_LOCKED_BY_HOUSEHOLD when an active household membership blocks', async () => {
@@ -127,7 +123,7 @@ describe('Change Base Currency — active share guard', () => {
     const res = await callChangeBase();
 
     expect(res.statusCode).toBe(409);
-    const err = res.body.response as ErrorResponse & {
+    const err = res.body.response as unknown as ErrorResponse & {
       details?: { blockers?: Array<{ type: string; count: number }> };
     };
     expect(err.code).toBe(API_ERROR_CODES.baseCurrencyLockedByHousehold);
@@ -167,7 +163,7 @@ describe('Change Base Currency — active share guard', () => {
     const res = await callChangeBase();
 
     expect(res.statusCode).toBe(409);
-    const err = res.body.response as ErrorResponse & {
+    const err = res.body.response as unknown as ErrorResponse & {
       details?: { blockers?: Array<{ type: string; count: number }> };
     };
     // Household takes the primary code when both are present.
@@ -208,7 +204,7 @@ describe('Change Base Currency — active share guard', () => {
     });
 
     expect(res.statusCode).toBe(409);
-    const err = res.body.response as ErrorResponse & {
+    const err = res.body.response as unknown as ErrorResponse & {
       details?: { blockers?: Array<{ type: string; count: number }> };
     };
     expect(err.code).toBe(API_ERROR_CODES.baseCurrencyLockedByHousehold);

--- a/packages/backend/src/services/currencies/change-base-currency.vehicles.e2e.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.vehicles.e2e.ts
@@ -1,15 +1,10 @@
-import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES, API_RESPONSE_STATUS, VEHICLE_CLASS } from '@bt/shared/types';
+import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES, VEHICLE_CLASS } from '@bt/shared/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import Accounts from '@models/accounts.model';
 import * as helpers from '@tests/helpers';
 import { format, subYears } from 'date-fns';
 
-const changeBaseTo = (newCurrencyCode: string) =>
-  helpers.makeRequest({
-    method: 'post',
-    url: '/user/currencies/change-base',
-    payload: { newCurrencyCode },
-  });
+const changeBaseTo = (newCurrencyCode: string) => helpers.changeBaseCurrencyAndWait({ newCurrencyCode });
 
 const pastDate = ({ yearsAgo }: { yearsAgo: number }) => format(subYears(new Date(), yearsAgo), 'yyyy-MM-dd');
 
@@ -48,9 +43,8 @@ describe('Change Base Currency — vehicles', () => {
     const currentBefore = accountBefore!.currentBalance.toNumber();
     const refCurrentBefore = accountBefore!.refCurrentBalance.toNumber();
 
-    const response = await changeBaseTo('USD');
-    expect(response.statusCode).toEqual(200);
-    expect(response.body.status).toEqual(API_RESPONSE_STATUS.success);
+    const status = await changeBaseTo('USD');
+    helpers.expectBaseCurrencyChangeCompleted(status);
 
     const accountAfter = await Accounts.findByPk(vehicle.accountId);
     // Currency untouched; still a vehicle system account.
@@ -89,8 +83,8 @@ describe('Change Base Currency — vehicles', () => {
     expect(currentBefore).toBeLessThan(initialBefore);
     expect(accountBefore!.refCurrentBalance.toNumber()).toBeLessThan(accountBefore!.refInitialBalance.toNumber());
 
-    const response = await changeBaseTo('USD');
-    expect(response.statusCode).toEqual(200);
+    const status = await changeBaseTo('USD');
+    helpers.expectBaseCurrencyChangeCompleted(status);
 
     const accountAfter = await Accounts.findByPk(vehicle.accountId);
 

--- a/packages/backend/src/services/import-export/core/queue/create-import-job-queue.ts
+++ b/packages/backend/src/services/import-export/core/queue/create-import-job-queue.ts
@@ -1,7 +1,9 @@
 import { SSEEventPayload, SSEEventType } from '@bt/shared/types';
+import { t } from '@i18n/index';
 import { logger } from '@js/utils/logger';
 import { SentryTraceData, withQueueProcessSpan, withQueuePublishSpan } from '@js/utils/sentry';
 import { sseManager } from '@services/common/sse';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import { Job, Queue, Worker } from 'bullmq';
 
 /**
@@ -219,6 +221,16 @@ export function createImportJobQueue<
         job,
         fn: async () => {
           const { userId } = job.data;
+
+          // A base-currency recalculation holds this user's lock: it drains
+          // in-flight writers before snapshotting rows, so an import committing
+          // transactions now would land amounts against the wrong base. Fail the
+          // job (attempts: 1, no retry) with a message the import UI surfaces. The
+          // enqueue route is already lock-guarded; this only catches jobs queued
+          // in the brief window before the lock landed.
+          if (await isBaseCurrencyChangeLocked({ userId })) {
+            throw new Error(t({ key: 'currencies.baseCurrencyChangeInProgress' }));
+          }
 
           sendProgress({
             userId,

--- a/packages/backend/src/services/sharing/invitations/accept-invitation.service.ts
+++ b/packages/backend/src/services/sharing/invitations/accept-invitation.service.ts
@@ -14,6 +14,7 @@ import ShareInvitations from '@models/share-invitations.model';
 import { getBaseCurrency } from '@models/users-currencies.model';
 import Users from '@models/users.model';
 import { withTransaction } from '@services/common/with-transaction';
+import { assertUsersNotBaseCurrencyLocked } from '@services/currencies/base-currency-lock';
 import { Op, QueryTypes } from 'sequelize';
 
 import { resolveResourceName } from '../auth/can-user-access-resource.service';
@@ -93,6 +94,12 @@ const acceptImpl = async ({ token, userId }: { token: string; userId: number }):
     // because the surrounding transaction rolls back when we throw.
     throw new ConflictError({ message: 'This invitation has expired.' });
   }
+
+  // Refuse while either the acceptor or the resource owner is mid base-currency
+  // migration. The route guard only inspects the acceptor's lock, so the owner's is
+  // checked here too — accepting during their migration recreates exactly the
+  // shared-account/mixed-base state `changeBaseCurrencyImpl`'s share validation forbids.
+  await assertUsersNotBaseCurrencyLocked({ requesterUserId: userId, otherUserIds: [invitation.ownerUserId] });
 
   const resourceName = await resolveResourceName({
     resourceType: invitation.resourceType,

--- a/packages/backend/src/services/sharing/invitations/back-invite-from-invitation.service.ts
+++ b/packages/backend/src/services/sharing/invitations/back-invite-from-invitation.service.ts
@@ -5,6 +5,7 @@ import { connection } from '@models/index';
 import ResourceShares from '@models/resource-shares.model';
 import ShareInvitations from '@models/share-invitations.model';
 import { withTransaction } from '@services/common/with-transaction';
+import { assertUsersNotBaseCurrencyLocked } from '@services/currencies/base-currency-lock';
 import { Op, QueryTypes } from 'sequelize';
 
 import { getEmailForUser } from '../find-user-by-email.service';
@@ -76,6 +77,12 @@ const backInviteFromInvitationImpl = async ({
   if (!acceptedMembership) {
     throw new NotFoundError({ message: 'Invitation not found' });
   }
+
+  // Refuse while either the caller or the inviter is mid base-currency migration. Sharing
+  // a household back during a migration recreates the shared-account/mixed-base state
+  // `changeBaseCurrencyImpl`'s share validation forbids. The route guard only inspects the
+  // caller's lock, so the inviter's is checked here too.
+  await assertUsersNotBaseCurrencyLocked({ requesterUserId: callerUserId, otherUserIds: [inviterUserId] });
 
   // Reject early when the reciprocal share already exists. createInvitation's duplicate
   // check fires at accept time, not at create time, so without this guard a redundant

--- a/packages/backend/src/services/subscriptions/process-auto-record.ts
+++ b/packages/backend/src/services/subscriptions/process-auto-record.ts
@@ -2,6 +2,7 @@ import { SUBSCRIPTION_PERIOD_STATUSES } from '@bt/shared/types';
 import { logger } from '@js/utils/logger';
 import SubscriptionPeriods from '@models/subscription-periods.model';
 import Subscriptions from '@models/subscriptions.model';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import { Op } from 'sequelize';
 
 import { markPeriodPaid } from './mark-period-paid';
@@ -59,7 +60,20 @@ export async function processAutoRecordPeriods(): Promise<ProcessResult> {
   let booked = 0;
   let failed = 0;
 
+  // A user mid base-currency migration has their ref* amounts owned by the
+  // recalc; booking a period would compute refAmount against the wrong base.
+  // Skip that user's subscriptions this tick — the hourly cron retries once the
+  // lock clears. Cached per user so one Redis GET covers all their subscriptions.
+  const lockedUserCache = new Map<number, boolean>();
+
   for (const subscription of subscriptions) {
+    let userLocked = lockedUserCache.get(subscription.userId);
+    if (userLocked === undefined) {
+      userLocked = await isBaseCurrencyChangeLocked({ userId: subscription.userId });
+      lockedUserCache.set(subscription.userId, userLocked);
+    }
+    if (userLocked) continue;
+
     for (const period of subscription.periods) {
       try {
         await markPeriodPaid({

--- a/packages/backend/src/services/subscriptions/subscription-auto-record.e2e.ts
+++ b/packages/backend/src/services/subscriptions/subscription-auto-record.e2e.ts
@@ -2,6 +2,8 @@ import { SUBSCRIPTION_FREQUENCIES, SUBSCRIPTION_PERIOD_STATUSES, SUBSCRIPTION_TY
 import { describe, expect, it } from '@jest/globals';
 import SubscriptionPeriods from '@models/subscription-periods.model';
 import Subscriptions from '@models/subscriptions.model';
+import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
 import * as helpers from '@tests/helpers';
 import { addDays, format, subDays } from 'date-fns';
 
@@ -225,6 +227,27 @@ describe('Subscription auto-record cron', () => {
       const result = await processAutoRecordPeriods();
       expect(result.booked).toBe(2);
       expect(result.failed).toBe(0);
+    });
+  });
+
+  describe('base-currency lock', () => {
+    it('skips a locked user this tick, then books once the lock clears', async () => {
+      const { id: userId } = await helpers.getUserInfo({ raw: true });
+      const account = await helpers.createAccount({ raw: true });
+      await createAutoRecordSubscription({ name: 'Locked user', accountId: account.id });
+
+      await redisClient.set(buildLockKey(userId), 'test-lock');
+      try {
+        const locked = await processAutoRecordPeriods();
+        expect(locked.booked).toBe(0);
+        expect(await countTransactionsForAccount({ accountId: account.id })).toBe(0);
+      } finally {
+        await redisClient.del(buildLockKey(userId));
+      }
+
+      const unlocked = await processAutoRecordPeriods();
+      expect(unlocked.booked).toBe(1);
+      expect(await countTransactionsForAccount({ accountId: account.id })).toBe(1);
     });
   });
 

--- a/packages/backend/src/services/vehicles/refresh-vehicle-value-lock.e2e.ts
+++ b/packages/backend/src/services/vehicles/refresh-vehicle-value-lock.e2e.ts
@@ -1,0 +1,46 @@
+import { VEHICLE_CLASS } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import { redisClient } from '@root/redis-client';
+import { buildLockKey } from '@services/currencies/base-currency-lock';
+import * as helpers from '@tests/helpers';
+import { format, subYears } from 'date-fns';
+
+// GET /vehicles/:id force-refreshes the depreciated value on every read and
+// stamps `valueLastComputedAt`. The base-currency lock must suppress that
+// refresh (the recalc owns the ref* amounts), so the stored value — and its
+// `valueLastComputedAt` — stay frozen until the lock clears.
+describe('Vehicle lazy refresh — base-currency lock', () => {
+  it('skips the force-refresh while the lock is held, then refreshes once it clears', async () => {
+    const vehicle = await helpers.createVehicle({
+      name: 'Toyota Camry 2020',
+      currencyCode: 'USD',
+      make: 'Toyota',
+      model: 'Camry',
+      year: 2020,
+      vehicleClass: VEHICLE_CLASS.sedan,
+      purchasePrice: 25000,
+      purchaseDate: format(subYears(new Date(), 3), 'yyyy-MM-dd'),
+      raw: true,
+    });
+
+    const computedAtOnCreate = vehicle.valueLastComputedAt;
+    expect(computedAtOnCreate).toBeTruthy();
+
+    const lockKey = buildLockKey(vehicle.userId);
+    await redisClient.set(lockKey, 'test-lock');
+
+    // Locked: the detail read must NOT recompute, so `valueLastComputedAt` stays
+    // exactly at creation time (a refresh would have advanced it).
+    const whileLocked = await helpers.getVehicleById({ id: vehicle.id, raw: true });
+    expect(whileLocked.valueLastComputedAt).toBe(computedAtOnCreate);
+
+    await redisClient.del(lockKey);
+
+    // Unlocked: the force-refresh runs again and advances `valueLastComputedAt`.
+    const afterUnlock = await helpers.getVehicleById({ id: vehicle.id, raw: true });
+    expect(afterUnlock.valueLastComputedAt).not.toBe(computedAtOnCreate);
+    expect(new Date(afterUnlock.valueLastComputedAt!).getTime()).toBeGreaterThan(
+      new Date(computedAtOnCreate!).getTime(),
+    );
+  });
+});

--- a/packages/backend/src/services/vehicles/refresh-vehicle-value.service.ts
+++ b/packages/backend/src/services/vehicles/refresh-vehicle-value.service.ts
@@ -6,6 +6,7 @@ import Balances from '@models/balances.model';
 import Vehicles from '@models/vehicles.model';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { withTransaction } from '@services/common/with-transaction';
+import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import { parseISO } from 'date-fns';
 
 import { computeVehicleValue } from './compute-vehicle-value';
@@ -46,6 +47,19 @@ const refreshVehicleValueIfStaleImpl = async ({
 
   const account = vehicle.account;
   const now = asOf ?? new Date();
+
+  // While a base-currency recalculation holds the user's lock it is rewriting
+  // every ref* amount; recomputing and persisting a fresh refValue here (this
+  // fires from GET /vehicles/:id and GET /accounts, including the force-refresh
+  // detail read) would race that migration. Serve the stored value untouched,
+  // exactly like a cache hit — the next lazy read after the lock clears refreshes.
+  if (await isBaseCurrencyChangeLocked({ userId: vehicle.userId })) {
+    return {
+      value: account.currentBalance,
+      refValue: account.refCurrentBalance,
+      refreshed: false,
+    };
+  }
 
   const cacheValid =
     !force &&
@@ -120,6 +134,13 @@ export const refreshStaleVehicleValuesForUser = async ({
   force = false,
   asOf,
 }: RefreshBulkParams): Promise<{ refreshedCount: number }> => {
+  // Skip the whole bulk refresh while a base-currency recalculation holds the
+  // user's lock; the accounts list serves the stored values and the next read
+  // after the lock clears refreshes them.
+  if (await isBaseCurrencyChangeLocked({ userId })) {
+    return { refreshedCount: 0 };
+  }
+
   const vehicles = await Vehicles.findAll({
     where: { userId },
     attributes: ['id', 'valueLastComputedAt'],

--- a/packages/backend/src/tests/helpers/currencies.ts
+++ b/packages/backend/src/tests/helpers/currencies.ts
@@ -1,3 +1,4 @@
+import type { BaseCurrencyChangeStatus } from '@bt/shared/types';
 import Currencies from '@models/currencies.model';
 import ExchangeRates from '@models/exchange-rates.model';
 import { UpdateExchangeRatePair } from '@models/user-exchange-rates.model';
@@ -134,4 +135,102 @@ export async function updateUserCurrency<R extends boolean | undefined = undefin
     payload: { ...currency },
     raw,
   });
+}
+
+/**
+ * POST /user/currencies/change-base. Enqueues the recalculation and resolves to
+ * `{ jobId, state: 'queued' }` (HTTP 202). Share-blocker / same-currency rejections
+ * still surface synchronously. Poll the result via {@link changeBaseCurrencyAndWait}.
+ */
+export function changeBaseCurrency<R extends boolean | undefined = undefined>({
+  newCurrencyCode,
+  raw,
+}: {
+  newCurrencyCode: string;
+  raw?: R;
+}) {
+  return makeRequest<{ jobId: string; state: 'queued' }, R>({
+    method: 'post',
+    url: '/user/currencies/change-base',
+    payload: { newCurrencyCode },
+    raw,
+  });
+}
+
+export function getBaseCurrencyChangeStatus<R extends boolean | undefined = undefined>({ raw }: { raw?: R } = {}) {
+  return makeRequest<BaseCurrencyChangeStatus, R>({
+    method: 'get',
+    url: '/user/currencies/change-base/status',
+    raw,
+  });
+}
+
+/**
+ * Enqueue a base-currency change and poll the status endpoint every 100ms until it
+ * settles. The recalculation runs in a BullMQ worker, so the POST only returns
+ * `{ jobId }` — callers must poll for the terminal state. Mirrors
+ * `waitForCsvImportCompletion`.
+ */
+export async function changeBaseCurrencyAndWait({
+  newCurrencyCode,
+  timeoutMs = 30_000,
+}: {
+  newCurrencyCode: string;
+  timeoutMs?: number;
+}): Promise<BaseCurrencyChangeStatus> {
+  const enqueueRes = await changeBaseCurrency({ newCurrencyCode });
+  if (enqueueRes.statusCode !== 202) {
+    throw new Error(
+      `Expected 202 from change-base enqueue, got ${enqueueRes.statusCode}: ${JSON.stringify(enqueueRes.body)}`,
+    );
+  }
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = await getBaseCurrencyChangeStatus({ raw: true });
+    if (status.state === 'completed' || status.state === 'failed') {
+      return status;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Base-currency change did not finish within ${timeoutMs}ms`);
+}
+
+/**
+ * Poll the status endpoint (without enqueueing) until the change settles to a
+ * terminal state (`completed`, `failed`, or `idle`). Used to drain a job that was
+ * enqueued out-of-band so it doesn't run against the next test's truncated DB.
+ */
+export async function waitForBaseCurrencyChangeSettled({
+  timeoutMs = 30_000,
+}: { timeoutMs?: number } = {}): Promise<BaseCurrencyChangeStatus> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const status = await getBaseCurrencyChangeStatus({ raw: true });
+    if (status.state === 'completed' || status.state === 'failed' || status.state === 'idle') {
+      return status;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Base-currency change did not settle within ${timeoutMs}ms`);
+}
+
+/** Narrow a terminal status to `completed` so tests can read `result` directly.
+ *  Throws (failing the calling test) when the worker finished with `failed`. */
+export function expectBaseCurrencyChangeCompleted(
+  status: BaseCurrencyChangeStatus,
+): asserts status is Extract<BaseCurrencyChangeStatus, { state: 'completed' }> {
+  if (status.state !== 'completed') {
+    const detail = status.state === 'failed' ? ` Error: ${status.error}` : '';
+    throw new Error(`Expected completed base-currency change, got state="${status.state}".${detail}`);
+  }
+}
+
+/** Narrow a terminal status to `failed` so tests can read `error` directly. */
+export function expectBaseCurrencyChangeFailed(
+  status: BaseCurrencyChangeStatus,
+): asserts status is Extract<BaseCurrencyChangeStatus, { state: 'failed' }> {
+  if (status.state !== 'failed') {
+    throw new Error(`Expected failed base-currency change, got state="${status.state}".`);
+  }
 }

--- a/packages/backend/src/tests/setupIntegrationTests.ts
+++ b/packages/backend/src/tests/setupIntegrationTests.ts
@@ -13,6 +13,7 @@ import { categorizationQueue, categorizationWorker } from '@services/ai-categori
 import { flushAllPendingCategorizationBuffers } from '@services/ai-categorization/event-listeners';
 import { closeAllMonobankQueueBundles } from '@services/bank-data-providers/monobank/transaction-sync-queue';
 import { logoResolutionQueue, logoResolutionWorker } from '@services/brand-logos';
+import { baseCurrencyChangeQueue, baseCurrencyChangeWorker } from '@services/currencies/base-currency-change-queue';
 import {
   budgetBakersWalletImportQueue,
   budgetBakersWalletImportWorker,
@@ -471,6 +472,8 @@ afterAll(async () => {
     await logoResolutionQueue.close();
     await subscriptionReminderEmailWorker.close();
     await subscriptionReminderEmailQueue.close();
+    await baseCurrencyChangeWorker.close();
+    await baseCurrencyChangeQueue.close();
 
     // Now safe to close Redis client
     await redisClient.quit();

--- a/packages/frontend/src/api/_api.ts
+++ b/packages/frontend/src/api/_api.ts
@@ -1,10 +1,12 @@
 import { API_HTTP, API_VER } from '@/api/api-base-url';
 import { ApiBaseError } from '@/common/types';
 import { NotificationType, useNotificationCenter } from '@/components/notification-center';
+import { useBaseCurrencyChangeStatus } from '@/composable/use-base-currency-change-status';
 import { getCurrentLocale, i18n } from '@/i18n';
 import * as errors from '@/js/errors';
 import { router } from '@/routes';
 import { useAuthStore } from '@/stores';
+import type { BaseCurrencyChangeStatus } from '@bt/shared/types';
 import { API_ERROR_CODES, API_RESPONSE_STATUS } from '@bt/shared/types/api';
 
 type HTTP_METHOD = 'PATCH' | 'POST' | 'PUT' | 'GET' | 'DELETE';
@@ -276,6 +278,10 @@ class ApiCaller {
 
     if (status === API_RESPONSE_STATUS.error) {
       if (response.code === API_ERROR_CODES.unauthorized) {
+        // Tear down the base-currency watchdog first: without a session its 2s
+        // status poll would 401 on every tick and re-enter this same branch.
+        useBaseCurrencyChangeStatus().stop();
+
         useAuthStore().logout();
 
         router.push('/sign-in');
@@ -287,6 +293,23 @@ class ApiCaller {
         });
 
         throw new errors.AuthError(response, url);
+      }
+
+      if (response.code === API_ERROR_CODES.baseCurrencyChangeInProgress) {
+        // A change is running server-side and rejected this mutation. Bring up the
+        // blocking overlay on this device (only if not already watching, so a burst
+        // of 423s doesn't reset the visible step), then still reject so callers unwind.
+        const watch = useBaseCurrencyChangeStatus();
+        if (!watch.isBlocking.value) {
+          // The LockedError carries the live status in `details.status`; seeding it
+          // skips the one-tick flash of a fabricated "queued" placeholder.
+          const seed = response.details?.status;
+          if (typeof seed?.state === 'string') {
+            watch.start({ initialStatus: seed as BaseCurrencyChangeStatus });
+          } else {
+            watch.start();
+          }
+        }
       }
 
       if (response.code === API_ERROR_CODES.unexpected) {

--- a/packages/frontend/src/api/currencies.ts
+++ b/packages/frontend/src/api/currencies.ts
@@ -1,5 +1,6 @@
 import { api } from '@/api/_api';
 import {
+  type BaseCurrencyChangeStatus,
   CurrencyModel,
   ExchangeRatesModel,
   RefBalanceRemeasureResult,
@@ -42,8 +43,19 @@ export const deleteUserCurrency = (currencyCode: string) => api.delete('/user/cu
 
 export const setBaseUserCurrency = (currencyCode: string) => api.post('/user/currencies/base', { currencyCode });
 
-export const changeBaseCurrency = (newCurrencyCode: string) =>
+/**
+ * Enqueues the base-currency recalculation as a background job. Resolves as soon
+ * as the job is queued — progress is tracked via `getBaseCurrencyChangeStatus`.
+ */
+export const changeBaseCurrency = (newCurrencyCode: string): Promise<{ jobId: string; state: 'queued' }> =>
   api.post('/user/currencies/change-base', { newCurrencyCode });
+
+/**
+ * Current state of the user's base-currency change job. Returns `idle` when no
+ * change is in flight, so it is safe to call on every app boot.
+ */
+export const getBaseCurrencyChangeStatus = (): Promise<BaseCurrencyChangeStatus> =>
+  api.get('/user/currencies/change-base/status');
 
 export const addUserCurrencies = async (
   currencies: {

--- a/packages/frontend/src/app.vue
+++ b/packages/frontend/src/app.vue
@@ -2,12 +2,14 @@
   <main class="bg-background">
     <router-view />
 
+    <base-currency-change-overlay />
     <notifications-center />
     <update-available-banner />
   </main>
 </template>
 
 <script setup lang="ts">
+import BaseCurrencyChangeOverlay from '@/components/common/base-currency-change-overlay.vue';
 import UpdateAvailableBanner from '@/components/common/update-available-banner.vue';
 import NotificationsCenter from '@/components/notification-center/notifications-center.vue';
 import { useExchangeRates } from '@/composable/data-queries/currencies';

--- a/packages/frontend/src/components/common/base-currency-change-overlay.vue
+++ b/packages/frontend/src/components/common/base-currency-change-overlay.vue
@@ -1,0 +1,258 @@
+<template>
+  <Teleport to="body">
+    <div
+      v-if="isVisible"
+      ref="overlayRef"
+      class="bg-background/95 fixed inset-0 z-(--z-app-lock) flex items-center justify-center p-4 backdrop-blur-sm"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="base-currency-overlay-title"
+      aria-describedby="base-currency-overlay-description"
+      tabindex="-1"
+    >
+      <Card class="w-full max-w-md shadow-lg">
+        <CardContent class="p-6 text-center sm:pt-6">
+          <template v-if="showProgress">
+            <!-- Hero: a slow ring spinning around a currency-swap badge signals live work. -->
+            <div class="relative mx-auto flex size-16 items-center justify-center">
+              <!-- Frozen mid-spin the ring reads as a broken circle, so drop it entirely
+                   under reduced motion — the badge alone stays clean. -->
+              <Loader2Icon
+                class="text-primary/30 animation-duration-[2.5s] absolute size-16 animate-spin motion-reduce:hidden"
+                aria-hidden="true"
+              />
+              <div class="bg-primary/10 ring-primary/15 flex size-11 items-center justify-center rounded-full ring-1">
+                <ArrowLeftRightIcon class="text-primary size-5" aria-hidden="true" />
+              </div>
+            </div>
+
+            <h2 id="base-currency-overlay-title" class="mt-5 text-lg font-semibold">
+              {{ $t('settings.currencies.setBase.overlay.title') }}
+            </h2>
+
+            <p id="base-currency-overlay-description" class="text-muted-foreground mt-2 text-sm">
+              {{ $t('settings.currencies.setBase.overlay.description') }}
+            </p>
+
+            <!-- Progress: a determinate bar (solid = done, shimmering slice = in progress)
+                 plus the current step label and an "X of N" counter. -->
+            <div class="mt-6">
+              <div
+                class="bg-primary/25 relative h-2 w-full overflow-hidden rounded-full"
+                role="progressbar"
+                :aria-valuemin="0"
+                :aria-valuemax="totalSteps"
+                :aria-valuenow="currentStepNumber ?? undefined"
+                :aria-valuetext="counterText ?? undefined"
+              >
+                <div
+                  class="bg-primary absolute inset-y-0 left-0 transition-[width] duration-700 ease-out"
+                  :style="{ width: `${donePercent}%` }"
+                />
+                <div v-if="showSweep" class="bcc-sweep pointer-events-none absolute inset-0" aria-hidden="true" />
+              </div>
+
+              <div class="mt-3 flex items-center justify-between gap-3 text-sm">
+                <span class="text-foreground flex min-w-0 items-center gap-2 font-medium">
+                  <CircleCheckIcon v-if="isFinishing" class="text-success-text size-4 shrink-0" aria-hidden="true" />
+                  <span v-else class="bg-primary size-1.5 shrink-0 animate-pulse rounded-full" aria-hidden="true" />
+                  <span class="truncate">{{ $t(currentLabelKey) }}</span>
+                </span>
+
+                <span v-if="counterText" class="text-muted-foreground shrink-0 text-xs tabular-nums">
+                  {{ counterText }}
+                </span>
+              </div>
+            </div>
+
+            <p v-if="isTakingLong" class="text-muted-foreground mt-5 text-sm">
+              {{ $t('settings.currencies.setBase.overlay.takingLong') }}
+            </p>
+
+            <template v-if="statusUnreachable">
+              <div class="border-border/60 mt-5 border-t pt-5">
+                <p class="text-destructive-text text-sm font-medium">
+                  {{ $t('settings.currencies.setBase.overlay.unreachableTitle') }}
+                </p>
+
+                <p class="text-muted-foreground mt-2 text-sm">
+                  {{ $t('settings.currencies.setBase.overlay.unreachableDescription') }}
+                </p>
+
+                <Button ref="dismissButtonRef" variant="outline" class="mt-4" @click="stop">
+                  {{ $t('settings.currencies.setBase.overlay.dismiss') }}
+                </Button>
+              </div>
+            </template>
+          </template>
+
+          <template v-else-if="liveFailure">
+            <div class="bg-destructive/10 mx-auto flex size-16 items-center justify-center rounded-full">
+              <TriangleAlertIcon class="text-destructive-text size-8" aria-hidden="true" />
+            </div>
+
+            <h2 id="base-currency-overlay-title" class="mt-5 text-lg font-semibold">
+              {{ $t('settings.currencies.setBase.overlay.failedTitle') }}
+            </h2>
+
+            <p id="base-currency-overlay-description" class="text-muted-foreground mt-2 text-sm">{{ liveFailure }}</p>
+
+            <Button ref="dismissButtonRef" variant="outline" class="mt-6" @click="stop">
+              {{ $t('settings.currencies.setBase.overlay.dismiss') }}
+            </Button>
+          </template>
+        </CardContent>
+      </Card>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import Button from '@/components/lib/ui/button/Button.vue';
+import type { ComponentPublicInstance } from 'vue';
+import { Card, CardContent } from '@/components/lib/ui/card';
+import { useBaseCurrencyChangeStatus } from '@/composable/use-base-currency-change-status';
+// Type-only: a runtime import of the shared step const can read as stale-undefined
+// in the dockerized dev frontend until its container restarts.
+import type { BaseCurrencyChangeStep } from '@bt/shared/types';
+import { ArrowLeftRightIcon, CircleCheckIcon, Loader2Icon, TriangleAlertIcon } from '@lucide/vue';
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const { t } = useI18n();
+const { status, isBlocking, isTakingLong, liveFailure, statusUnreachable, stop } = useBaseCurrencyChangeStatus();
+
+// Declared in the backend's execution order (see BASE_CURRENCY_CHANGE_STEPS) so its
+// key order is the source for step numbering, and `satisfies` breaks the build if a
+// backend step is added or renamed instead of silently rendering a raw i18n key.
+const STEP_LABEL_KEYS = {
+  transactions: 'settings.currencies.setBase.overlay.steps.transactions',
+  accounts: 'settings.currencies.setBase.overlay.steps.accounts',
+  loanDetails: 'settings.currencies.setBase.overlay.steps.loanDetails',
+  balances: 'settings.currencies.setBase.overlay.steps.balances',
+  investmentTransactions: 'settings.currencies.setBase.overlay.steps.investmentTransactions',
+  portfolioTransfers: 'settings.currencies.setBase.overlay.steps.portfolioTransfers',
+  holdings: 'settings.currencies.setBase.overlay.steps.holdings',
+  portfolioBalances: 'settings.currencies.setBase.overlay.steps.portfolioBalances',
+} satisfies Record<BaseCurrencyChangeStep, string>;
+
+const STEP_ORDER = Object.keys(STEP_LABEL_KEYS) as BaseCurrencyChangeStep[];
+const totalSteps = STEP_ORDER.length;
+
+// Keep the progress card up through the brief `completed` window too: the terminal
+// handler is wiping caches and about to reload, and dropping the overlay early would
+// flash the underlying stale-base UI.
+const showProgress = computed(() => isBlocking.value || status.value?.state === 'completed');
+
+const isVisible = computed(() => showProgress.value || Boolean(liveFailure.value));
+
+/**
+ * Where the change is right now, mapped to what the bar shows:
+ *  - `running`  → 0-based index of the step being processed (some done, one in flight)
+ *  - `finishing`→ the brief `completed` window before the reload (bar full)
+ *  - `preparing`→ queued, or running with no step yet (indeterminate bar)
+ */
+const progress = computed<
+  { kind: 'running'; index: number; step: BaseCurrencyChangeStep } | { kind: 'finishing' } | { kind: 'preparing' }
+>(() => {
+  const current = status.value;
+  if (current?.state === 'completed') return { kind: 'finishing' };
+  if (current?.state === 'running' && current.step) {
+    const index = STEP_ORDER.indexOf(current.step);
+    if (index >= 0) return { kind: 'running', index, step: current.step };
+  }
+  return { kind: 'preparing' };
+});
+
+const isFinishing = computed(() => progress.value.kind === 'finishing');
+
+// A white highlight sweeps the bar while work is in flight; the completed frame drops
+// it and just shows the full fill.
+const showSweep = computed(() => progress.value.kind !== 'finishing');
+
+// Steps reported before the current one are done, so the fill is index/total: solid
+// primary up to there, a dimmer primary track for what's left. `finishing` fills fully;
+// `preparing` leaves the track empty with only the sweep, reading as indeterminate work.
+const donePercent = computed(() => {
+  const p = progress.value;
+  if (p.kind === 'finishing') return 100;
+  if (p.kind === 'running') return (p.index / totalSteps) * 100;
+  return 0;
+});
+
+const currentStepNumber = computed(() => (progress.value.kind === 'running' ? progress.value.index + 1 : null));
+
+const counterText = computed(() =>
+  currentStepNumber.value == null
+    ? null
+    : t('settings.currencies.setBase.overlay.stepCounter', { current: currentStepNumber.value, total: totalSteps }),
+);
+
+const currentLabelKey = computed(() => {
+  const p = progress.value;
+  if (p.kind === 'running') return STEP_LABEL_KEYS[p.step];
+  if (p.kind === 'finishing') return 'settings.currencies.setBase.overlay.finishing';
+  return 'settings.currencies.setBase.overlay.preparing';
+});
+
+const overlayRef = ref<HTMLElement | null>(null);
+const dismissButtonRef = ref<ComponentPublicInstance | null>(null);
+
+/** True whenever a panel with a dismiss button is showing (failure or unreachable). */
+const dismissActionVisible = computed(() => Boolean(liveFailure.value) || statusUnreachable.value);
+
+/** The app mount root; inerting it keeps Tab from reaching the app behind the overlay. */
+const appRoot = (): HTMLElement | null => document.getElementById('app');
+
+watch(isVisible, async (visible) => {
+  const root = appRoot();
+  if (visible) {
+    root?.setAttribute('inert', '');
+    await nextTick();
+    overlayRef.value?.focus();
+  } else {
+    root?.removeAttribute('inert');
+  }
+});
+
+// The overlay can swap from progress to the failure/unreachable panel without ever
+// hiding, so the isVisible watch above won't fire. Move focus to the dismiss button
+// on that in-place switch so keyboard users land on the only remaining action.
+watch(dismissActionVisible, async (present) => {
+  if (!present) return;
+  await nextTick();
+  (dismissButtonRef.value?.$el as HTMLElement | undefined)?.focus();
+});
+
+onUnmounted(() => {
+  // A leaked inert attribute would dead-lock the whole UI, so always clear it.
+  appRoot()?.removeAttribute('inert');
+});
+</script>
+
+<style scoped>
+/* A soft white highlight travelling left→right across the whole bar — signals the
+   recalculation is actively progressing, on top of the determinate done/remaining fill. */
+.bcc-sweep {
+  background: linear-gradient(
+    90deg,
+    transparent,
+    color-mix(in srgb, var(--color-primary-foreground) 24%, transparent),
+    transparent
+  );
+  transform: translateX(-100%);
+  animation: bcc-sweep 1.4s linear infinite;
+}
+
+@keyframes bcc-sweep {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bcc-sweep {
+    animation: none;
+  }
+}
+</style>

--- a/packages/frontend/src/composable/data-queries/currencies.ts
+++ b/packages/frontend/src/composable/data-queries/currencies.ts
@@ -5,7 +5,7 @@ import {
   loadUserCurrenciesExchangeRates,
   setBaseUserCurrency,
 } from '@/api/currencies';
-import { VUE_QUERY_CACHE_KEYS, VUE_QUERY_GLOBAL_PREFIXES } from '@/common/const';
+import { VUE_QUERY_CACHE_KEYS } from '@/common/const';
 import { useCurrenciesStore } from '@/stores';
 import { CurrencyModel, UserExchangeRatesModel } from '@bt/shared/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
@@ -69,23 +69,15 @@ export const useSetBaseCurrency = () => {
 };
 
 /**
- * Mutation for changing user's base currency and recalculating all amounts
+ * Enqueues a base-currency change. The mutation resolves as soon as the job is
+ * queued; the change runs in the background and the completion handler (which
+ * owns cache invalidation, via a full reset + reload) is driven by
+ * `use-base-currency-change-status`.
  */
-export const useChangeBaseCurrency = () => {
-  const queryClient = useQueryClient();
-  const currenciesStore = useCurrenciesStore();
-
-  return useMutation({
+export const useChangeBaseCurrency = () =>
+  useMutation({
     mutationFn: (newCurrencyCode: string) => changeBaseCurrency(newCurrencyCode),
-    onSuccess: () => {
-      currenciesStore.loadCurrencies({ force: true });
-      currenciesStore.loadBaseCurrency({ force: true });
-      queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.transactionChange] });
-      queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.securityPriceChange] });
-      queryClient.invalidateQueries({ queryKey: [VUE_QUERY_GLOBAL_PREFIXES.currencies] });
-    },
   });
-};
 
 /**
  * Query for fetching user's exchange rates.

--- a/packages/frontend/src/composable/use-base-currency-change-status.spec.ts
+++ b/packages/frontend/src/composable/use-base-currency-change-status.spec.ts
@@ -1,0 +1,287 @@
+import { AuthError } from '@/js/errors';
+import { API_ERROR_CODES, type BaseCurrencyChangeStatus, type BaseCurrencyChangeStep } from '@bt/shared/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getStatusMock, resetQueryCachesMock, captureExceptionMock, sseOnMock, reloadMock } = vi.hoisted(() => ({
+  getStatusMock: vi.fn(),
+  resetQueryCachesMock: vi.fn(),
+  captureExceptionMock: vi.fn(),
+  sseOnMock: vi.fn(),
+  reloadMock: vi.fn(),
+}));
+
+vi.mock('@/api/currencies', () => ({ getBaseCurrencyChangeStatus: getStatusMock }));
+vi.mock('@/lib/query-persister', () => ({ resetQueryCaches: resetQueryCachesMock }));
+vi.mock('@/lib/query-client', () => ({ queryClient: {} }));
+vi.mock('@/lib/sentry', () => ({ captureException: captureExceptionMock }));
+vi.mock('@/composable/use-sse', () => ({ useSSE: () => ({ on: sseOnMock }) }));
+
+import { useBaseCurrencyChangeStatus } from './use-base-currency-change-status';
+
+const queued = (jobId = 'job-1'): BaseCurrencyChangeStatus => ({ state: 'queued', jobId });
+const running = (step: BaseCurrencyChangeStep, jobId = 'job-1'): BaseCurrencyChangeStatus => ({
+  state: 'running',
+  jobId,
+  step,
+});
+const completed = (jobId = 'job-1'): BaseCurrencyChangeStatus => ({
+  state: 'completed',
+  jobId,
+  finishedAt: Date.now(),
+  result: {
+    transactionsUpdated: 1,
+    accountsUpdated: 1,
+    loanDetailsUpdated: 0,
+    balancesRebuilt: 0,
+    investmentTransactionsUpdated: 0,
+    portfolioTransfersUpdated: 0,
+    holdingsUpdated: 0,
+    portfolioBalancesUpdated: 0,
+  },
+});
+const failed = (error: string, jobId = 'job-1'): BaseCurrencyChangeStatus => ({ state: 'failed', jobId, error });
+
+/** localStorage key the composable uses to dedupe completion handling per browser. */
+const HANDLED_JOB_KEY = 'base-currency-change-handled-job';
+
+/** In-memory localStorage stand-in; each spy is overridable per test (e.g. to throw). */
+const makeStorageMock = () => {
+  const store = new Map<string, string>();
+  return {
+    getItem: vi.fn((key: string): string | null => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string): void => void store.set(key, value)),
+    removeItem: vi.fn((key: string): void => void store.delete(key)),
+    clear: vi.fn((): void => store.clear()),
+  };
+};
+let storageMock: ReturnType<typeof makeStorageMock>;
+
+/** Latest SSE callback registered by the composable's live watch. */
+const latestSseCallback = (): ((payload: BaseCurrencyChangeStatus) => void) =>
+  sseOnMock.mock.calls[sseOnMock.mock.calls.length - 1]![1];
+
+describe('useBaseCurrencyChangeStatus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetQueryCachesMock.mockResolvedValue(undefined);
+    sseOnMock.mockReturnValue(() => {});
+    storageMock = makeStorageMock();
+    vi.stubGlobal('location', { reload: reloadMock });
+    vi.stubGlobal('localStorage', storageMock);
+  });
+
+  afterEach(() => {
+    useBaseCurrencyChangeStatus().stop();
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('blocks while queued/running and resets caches + reloads once on a live completion', async () => {
+    getStatusMock.mockResolvedValueOnce(running('accounts')).mockResolvedValueOnce(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    expect(store.isBlocking.value).toBe(true);
+
+    // First poll: still running. Second poll: completed → terminal side effects.
+    await vi.advanceTimersByTimeAsync(0);
+    expect(store.status.value?.state).toBe('running');
+    expect(reloadMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(resetQueryCachesMock).toHaveBeenCalledTimes(1);
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    // The marker is written before the reload so the post-reload boot stays informational.
+    expect(storageMock.setItem).toHaveBeenCalledWith(HANDLED_JOB_KEY, 'job-1');
+  });
+
+  it('fires the terminal side effect exactly once when SSE and the poll both deliver completed', async () => {
+    getStatusMock.mockResolvedValue(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    // SSE delivers the terminal state first.
+    latestSseCallback()(completed());
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The poll then also returns completed; the guard must suppress a second run.
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(resetQueryCachesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('wipes caches, writes the handled-job marker and reloads once for an unhandled completion at boot', async () => {
+    // A device closed/hard-refreshed mid-change boots after completion: its persisted
+    // monetary data was computed against the old base, so it must wipe + reload.
+    getStatusMock.mockResolvedValue(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    await store.checkOnBoot();
+
+    expect(resetQueryCachesMock).toHaveBeenCalledTimes(1);
+    expect(storageMock.setItem).toHaveBeenCalledWith(HANDLED_JOB_KEY, 'job-1');
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an already-handled completion at boot as informational — no wipe, no reload', async () => {
+    // The marker already names this job (this browser reloaded for it before), so the
+    // retained-24h completion must not loop.
+    storageMock.getItem.mockReturnValue('job-1');
+    getStatusMock.mockResolvedValue(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    await store.checkOnBoot();
+
+    expect(resetQueryCachesMock).not.toHaveBeenCalled();
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(store.isBlocking.value).toBe(false);
+  });
+
+  it('does not reload for a boot completion when localStorage access throws', async () => {
+    // Broken storage (private mode/quota) counts as handled, so it can never drive a loop.
+    storageMock.getItem.mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    getStatusMock.mockResolvedValue(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    await store.checkOnBoot();
+
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(resetQueryCachesMock).not.toHaveBeenCalled();
+  });
+
+  it('attaches the live watch when a change is in flight at boot, then reloads on completion', async () => {
+    // Boot fetch + the immediate live poll both see it still running; the change
+    // only completes on the timer-driven poll, so the overlay is up meanwhile.
+    getStatusMock
+      .mockResolvedValueOnce(running('transactions'))
+      .mockResolvedValueOnce(running('accounts'))
+      .mockResolvedValueOnce(completed());
+
+    const store = useBaseCurrencyChangeStatus();
+    await store.checkOnBoot();
+
+    expect(store.isBlocking.value).toBe(true);
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reloads on a live completion when the cache wipe rejects', async () => {
+    getStatusMock.mockResolvedValueOnce(completed());
+    resetQueryCachesMock.mockRejectedValueOnce(new Error('indexeddb blocked'));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a sustained poll outage to Sentry once, not on every tick', async () => {
+    getStatusMock.mockRejectedValue(new Error('status endpoint down'));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    // Immediate poll + several interval polls all fail; only the first is reported.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+    expect(store.isBlocking.value).toBe(true);
+  });
+
+  it('never reports an auth-expired poll to Sentry — the API handler already handled it', async () => {
+    getStatusMock.mockRejectedValue(new AuthError({ code: API_ERROR_CODES.unauthorized, message: 'expired' }));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(captureExceptionMock).not.toHaveBeenCalled();
+  });
+
+  it('exposes an escape hatch after a sustained poll outage and clears it on recovery', async () => {
+    getStatusMock.mockRejectedValue(new Error('status endpoint down'));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    // Immediate poll + nine interval polls = ten consecutive failures.
+    await vi.advanceTimersByTimeAsync(0);
+    for (let i = 0; i < 9; i += 1) {
+      await vi.advanceTimersByTimeAsync(2000);
+    }
+
+    expect(store.statusUnreachable.value).toBe(true);
+    expect(store.isBlocking.value).toBe(true);
+
+    // A recovering server answers again; the next successful poll clears the flag.
+    getStatusMock.mockResolvedValue(running('accounts'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(store.statusUnreachable.value).toBe(false);
+    expect(store.isBlocking.value).toBe(true);
+  });
+
+  it('flags a stalled step as taking long and clears the flag when the step advances', async () => {
+    getStatusMock.mockResolvedValue(running('accounts'));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    // The step never changes for the whole threshold window.
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(store.isTakingLong.value).toBe(true);
+    expect(store.isBlocking.value).toBe(true);
+
+    // Real progress on the next poll resets the stall timer.
+    getStatusMock.mockResolvedValue(running('balances'));
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(store.isTakingLong.value).toBe(false);
+  });
+
+  it('shows the failure panel on a live failure without wiping caches', async () => {
+    getStatusMock.mockResolvedValueOnce(failed('drain timed out'));
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(store.liveFailure.value).toBe('drain timed out');
+    expect(store.isBlocking.value).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+    expect(resetQueryCachesMock).not.toHaveBeenCalled();
+  });
+
+  it('drops the overlay when the server reports idle', async () => {
+    getStatusMock.mockResolvedValueOnce({ state: 'idle' } as BaseCurrencyChangeStatus);
+
+    const store = useBaseCurrencyChangeStatus();
+    store.start({ initialStatus: queued() });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(store.status.value).toBeNull();
+    expect(store.isBlocking.value).toBe(false);
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/composable/use-base-currency-change-status.ts
+++ b/packages/frontend/src/composable/use-base-currency-change-status.ts
@@ -1,0 +1,353 @@
+import { getBaseCurrencyChangeStatus } from '@/api/currencies';
+import { useSSE } from '@/composable/use-sse';
+import { AuthError } from '@/js/errors';
+import { queryClient } from '@/lib/query-client';
+import { resetQueryCaches } from '@/lib/query-persister';
+import { captureException } from '@/lib/sentry';
+import { SSE_EVENT_TYPES, type BaseCurrencyChangeStatus, type BaseCurrencyChangeStep } from '@bt/shared/types';
+import { computed, ref } from 'vue';
+
+const STATUS_POLL_INTERVAL_MS = 2000;
+/** localStorage key holding the jobId of the last completion this browser already
+ *  handled (wiped caches + reloaded for). Dedupes so a reload fires at most once per
+ *  job per browser, whether the completion is seen live or first observed at boot. */
+const HANDLED_JOB_STORAGE_KEY = 'base-currency-change-handled-job';
+/** Consecutive poll failures before the overlay offers a manual escape hatch —
+ *  ~20s at the 2s interval, long enough to ride out a brief backend blip. */
+const MAX_POLL_FAILURES_BEFORE_UNREACHABLE = 10;
+/** After this long on the same step the overlay adds a "still working" note but
+ *  keeps blocking — the server lock is still held, so the change is not done. */
+const TAKING_LONG_THRESHOLD_MS = 5 * 60 * 1000;
+
+// Module-scoped singleton: at most one base-currency change runs per user, and
+// its blocking overlay must be identical on every open screen, so every caller
+// shares this state.
+
+/** Latest status observed for the active change, or null when nothing is tracked. */
+const status = ref<BaseCurrencyChangeStatus | null>(null);
+/** Message from a change that failed while this device was watching live. Drives
+ *  the dismissible error panel; never set for a terminal status first seen at boot. */
+const liveFailure = ref<string | null>(null);
+/** True once the active change has sat on one step past the taking-long threshold. */
+const isTakingLong = ref(false);
+/** True once the status poll has failed enough times in a row that the state can no
+ *  longer be verified. Drives the overlay's dismissible escape hatch; a successful
+ *  poll clears it, since a recovering server resumes normal progress. */
+const statusUnreachable = ref(false);
+
+/** Blocks the whole app while a change is queued or running. */
+const isBlocking = computed(() => status.value?.state === 'queued' || status.value?.state === 'running');
+
+// ---- Internal watchdog machinery — consumers never read these ----
+
+let pollHandle: ReturnType<typeof setInterval> | null = null;
+let unsubscribeSse: (() => void) | null = null;
+/** Guards the terminal side effect so completion fires exactly once even if SSE
+ *  and the poll deliver the terminal state in the same tick. */
+let terminalHandled = false;
+/** Timestamp of the last observed state/step change, for the taking-long timer. */
+let lastProgressAt = 0;
+/** Identity (state + step) of the last applied status, to detect real progress. */
+let lastProgressKey = '';
+/** True while the poll is in a run of consecutive failures, so a sustained outage
+ *  reports to Sentry once rather than on every 2s tick. */
+let pollFailing = false;
+/** Count of consecutive poll failures, reset on the next success. Once it crosses
+ *  the threshold the overlay surfaces the unreachable escape hatch. */
+let consecutivePollFailures = 0;
+
+function progressKey(next: BaseCurrencyChangeStatus): string {
+  return next.state === 'running' ? `running:${next.step ?? ''}` : next.state;
+}
+
+/** True when this browser has already wiped+reloaded for the given completion. A
+ *  storage read failure (private mode, quota) counts as handled so broken storage
+ *  can never let the same completion trigger a reload loop. */
+function isCompletionHandled({ jobId }: { jobId: string }): boolean {
+  try {
+    return localStorage.getItem(HANDLED_JOB_STORAGE_KEY) === jobId;
+  } catch {
+    return true;
+  }
+}
+
+/** Records that this completion has been handled, so a later boot stays informational.
+ *  Storage failures are swallowed — the marker is a best-effort loop guard. */
+function markCompletionHandled({ jobId }: { jobId: string }): void {
+  try {
+    localStorage.setItem(HANDLED_JOB_STORAGE_KEY, jobId);
+  } catch {
+    // Storage unavailable: nothing to persist, callers already treat that as handled.
+  }
+}
+
+/** Stops the poll loop and drops the SSE subscription, leaving overlay state intact. */
+function clearTimers(): void {
+  if (pollHandle) {
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+  unsubscribeSse?.();
+  unsubscribeSse = null;
+}
+
+/** Tears everything down and hides the overlay. Public: also the failure panel's dismiss. */
+function stop(): void {
+  clearTimers();
+  terminalHandled = false;
+  isTakingLong.value = false;
+  statusUnreachable.value = false;
+  consecutivePollFailures = 0;
+  pollFailing = false;
+  status.value = null;
+  liveFailure.value = null;
+}
+
+/** Routes a terminal status to its side effect exactly once. */
+async function handleTerminal(next: BaseCurrencyChangeStatus): Promise<void> {
+  if (terminalHandled) return;
+  terminalHandled = true;
+  clearTimers();
+  if (next.state === 'completed') {
+    // Every cached monetary value was computed against the old base, so a full
+    // cache wipe plus one reload is the only honest way to repaint them all. Reload
+    // even if the wipe rejects — otherwise the app is left interactive on stale data.
+    await resetQueryCaches(queryClient).catch((error) =>
+      captureException({ error, context: { scope: 'base-currency-change-status:reset' } }),
+    );
+    // Mark before reloading so the post-reload boot sees this job as handled and
+    // stays informational instead of wiping and reloading a second time.
+    markCompletionHandled({ jobId: next.jobId });
+    window.location.reload();
+  } else if (next.state === 'failed') {
+    liveFailure.value = next.error;
+  }
+}
+
+/** Applies an observed status: tracks progress for the taking-long timer and fires
+ *  the terminal handler on the first queued/running → completed/failed transition. */
+function applyStatus(next: BaseCurrencyChangeStatus): void {
+  const key = progressKey(next);
+  if (key !== lastProgressKey) {
+    lastProgressKey = key;
+    lastProgressAt = Date.now();
+    isTakingLong.value = false;
+  }
+  status.value = next;
+
+  if (next.state === 'idle') {
+    // The server reports nothing in progress (the job finished and aged out, or
+    // its lock was reconciled). Nothing to reload — just drop the overlay.
+    stop();
+    return;
+  }
+  if (next.state === 'completed' || next.state === 'failed') {
+    void handleTerminal(next);
+  }
+}
+
+async function poll(): Promise<void> {
+  try {
+    applyStatus(await getBaseCurrencyChangeStatus());
+    pollFailing = false;
+    consecutivePollFailures = 0;
+    statusUnreachable.value = false;
+  } catch (error) {
+    // A 401 means the global API handler already stopped this watchdog and logged
+    // the user out — an expired session is not a poll outage worth reporting.
+    if (error instanceof AuthError) return;
+    // Keep polling: the server is still locked, so the overlay must stay up. Report
+    // only the first failure of a streak — a sustained outage otherwise floods Sentry
+    // with a fresh event every 2s.
+    if (!pollFailing) {
+      pollFailing = true;
+      captureException({ error, context: { scope: 'base-currency-change-status:poll' } });
+    }
+    consecutivePollFailures += 1;
+    if (consecutivePollFailures >= MAX_POLL_FAILURES_BEFORE_UNREACHABLE) {
+      // The status endpoint has been down long enough that we can't confirm the
+      // change is still running. Offer a manual escape so the user isn't locked out;
+      // polling continues, so a recovering server clears this on the next success.
+      statusUnreachable.value = true;
+    }
+  }
+}
+
+/** Starts the live watchdog: an unconditional 2s poll — the delivery guarantee —
+ *  plus an SSE listener that only fires when another feature already holds a
+ *  connection open (SSE is a lazy shared singleton, so it is a bonus, never relied on). */
+function beginWatch({ seed }: { seed?: BaseCurrencyChangeStatus } = {}): void {
+  clearTimers();
+  terminalHandled = false;
+  pollFailing = false;
+  consecutivePollFailures = 0;
+  isTakingLong.value = false;
+  statusUnreachable.value = false;
+  liveFailure.value = null;
+  lastProgressKey = '';
+  lastProgressAt = Date.now();
+
+  // Seed a blocking placeholder so the overlay appears instantly; the first poll
+  // replaces it with the real state within one tick.
+  status.value = seed ?? { state: 'queued', jobId: '' };
+
+  unsubscribeSse = useSSE().on(SSE_EVENT_TYPES.BASE_CURRENCY_CHANGE_STATUS, (payload) => applyStatus(payload));
+
+  void poll();
+  pollHandle = setInterval(() => {
+    if (isBlocking.value && Date.now() - lastProgressAt >= TAKING_LONG_THRESHOLD_MS) {
+      isTakingLong.value = true;
+    }
+    void poll();
+  }, STATUS_POLL_INTERVAL_MS);
+}
+
+/**
+ * Begins tracking a change this device knows is in flight — the initiator's 202,
+ * or a 423 kicked from the global API handler. Any prior watch is torn down first.
+ */
+function start(params?: { initialStatus?: BaseCurrencyChangeStatus }): void {
+  beginWatch({ seed: params?.initialStatus });
+}
+
+/**
+ * Fetches the status once at app boot and drives the right side effect. A change in
+ * flight attaches the live watchdog. A `completed` this browser has not yet handled
+ * (it was closed or hard-refreshed while the change ran) wipes caches and reloads
+ * once — the persisted monetary data was computed against the old base. The handled-
+ * job marker guarantees that reload fires at most once per job per browser, so the
+ * retained-24h completion cannot loop. `failed` at boot changed no data, so it is
+ * informational only.
+ */
+async function checkOnBoot(): Promise<void> {
+  try {
+    const next = await getBaseCurrencyChangeStatus();
+    if (next.state === 'queued' || next.state === 'running') {
+      beginWatch({ seed: next });
+      return;
+    }
+    if (next.state === 'completed' && !isCompletionHandled({ jobId: next.jobId })) {
+      await resetQueryCaches(queryClient).catch((error) =>
+        captureException({ error, context: { scope: 'base-currency-change-status:reset' } }),
+      );
+      markCompletionHandled({ jobId: next.jobId });
+      window.location.reload();
+    }
+  } catch (error) {
+    // Boot status is best-effort; a failure here must not block app initialization.
+    captureException({ error, context: { scope: 'base-currency-change-status:boot' } });
+  }
+}
+
+/**
+ * Shared SSE + status-poll watchdog for the base-currency change job. Polling is
+ * the delivery guarantee (SSE is a bonus channel that may never connect); the
+ * terminal handler is idempotent and fires on the first observed terminal state.
+ */
+export function useBaseCurrencyChangeStatus() {
+  return {
+    /** Read-only to callers — the composable owns every write. */
+    status,
+    isBlocking,
+    isTakingLong,
+    liveFailure,
+    statusUnreachable,
+    start,
+    stop,
+    checkOnBoot,
+  };
+}
+
+// ---- Dev-only overlay driver ----
+// Preview the blocking overlay in a running dev build without starting a real (heavy,
+// irreversible) base-currency change or touching the backend. Seeds the shared status
+// while suppressing the poll/SSE watchdog and the terminal cache-wipe+reload, so nothing
+// hits the network or navigates. Stripped from production bundles by the DEV guard.
+// From the browser console:
+//   __baseCurrencyOverlay.play()                 // auto-advance all 8 steps on a loop
+//   __baseCurrencyOverlay.step('holdings')       // jump to one step
+//   __baseCurrencyOverlay.queued()               // pre-step "getting ready" frame
+//   __baseCurrencyOverlay.finishing()            // brief "completed" frame (no reload)
+//   __baseCurrencyOverlay.takingLong()           // add the "taking longer" note
+//   __baseCurrencyOverlay.unreachable()          // show the dismissible escape hatch
+//   __baseCurrencyOverlay.fail('boom')           // failure panel
+//   __baseCurrencyOverlay.hide()                 // dismiss
+if (import.meta.env.DEV) {
+  const DEV_STEPS: BaseCurrencyChangeStep[] = [
+    'transactions',
+    'accounts',
+    'loanDetails',
+    'balances',
+    'investmentTransactions',
+    'portfolioTransfers',
+    'holdings',
+    'portfolioBalances',
+  ];
+  let devTimer: ReturnType<typeof setInterval> | null = null;
+  const stopDevTimer = () => {
+    if (devTimer) {
+      clearInterval(devTimer);
+      devTimer = null;
+    }
+  };
+  const setMockStatus = (next: BaseCurrencyChangeStatus | null) => {
+    clearTimers();
+    terminalHandled = true;
+    isTakingLong.value = false;
+    statusUnreachable.value = false;
+    liveFailure.value = null;
+    status.value = next;
+  };
+  (window as unknown as { __baseCurrencyOverlay?: unknown }).__baseCurrencyOverlay = {
+    play(intervalMs = 1500) {
+      stopDevTimer();
+      let i = 0;
+      setMockStatus({ state: 'running', jobId: 'dev-mock', step: DEV_STEPS[i] });
+      devTimer = setInterval(() => {
+        i = (i + 1) % DEV_STEPS.length;
+        status.value = { state: 'running', jobId: 'dev-mock', step: DEV_STEPS[i] };
+      }, intervalMs);
+    },
+    step(name: BaseCurrencyChangeStep) {
+      stopDevTimer();
+      setMockStatus({ state: 'running', jobId: 'dev-mock', step: name });
+    },
+    queued() {
+      stopDevTimer();
+      setMockStatus({ state: 'queued', jobId: 'dev-mock' });
+    },
+    finishing() {
+      stopDevTimer();
+      setMockStatus({
+        state: 'completed',
+        jobId: 'dev-mock',
+        finishedAt: 0,
+        result: {
+          transactionsUpdated: 0,
+          accountsUpdated: 0,
+          loanDetailsUpdated: 0,
+          balancesRebuilt: 0,
+          investmentTransactionsUpdated: 0,
+          portfolioTransfersUpdated: 0,
+          holdingsUpdated: 0,
+          portfolioBalancesUpdated: 0,
+        },
+      });
+    },
+    takingLong() {
+      isTakingLong.value = true;
+    },
+    unreachable() {
+      statusUnreachable.value = true;
+    },
+    fail(message = 'Simulated base-currency change failure (dev preview).') {
+      stopDevTimer();
+      setMockStatus(null);
+      liveFailure.value = message;
+    },
+    hide() {
+      stopDevTimer();
+      stop();
+    },
+  };
+}

--- a/packages/frontend/src/i18n/locales/chunks/en/common.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/common.json
@@ -310,5 +310,33 @@
         "minutes": "{minutes}m"
       }
     }
+  },
+  "settings": {
+    "currencies": {
+      "setBase": {
+        "overlay": {
+          "title": "Changing your base currency",
+          "description": "We're recalculating every amount into your new base currency. This can take a few minutes — please keep this tab open.",
+          "takingLong": "This is taking longer than usual. Your data is safe — we're still working on it.",
+          "failedTitle": "Base currency change failed",
+          "unreachableTitle": "Can't verify the change status",
+          "unreachableDescription": "The server is not responding. You can dismiss this screen — if the change is still running, the app will lock again on your next action.",
+          "dismiss": "Dismiss",
+          "preparing": "Getting things ready…",
+          "finishing": "Finishing up…",
+          "stepCounter": "Step {current} of {total}",
+          "steps": {
+            "transactions": "Updating transactions",
+            "accounts": "Updating accounts",
+            "loanDetails": "Updating loans",
+            "balances": "Rebuilding balance history",
+            "investmentTransactions": "Updating investment transactions",
+            "portfolioTransfers": "Updating portfolio transfers",
+            "holdings": "Updating holdings",
+            "portfolioBalances": "Rebuilding portfolio balances"
+          }
+        }
+      }
+    }
   }
 }

--- a/packages/frontend/src/lib/query-client.ts
+++ b/packages/frontend/src/lib/query-client.ts
@@ -20,6 +20,7 @@ const NON_RETRYABLE_API_CODES: ReadonlySet<API_ERROR_CODES> = new Set([
   API_ERROR_CODES.categoryHasTransactions,
   API_ERROR_CODES.locked,
   API_ERROR_CODES.baseCurrencyChangeInProgress,
+  API_ERROR_CODES.baseCurrencyChangeInProgressOtherUser,
   API_ERROR_CODES.payloadTooLarge,
   API_ERROR_CODES.currencyNotConnected,
 ]);

--- a/packages/frontend/src/pages/settings/subpages/currencies/edit-currency/set-base-currency.vue
+++ b/packages/frontend/src/pages/settings/subpages/currencies/edit-currency/set-base-currency.vue
@@ -101,6 +101,7 @@ import Button from '@/components/lib/ui/button/Button.vue';
 import * as Collapsible from '@/components/lib/ui/collapsible';
 import { useNotificationCenter } from '@/components/notification-center';
 import { useChangeBaseCurrency } from '@/composable/data-queries/currencies';
+import { useBaseCurrencyChangeStatus } from '@/composable/use-base-currency-change-status';
 import { ApiErrorResponseError } from '@/js/errors';
 import { API_ERROR_CODES, type BaseCurrencyBlocker } from '@bt/shared/types';
 import { ChevronDownIcon, InfoIcon, TriangleAlertIcon } from '@lucide/vue';
@@ -127,8 +128,9 @@ const emit = defineEmits<{
   'trigger-disabled': [value: boolean];
 }>();
 
-const { addSuccessNotification, addErrorNotification } = useNotificationCenter();
+const { addErrorNotification } = useNotificationCenter();
 const changeBaseCurrencyMutation = useChangeBaseCurrency();
+const baseCurrencyChangeStatus = useBaseCurrencyChangeStatus();
 const { t } = useI18n();
 
 const form = reactive({
@@ -169,14 +171,21 @@ const buildLockedMessage = ({ blockers }: { blockers: BaseCurrencyBlocker[] }) =
 const makeBaseCurrency = async () => {
   try {
     emit('trigger-disabled', true);
-    await changeBaseCurrencyMutation.mutateAsync(props.currency.currency!.code);
+    const { jobId } = await changeBaseCurrencyMutation.mutateAsync(props.currency.currency!.code);
 
-    addSuccessNotification(t('settings.currencies.setBase.successMessage'));
+    // The recalculation runs as a background job; the blocking overlay takes over
+    // from here and reloads the app once the change completes.
+    baseCurrencyChangeStatus.start({ initialStatus: { state: 'queued', jobId } });
 
     emit('submit');
   } catch (e: unknown) {
     if (e instanceof ApiErrorResponseError) {
       const { code, details, message } = e.data ?? {};
+      // A change is already running (another device won the race): the global 423
+      // handler already raised the blocking overlay, so no error toast is warranted.
+      if (code === API_ERROR_CODES.baseCurrencyChangeInProgress) {
+        return;
+      }
       if (
         code === API_ERROR_CODES.baseCurrencyLockedByHousehold ||
         code === API_ERROR_CODES.baseCurrencyLockedByShares

--- a/packages/frontend/src/stores/root.ts
+++ b/packages/frontend/src/stores/root.ts
@@ -1,3 +1,4 @@
+import { useBaseCurrencyChangeStatus } from '@/composable/use-base-currency-change-status';
 import { useAuthStore } from '@/stores/auth';
 import { useCategoriesStore } from '@/stores/categories/categories';
 import { useCurrenciesStore } from '@/stores/currencies';
@@ -30,6 +31,8 @@ export const useRootStore = defineStore('root', () => {
         ...(categories.value.length ? [] : [categoriesStore.loadCategories()]),
         currenciesStore.loadCurrencies(),
         ...(isBaseCurrencyExists.value ? [] : [currenciesStore.loadBaseCurrency()]),
+        // Attaches the blocking overlay if a base-currency change is already in flight.
+        useBaseCurrencyChangeStatus().checkOnBoot(),
       ]);
 
       isAppInitialized.value = true;

--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -97,6 +97,8 @@
   --z-dialog: 50;
   --z-over-dialog: 51;
   --z-notifications: 51;
+  /* App-lock overlay must sit above dialogs and notifications — nothing may render over it. */
+  --z-app-lock: 100;
 
   /* Keyframes and animations */
   --animate-accordion-down: accordion-down 0.2s ease-out;

--- a/packages/shared/src/types/api.ts
+++ b/packages/shared/src/types/api.ts
@@ -19,6 +19,7 @@ export enum API_ERROR_CODES {
   BadRequest = 'BAD_REQUEST',
   locked = 'LOCKED',
   baseCurrencyChangeInProgress = 'BASE_CURRENCY_CHANGE_IN_PROGRESS',
+  baseCurrencyChangeInProgressOtherUser = 'BASE_CURRENCY_CHANGE_IN_PROGRESS_OTHER_USER',
   badGateway = 'BAD_GATEWAY',
   payloadTooLarge = 'PAYLOAD_TOO_LARGE',
   serviceUnavailable = 'SERVICE_UNAVAILABLE',

--- a/packages/shared/src/types/currencies.ts
+++ b/packages/shared/src/types/currencies.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-table counts returned by a base-currency recalculation: how many rows had
+ * their `ref*` amounts rewritten into the new base. Surfaced as the change-base
+ * job result so the client can confirm the sweep touched every table.
+ */
+export interface RecalculateResult {
+  transactionsUpdated: number;
+  accountsUpdated: number;
+  loanDetailsUpdated: number;
+  balancesRebuilt: number;
+  investmentTransactionsUpdated: number;
+  portfolioTransfersUpdated: number;
+  holdingsUpdated: number;
+  portfolioBalancesUpdated: number;
+}
+
+/**
+ * Recalculation phases in execution order. Shared so the frontend's per-step
+ * progress labels stay compile-linked to what the backend actually reports.
+ */
+export const BASE_CURRENCY_CHANGE_STEPS = [
+  'transactions',
+  'accounts',
+  'loanDetails',
+  'balances',
+  'investmentTransactions',
+  'portfolioTransfers',
+  'holdings',
+  'portfolioBalances',
+] as const;
+
+export type BaseCurrencyChangeStep = (typeof BASE_CURRENCY_CHANGE_STEPS)[number];
+
+/**
+ * Result of `GET /user/currencies/change-base/status`. The base-currency change
+ * runs as a background job that any device polls to drive the blocking overlay.
+ * `idle` covers both "never ran" and "job aged out of retention" — the endpoint
+ * never 404s, since the frontend calls it on every boot.
+ */
+export type BaseCurrencyChangeStatus =
+  | { state: 'idle' }
+  | { state: 'queued'; jobId: string }
+  | { state: 'running'; jobId: string; step?: BaseCurrencyChangeStep; startedAt?: number }
+  | { state: 'completed'; jobId: string; finishedAt: number; result: RecalculateResult }
+  | { state: 'failed'; jobId: string; finishedAt?: number; error: string };

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -10,6 +10,7 @@ export * from './investments';
 export * from './venture';
 export * from './vehicles';
 export * from './loans';
+export * from './currencies';
 export * from './api';
 export * from './import-export';
 export * from './ynab-import';

--- a/packages/shared/src/types/sse.ts
+++ b/packages/shared/src/types/sse.ts
@@ -1,4 +1,5 @@
 import type { BudgetBakersWalletImportProgress } from './budget-bakers-wallet-import';
+import type { BaseCurrencyChangeStatus } from './currencies';
 import type { CsvImportProgress } from './import-export';
 /**
  * Server-Sent Events (SSE) shared types
@@ -16,6 +17,7 @@ export const SSE_EVENT_TYPES = {
   YNAB_IMPORT_PROGRESS: 'ynab_import_progress',
   BUDGET_BAKERS_WALLET_IMPORT_PROGRESS: 'budget_bakers_wallet_import_progress',
   CSV_IMPORT_PROGRESS: 'csv_import_progress',
+  BASE_CURRENCY_CHANGE_STATUS: 'base_currency_change_status',
 } as const;
 
 export type SSEEventType = (typeof SSE_EVENT_TYPES)[keyof typeof SSE_EVENT_TYPES];
@@ -83,7 +85,8 @@ export type SSEEventPayload =
   | SyncStatusChangedPayload
   | YnabImportProgress
   | BudgetBakersWalletImportProgress
-  | CsvImportProgress;
+  | CsvImportProgress
+  | BaseCurrencyChangeStatus;
 
 /**
  * Maps each SSE event name to the payload its listeners receive. Lets a typed
@@ -98,4 +101,5 @@ export interface SSEEventPayloadMap {
   [SSE_EVENT_TYPES.YNAB_IMPORT_PROGRESS]: YnabImportProgress;
   [SSE_EVENT_TYPES.BUDGET_BAKERS_WALLET_IMPORT_PROGRESS]: BudgetBakersWalletImportProgress;
   [SSE_EVENT_TYPES.CSV_IMPORT_PROGRESS]: CsvImportProgress;
+  [SSE_EVENT_TYPES.BASE_CURRENCY_CHANGE_STATUS]: BaseCurrencyChangeStatus;
 }


### PR DESCRIPTION
Moves base-currency recalculation into a BullMQ job that locks all writer endpoints (423) and streams progress to the client via SSE; update frontend to show a global lock screen