### PR TITLE
 feat(investments): Add exchange-specific holiday filtering to suppress price sync noise

### DIFF
--- a/packages/backend/src/services/investments/data-providers/base-provider.ts
+++ b/packages/backend/src/services/investments/data-providers/base-provider.ts
@@ -101,6 +101,7 @@ export interface SecurityPriceFetchInput {
   symbol: string;
   providerSymbol: ProviderSymbol;
   assetClass: ASSET_CLASS;
+  exchangeAcronym?: string | null;
 }
 
 export abstract class BaseSecurityDataProvider {

--- a/packages/backend/src/services/investments/data-providers/utils/is-market-closed.ts
+++ b/packages/backend/src/services/investments/data-providers/utils/is-market-closed.ts
@@ -1,20 +1,202 @@
 import { ASSET_CLASS } from '@bt/shared/types/investments';
+import { toUtcDateString } from '@common/utils/date';
 import { isWeekend } from 'date-fns';
 
+// US Market Holidays (NYSE, NASDAQ, NYSEARCA, AMEX, BATS, ARCA)
+const US_HOLIDAYS = new Set([
+  // 2025
+  '2025-01-01',
+  '2025-01-20',
+  '2025-02-17',
+  '2025-04-18',
+  '2025-05-26',
+  '2025-06-19',
+  '2025-07-04',
+  '2025-09-01',
+  '2025-11-27',
+  '2025-12-25',
+  // 2026
+  '2026-01-01',
+  '2026-01-19',
+  '2026-02-16',
+  '2026-04-03',
+  '2026-05-25',
+  '2026-06-19',
+  '2026-07-03',
+  '2026-09-07',
+  '2026-11-26',
+  '2026-12-25',
+  // 2027
+  '2027-01-01',
+  '2027-01-18',
+  '2027-02-15',
+  '2027-03-26',
+  '2027-05-31',
+  '2027-06-18',
+  '2027-07-05',
+  '2027-09-06',
+  '2027-11-25',
+  '2027-12-24',
+]);
+
+// Euronext Market Holidays (Amsterdam, Paris, etc. - AMS, PAR, EURONEXT, XAMS, XPAR)
+const EURONEXT_HOLIDAYS = new Set([
+  // 2025
+  '2025-01-01',
+  '2025-04-18',
+  '2025-04-21',
+  '2025-12-25',
+  '2025-12-26',
+  // 2026
+  '2026-01-01',
+  '2026-04-03',
+  '2026-04-06',
+  '2026-12-25',
+  '2026-12-26',
+  // 2027
+  '2027-01-01',
+  '2027-03-26',
+  '2027-03-29',
+  '2027-12-24',
+  '2027-12-25',
+  '2027-12-26',
+]);
+
+// Warsaw Stock Exchange Holidays (GPW, WSE, WAR)
+const GPW_HOLIDAYS = new Set([
+  // 2025
+  '2025-01-01',
+  '2025-01-06',
+  '2025-04-18',
+  '2025-04-21',
+  '2025-05-01',
+  '2025-05-03',
+  '2025-06-19',
+  '2025-08-15',
+  '2025-11-01',
+  '2025-11-11',
+  '2025-12-24',
+  '2025-12-25',
+  '2025-12-26',
+  '2025-12-31',
+  // 2026
+  '2026-01-01',
+  '2026-01-06',
+  '2026-04-03',
+  '2026-04-06',
+  '2026-05-01',
+  '2026-05-03',
+  '2026-06-04',
+  '2026-08-15',
+  '2026-11-01',
+  '2026-11-11',
+  '2026-12-24',
+  '2026-12-25',
+  '2026-12-26',
+  '2026-12-31',
+  // 2027
+  '2027-01-01',
+  '2027-01-06',
+  '2027-03-26',
+  '2027-03-29',
+  '2027-05-01',
+  '2027-05-03',
+  '2027-05-27',
+  '2027-08-15',
+  '2027-11-01',
+  '2027-11-11',
+  '2027-12-24',
+  '2027-12-25',
+  '2027-12-26',
+  '2027-12-31',
+]);
+
+// Indian Stock Exchange Holidays (NSE, BSE)
+const NSE_HOLIDAYS = new Set([
+  // 2025
+  '2025-02-26',
+  '2025-03-14',
+  '2025-03-31',
+  '2025-04-10',
+  '2025-04-14',
+  '2025-04-18',
+  '2025-05-01',
+  '2025-08-15',
+  '2025-08-27',
+  '2025-10-02',
+  '2025-10-21',
+  '2025-10-22',
+  '2025-11-05',
+  '2025-12-25',
+  // 2026
+  '2026-01-15',
+  '2026-01-26',
+  '2026-03-03',
+  '2026-03-26',
+  '2026-03-31',
+  '2026-04-03',
+  '2026-04-14',
+  '2026-05-01',
+  '2026-05-28',
+  '2026-06-26',
+  '2026-09-14',
+  '2026-10-02',
+  '2026-10-20',
+  '2026-11-10',
+  '2026-11-24',
+  '2026-12-25',
+  // 2027
+  '2027-01-26',
+  '2027-03-26',
+  '2027-04-14',
+  '2027-12-25',
+]);
+
+function isHolidayFor({ exchangeAcronym, date }: { exchangeAcronym: string; date: Date }): boolean {
+  const acronym = exchangeAcronym.toUpperCase().trim();
+  const dateStr = toUtcDateString(date);
+
+  if (['NYSE', 'NASDAQ', 'NYSEARCA', 'AMEX', 'BATS', 'ARCA'].includes(acronym)) {
+    return US_HOLIDAYS.has(dateStr);
+  }
+
+  if (['AMS', 'PAR', 'EURONEXT', 'XAMS', 'XPAR'].includes(acronym)) {
+    return EURONEXT_HOLIDAYS.has(dateStr);
+  }
+
+  if (['GPW', 'WSE', 'WAR'].includes(acronym)) {
+    return GPW_HOLIDAYS.has(dateStr);
+  }
+
+  if (['NSE', 'BSE'].includes(acronym)) {
+    return NSE_HOLIDAYS.has(dateStr);
+  }
+
+  return false;
+}
+
 /**
- * v1: weekend-only. Returns true when the security's market was closed on the
- * given date and we should expect providers to return no data. Crypto trades
- * 24/7.
- *
- * TODO: exchange-specific holidays (NYSE July 4, WSE Polish holidays, NSE
- * Diwali, etc.) still slip through and generate Sentry noise. Add a holiday
- * calendar keyed by `exchangeAcronym` (already on Securities model — just
- * needs to be threaded into SecurityPriceFetchInput).
+ * Returns true when the security's market was closed on the given date and we
+ * should expect providers to return no data. Crypto trades 24/7.
  */
-export function isMarketClosedOn({ assetClass, date }: { assetClass: ASSET_CLASS; date: Date }): boolean {
+export function isMarketClosedOn({
+  assetClass,
+  date,
+  exchangeAcronym,
+}: {
+  assetClass: ASSET_CLASS;
+  date: Date;
+  exchangeAcronym?: string | null;
+}): boolean {
   if (assetClass === ASSET_CLASS.crypto) return false;
 
-  return isWeekend(date);
+  if (isWeekend(date)) return true;
+
+  if (exchangeAcronym) {
+    return isHolidayFor({ exchangeAcronym, date });
+  }
+
+  return false;
 }
 
 /**
@@ -22,7 +204,7 @@ export function isMarketClosedOn({ assetClass, date }: { assetClass: ASSET_CLASS
  * `date` (so missing data is not noteworthy) and ones that should have had data
  * (so missing data is a real signal).
  */
-export function partitionByMarketStatus<T extends { assetClass: ASSET_CLASS }>({
+export function partitionByMarketStatus<T extends { assetClass: ASSET_CLASS; exchangeAcronym?: string | null }>({
   items,
   date,
 }: {
@@ -36,7 +218,7 @@ export function partitionByMarketStatus<T extends { assetClass: ASSET_CLASS }>({
   const actuallyMissing: T[] = [];
 
   for (const item of items) {
-    if (isMarketClosedOn({ assetClass: item.assetClass, date })) {
+    if (isMarketClosedOn({ assetClass: item.assetClass, date, exchangeAcronym: item.exchangeAcronym })) {
       expectedClosed.push(item);
     } else {
       actuallyMissing.push(item);

--- a/packages/backend/src/services/investments/data-providers/utils/is-market-closed.unit.ts
+++ b/packages/backend/src/services/investments/data-providers/utils/is-market-closed.unit.ts
@@ -34,14 +34,60 @@ describe('isMarketClosedOn', () => {
     expect(isMarketClosedOn({ assetClass: ASSET_CLASS.cash, date: SUNDAY })).toBe(true);
     expect(isMarketClosedOn({ assetClass: ASSET_CLASS.other, date: SUNDAY })).toBe(true);
   });
+
+  it('detects exchange-specific holidays', () => {
+    // US Holiday: July 3, 2026 (Observed Independence Day - Friday)
+    const US_HOLIDAY = new Date(2026, 6, 3, 12, 0, 0);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: US_HOLIDAY, exchangeAcronym: 'NYSE' })).toBe(true);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: US_HOLIDAY, exchangeAcronym: 'NASDAQ' })).toBe(
+      true,
+    );
+    // US holiday should not trigger closed for GPW or NSE if it's not a holiday there
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: US_HOLIDAY, exchangeAcronym: 'GPW' })).toBe(false);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: US_HOLIDAY, exchangeAcronym: 'NSE' })).toBe(false);
+    // US holiday should not trigger if exchangeAcronym is missing
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: US_HOLIDAY })).toBe(false);
+
+    // GPW Holiday: November 11, 2026 (Independence Day - Wednesday)
+    const GPW_HOLIDAY = new Date(2026, 10, 11, 12, 0, 0);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: GPW_HOLIDAY, exchangeAcronym: 'GPW' })).toBe(true);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: GPW_HOLIDAY, exchangeAcronym: 'WSE' })).toBe(true);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: GPW_HOLIDAY, exchangeAcronym: 'NYSE' })).toBe(
+      false,
+    );
+
+    // Euronext Holiday: April 6, 2026 (Easter Monday - Monday)
+    const EURONEXT_HOLIDAY = new Date(2026, 3, 6, 12, 0, 0);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: EURONEXT_HOLIDAY, exchangeAcronym: 'AMS' })).toBe(
+      true,
+    );
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: EURONEXT_HOLIDAY, exchangeAcronym: 'PAR' })).toBe(
+      true,
+    );
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: EURONEXT_HOLIDAY, exchangeAcronym: 'NYSE' })).toBe(
+      false,
+    );
+
+    // Indian Holiday: January 26, 2026 (Republic Day - Monday)
+    const INDIAN_HOLIDAY = new Date(2026, 0, 26, 12, 0, 0);
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: INDIAN_HOLIDAY, exchangeAcronym: 'NSE' })).toBe(
+      true,
+    );
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: INDIAN_HOLIDAY, exchangeAcronym: 'BSE' })).toBe(
+      true,
+    );
+    expect(isMarketClosedOn({ assetClass: ASSET_CLASS.stocks, date: INDIAN_HOLIDAY, exchangeAcronym: 'NYSE' })).toBe(
+      false,
+    );
+  });
 });
 
 describe('partitionByMarketStatus', () => {
   it('splits a mixed list on a weekend', () => {
     const items = [
-      { symbol: 'AAPL', assetClass: ASSET_CLASS.stocks },
+      { symbol: 'AAPL', assetClass: ASSET_CLASS.stocks, exchangeAcronym: 'NASDAQ' },
       { symbol: 'BTC-USD', assetClass: ASSET_CLASS.crypto },
-      { symbol: 'XTB.WA', assetClass: ASSET_CLASS.stocks },
+      { symbol: 'XTB.WA', assetClass: ASSET_CLASS.stocks, exchangeAcronym: 'GPW' },
       { symbol: 'ETH-EUR', assetClass: ASSET_CLASS.crypto },
       { symbol: 'BOND.GOV', assetClass: ASSET_CLASS.fixed_income },
     ];
@@ -50,6 +96,21 @@ describe('partitionByMarketStatus', () => {
 
     expect(result.expectedClosed.map((i) => i.symbol)).toEqual(['AAPL', 'XTB.WA', 'BOND.GOV']);
     expect(result.actuallyMissing.map((i) => i.symbol)).toEqual(['BTC-USD', 'ETH-EUR']);
+  });
+
+  it('splits list containing holiday exchanges on a weekday', () => {
+    // US Holiday: July 3, 2026 (Friday)
+    const US_HOLIDAY = new Date(2026, 6, 3, 12, 0, 0);
+    const items = [
+      { symbol: 'AAPL', assetClass: ASSET_CLASS.stocks, exchangeAcronym: 'NASDAQ' },
+      { symbol: 'BTC-USD', assetClass: ASSET_CLASS.crypto },
+      { symbol: 'XTB.WA', assetClass: ASSET_CLASS.stocks, exchangeAcronym: 'GPW' },
+    ];
+
+    const result = partitionByMarketStatus({ items, date: US_HOLIDAY });
+
+    expect(result.expectedClosed.map((i) => i.symbol)).toEqual(['AAPL']);
+    expect(result.actuallyMissing.map((i) => i.symbol)).toEqual(['BTC-USD', 'XTB.WA']);
   });
 
   it('treats everything as actually-missing on a weekday', () => {

--- a/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
+++ b/packages/backend/src/services/investments/securities-price/securities-daily-sync.service.ts
@@ -129,6 +129,7 @@ const securitiesPricesSyncImpl = async (options: SyncOptions): Promise<Securitie
     symbol: s.symbol ?? s.providerSymbol,
     providerSymbol: toProviderSymbol(s.providerSymbol),
     assetClass: s.assetClass,
+    exchangeAcronym: s.exchangeAcronym,
   }));
 
   logger.info(`[${label}] Fetching prices for ${securitiesById.size} securities using composite provider`);


### PR DESCRIPTION
## Issue

- #422 

## Summary

This PR implements exchange-specific holiday filtering to prevent daily price-sync failures (and false-positive Sentry notifications) on weekday exchange holidays.

Previously, `isMarketClosedOn` only filtered out weekends, meaning national holidays (e.g., NYSE July 4th, GPW Polish national holidays, Euronext holiday closures, or Indian public holidays) would trigger sync jobs that returned no pricing data, producing actionable error logs.


## Changes                       
                        
1. **Input Extension**: Added optional `exchangeAcronym` to `SecurityPriceFetchInput` and populated it in the daily sync pipeline (`securities-daily-sync.service.ts`).
2. **Holiday Lookups**: Built static lookup maps (`exchange-holidays`) in `is-market-closed.ts` covering 2025, 2026, and 2027 for:         
    - US markets (NYSE, NASDAQ, NYSEARCA, AMEX, BATS, ARCA)
    - Euronext (AMS, PAR, EURONEXT, XAMS, XPAR)                                           
    - WSE/GPW (GPW, WSE, WAR)                                                                        
    - NSE/BSE India (NSE, BSE)
3. **Market Status Logic**: Extended `isMarketClosedOn` to return true if the current date is a weekend or matches a known holiday for the security's exchange.
4. **Unit Tests**: Added comprehensive unit tests in `is-market-closed.unit.ts` to test holiday detection across different exchanges and verify partitioning.

## Verification                       

- **Unit Tests**: `npm run test:unit -- src/services/investments/data-providers/utils/is-market-closed.unit.ts` (10/10 Passed)             
- **E2E Integration Tests**: `npm run test:e2e -- --testPathPattern='securities-daily-sync.service.e2e.ts'` (15/15 Passed)
- **Linter & Formatting**: Checked clean.