### PR TITLE
Fix self-hosting MCP setup

### DIFF
--- a/packages/backend/src/routes/oauth-metadata.route.ts
+++ b/packages/backend/src/routes/oauth-metadata.route.ts
@@ -10,10 +10,13 @@ const MCP_SCOPES_SUPPORTED = ['finance:read', 'finance:write', 'finance:delete',
  * These are mounted at root-level well-known paths (RFC 9728, RFC 8414)
  * and cannot live under a prefixed Router.
  *
- * Keep in sync with static mirrors on the landing domain (nginx config):
+ * Keep in sync with the static mirrors served on the landing domain:
  *   - packages/frontend/public/.well-known/oauth-authorization-server
  *   - packages/frontend/public/.well-known/oauth-protected-resource
  * Any change to issuer, endpoints, or scopes here must be reflected there.
+ * Those mirrors are only reached in split-domain deployments; a same-origin
+ * frontend container proxies these paths here instead (see the oauth-mcp.conf
+ * block in self-hosting/frontend/docker-entrypoint.sh).
  */
 export function setupOAuthMetadataRoutes({ app }: { app: Express }) {
   // OAuth Protected Resource Metadata (RFC 9728)

--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -198,46 +198,17 @@ http {
       add_header X-Content-Type-Options "nosniff" always;
     }
 
-    # RFC 8414: OAuth Authorization Server Metadata.
-    # Mirrors the backend's /.well-known/oauth-authorization-server — the
-    # issuer field points to the actual AS (mcp.moneymatter.app). Keep in sync
-    # with packages/backend/src/routes/oauth-metadata.route.ts.
-    # Both root and path-aware (RFC 8414 §3.1) forms serve the same document.
-    location = /.well-known/oauth-authorization-server {
-      root /app;
-      default_type "application/json";
-      add_header Access-Control-Allow-Origin "*" always;
-      add_header Cache-Control "public, max-age=3600" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    }
-    location = /.well-known/oauth-authorization-server/mcp {
-      root /app;
-      try_files /.well-known/oauth-authorization-server =404;
-      default_type "application/json";
-      add_header Access-Control-Allow-Origin "*" always;
-      add_header Cache-Control "public, max-age=3600" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    }
-
-    # RFC 9728: OAuth Protected Resource Metadata.
-    # Mirrors the backend's /.well-known/oauth-protected-resource. Keep in sync
-    # with packages/backend/src/routes/oauth-metadata.route.ts.
-    # Both root and path-aware (RFC 9728 §3.1) forms serve the same document.
-    location = /.well-known/oauth-protected-resource {
-      root /app;
-      default_type "application/json";
-      add_header Access-Control-Allow-Origin "*" always;
-      add_header Cache-Control "public, max-age=3600" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    }
-    location = /.well-known/oauth-protected-resource/mcp {
-      root /app;
-      try_files /.well-known/oauth-protected-resource =404;
-      default_type "application/json";
-      add_header Access-Control-Allow-Origin "*" always;
-      add_header Cache-Control "public, max-age=3600" always;
-      add_header X-Content-Type-Options "nosniff" always;
-    }
+    # OAuth discovery metadata (RFC 8414 + RFC 9728) and the /mcp endpoint are
+    # NOT declared here. Their locations are written by the container
+    # entrypoint into /etc/nginx/includes/oauth-mcp.conf (included above),
+    # because what they must do depends on the deployment:
+    #   - BACKEND_URL set (same-origin): proxy to the backend, whose metadata
+    #     is built from MCP_BASE_URL and therefore names this deployment.
+    #   - BACKEND_URL unset (split-domain): serve the static mirrors from
+    #     /app/.well-known/ — baked with the hosted deployment's URLs and
+    #     rewritten by the entrypoint to MCP_BASE_URL when that is set.
+    # Declaring them here as well would be a duplicate `location` and nginx
+    # would refuse to start.
 
     # MCP Server Card (SEP-1649 draft). Content-Type is inferred from the
     # .json extension via mime.types — this location just adds CORS + cache.

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -157,9 +157,11 @@ APPLICATION_PORT=8081
 # https://www.logo.dev.
 # VITE_LOGO_DEV_TOKEN=
 
-# MCP base URL advertised to external MCP clients. Same-origin mode does NOT
-# proxy /mcp (only /api), so set this to a reachable backend origin to use MCP;
-# leave unset otherwise.
+# MCP base URL advertised to external MCP clients (Claude, ChatGPT, ...).
+# Set it to the origin you reach the app on, e.g. https://money.example.com —
+# the frontend container proxies /mcp and the OAuth discovery endpoints to the
+# backend. Split-domain deployments set it to the backend's own origin instead.
+# Leave unset if you do not use MCP.
 # MCP_BASE_URL=
 
 # Point the SPA at a separate API origin (leave unset for same-origin mode).

--- a/self-hosting/docs/environment-reference.md
+++ b/self-hosting/docs/environment-reference.md
@@ -78,10 +78,18 @@ is not derivable from the DSN by the entrypoint, so a Sentry deployment that
 leaves this unset gets a `connect-src` that blocks every error report.
 
 `MCP_BASE_URL` is the URL the app advertises to external MCP clients (Claude
-Desktop, ChatGPT). In same-origin mode the frontend reverse-proxies only `/api`,
-**not** `/mcp`, so the advertised `<origin>/mcp` would 404. To use MCP, publish
-the backend on a reachable origin (e.g. split-domain mode, or a subdomain) and
-set `MCP_BASE_URL` to it. Leave it unset if you do not use MCP.
+Desktop, ChatGPT). In same-origin mode set it to the origin you reach the app on
+(`https://money.example.com`): the frontend container proxies `/mcp` and the
+OAuth discovery endpoints to the backend, and the backend builds its discovery
+documents from this value, so clients are pointed at your instance rather than
+the hosted one. In split-domain mode set it to the backend's own origin. Leave
+it unset if you do not use MCP.
+
+Whatever fronts the frontend container must pass these paths through to it
+unchanged, alongside `/api/`: `/mcp`, `/.well-known/oauth-authorization-server`,
+`/.well-known/oauth-protected-resource` (both also in their `/mcp`-suffixed
+form), and `/authorize`, `/token`, `/register`. A proxy that forwards only `/`
+and `/api/` already covers them; one with an explicit path allow-list does not.
 
 The `VITE_` prefix on the frontend keys above is historical: these are read from
 the container's env at start, not inlined at build time. `docker-compose.yml`

--- a/self-hosting/docs/reverse-proxies.md
+++ b/self-hosting/docs/reverse-proxies.md
@@ -22,6 +22,11 @@ no second port to configure.
   default, which makes large imports fail with a "413" or "Request Entity Too
   Large" error. If your proxy has an upload size (or request size) limit, raise
   it to at least 15 MB.
+- **Forward the whole domain, not a list of paths.** Everything the app needs
+  is on that one port, but it is more than `/` and `/api/`: MCP clients also
+  fetch `/mcp`, `/.well-known/oauth-*` and `/authorize`, `/token`, `/register`.
+  If you hand-wrote per-path rules, those requests land on the wrong place and
+  MCP silently connects to the hosted service instead of yours.
 - **Close the direct port.** Your proxy serves the app over HTTPS, but the
   plain-HTTP port `8080` is still open to anyone until you close it –
   see [setup-guide.md](setup-guide.md#3-behind-your-own-reverse-proxy), step 3.
@@ -43,6 +48,11 @@ open the Proxy Host's **Advanced** tab, add the line below, and save:
 ```
 client_max_body_size 15m;
 ```
+
+If you connect an MCP client (Claude, ChatGPT) and the sign-in page returns a
+**403**, turn **Block Common Exploits** off on the Proxy Host. Nginx Proxy
+Manager's exploit filter rejects the OAuth authorization URL because of its
+query string.
 
 Nginx Proxy Manager is almost always run as a container itself. If yours is,
 don't forward to `http://<host>:8080` – reach the app over the Docker network

--- a/self-hosting/frontend/docker-entrypoint.sh
+++ b/self-hosting/frontend/docker-entrypoint.sh
@@ -115,4 +115,127 @@ else
   : > "$API_PROXY_INCLUDE"
 fi
 
+# --- MCP endpoint + OAuth discovery metadata --------------------------------
+
+# MCP clients read /.well-known/oauth-authorization-server and
+# /.well-known/oauth-protected-resource to learn which authorization server to
+# talk to, then call /mcp. Both root and path-aware forms are served
+# (RFC 8414 3.1, RFC 9728 3.1) because clients differ in which they request.
+#
+# Same-origin deployments proxy them to the backend, which builds the documents
+# from MCP_BASE_URL and so names this deployment. Split-domain deployments have
+# no backend to proxy to here and serve the static mirrors baked into
+# /app/.well-known/ instead. The mirrors ship with the hosted deployment's
+# URLs, so when MCP_BASE_URL is set they are rewritten to it — otherwise a
+# client that asks this origin would be sent to the hosted service.
+OAUTH_MCP_INCLUDE="/etc/nginx/includes/oauth-mcp.conf"
+if [ -n "${BACKEND_URL-}" ]; then
+  cat > "$OAUTH_MCP_INCLUDE" <<EOF
+location = /mcp {
+  proxy_pass ${BACKEND_URL};
+  proxy_http_version 1.1;
+  proxy_set_header Host \$host;
+  proxy_set_header X-Real-IP \$remote_addr;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+  proxy_set_header X-Forwarded-Host \$host;
+  proxy_set_header Connection "";
+  # MCP responses stream over SSE; buffering would stall them.
+  proxy_buffering off;
+  proxy_read_timeout 3600s;
+}
+# Clients differ on whether the pasted MCP URL keeps a trailing slash; without
+# this a "/mcp/" connector lands on the SPA fallback and fails confusingly.
+location = /mcp/ {
+  rewrite ^ /mcp last;
+}
+
+# Claude.ai ignores the endpoints advertised in the metadata and calls
+# /authorize, /token and /register on the origin root. The backend answers
+# those with 307s to their real /api/v1/auth/oauth2/* paths.
+location = /authorize {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+location = /token {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+location = /register {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+
+location = /.well-known/oauth-authorization-server {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+location = /.well-known/oauth-authorization-server/mcp {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+location = /.well-known/oauth-protected-resource {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+location = /.well-known/oauth-protected-resource/mcp {
+  proxy_pass ${BACKEND_URL};
+  proxy_set_header Host \$host;
+  proxy_set_header X-Forwarded-Proto \$scheme;
+}
+EOF
+else
+  # The sed pattern must match the issuer baked into the mirror files
+  # (packages/frontend/public/.well-known/). On the hosted deployment
+  # MCP_BASE_URL equals that issuer, so the rewrite is a no-op there.
+  if [ -n "$MCP_BASE_URL" ]; then
+    for doc in /app/.well-known/oauth-authorization-server /app/.well-known/oauth-protected-resource; do
+      sed "s|https://mcp\.moneymatter\.app|${MCP_BASE_URL%/}|g" "$doc" > "$doc.tmp"
+      mv "$doc.tmp" "$doc"
+    done
+  fi
+
+  cat > "$OAUTH_MCP_INCLUDE" <<'EOF'
+location = /.well-known/oauth-authorization-server {
+  root /app;
+  default_type "application/json";
+  add_header Access-Control-Allow-Origin "*" always;
+  add_header Cache-Control "public, max-age=3600" always;
+  add_header X-Content-Type-Options "nosniff" always;
+}
+location = /.well-known/oauth-authorization-server/mcp {
+  root /app;
+  try_files /.well-known/oauth-authorization-server =404;
+  default_type "application/json";
+  add_header Access-Control-Allow-Origin "*" always;
+  add_header Cache-Control "public, max-age=3600" always;
+  add_header X-Content-Type-Options "nosniff" always;
+}
+location = /.well-known/oauth-protected-resource {
+  root /app;
+  default_type "application/json";
+  add_header Access-Control-Allow-Origin "*" always;
+  add_header Cache-Control "public, max-age=3600" always;
+  add_header X-Content-Type-Options "nosniff" always;
+}
+location = /.well-known/oauth-protected-resource/mcp {
+  root /app;
+  try_files /.well-known/oauth-protected-resource =404;
+  default_type "application/json";
+  add_header Access-Control-Allow-Origin "*" always;
+  add_header Cache-Control "public, max-age=3600" always;
+  add_header X-Content-Type-Options "nosniff" always;
+}
+EOF
+fi
+
 exec "$@"


### PR DESCRIPTION
The frontend container served static OAuth discovery documents naming the hosted instance and had no `/mcp` route, so self-hosted MCP clients silently authenticated against the cloud. Closes #429