### PR TITLE
Prevent DB constraint errors on archived accounts and txs

### DIFF
--- a/packages/backend/src/services/accounts.service.ts
+++ b/packages/backend/src/services/accounts.service.ts
@@ -36,6 +36,7 @@ import { Op } from 'sequelize';
 
 import { archiveAccount as performArchiveSideEffects } from './accounts/archive-account';
 import { restampRefInitialBalance } from './accounts/restamp-ref-initial-balance';
+import { unlinkSubscriptionsFromAccount } from './accounts/unlink-subscriptions-from-account';
 import { withTransaction } from './common/with-transaction';
 
 type AccountWithRelinkStatus = Accounts.default & {
@@ -425,6 +426,11 @@ const deleteAccountByIdInTx = withTransaction(
     // about-to-be-cascaded leg on this account. Same transaction as the destroy, so a
     // failure rolls everything back together.
     await convertCrossUserTransfersForAccountIds({ accountIds: [id], ownerUserId: userId });
+
+    // The destroy cascades `Subscriptions.accountId` to NULL at the DB level, which trips
+    // the auto-record check constraint on any subscription still booking into this account.
+    // Clearing both columns first is the only way to satisfy it — the cascade can't.
+    await unlinkSubscriptionsFromAccount({ accountId: id });
 
     const affectedRows = await Accounts.deleteAccountById({ id, userId });
     if (affectedRows === 0) {

--- a/packages/backend/src/services/accounts/archive-account.e2e.ts
+++ b/packages/backend/src/services/accounts/archive-account.e2e.ts
@@ -214,6 +214,37 @@ describe('Account archiving (PUT /accounts/:id)', () => {
         });
         expect(updatedSubscription.accountId ?? null).toBeNull();
       });
+
+      it('turns auto-record off when unlinking, since auto-record requires an account', async () => {
+        const account = await helpers.createAccount({
+          payload: helpers.buildAccountPayload(),
+          raw: true,
+        });
+
+        const subscription = await helpers.createSubscription({
+          name: 'Auto-record Subscription',
+          frequency: SUBSCRIPTION_FREQUENCIES.monthly,
+          startDate: new Date().toISOString(),
+          accountId: account.id,
+          expectedAmount: 10,
+          expectedCurrencyCode: account.currencyCode,
+          autoRecord: true,
+          raw: true,
+        });
+
+        const response = await helpers.updateAccount({
+          id: account.id,
+          payload: { status: ACCOUNT_STATUSES.archived },
+        });
+
+        expect(response.statusCode).toBe(200);
+
+        const updatedSubscription = await helpers.getSubscriptionById({
+          id: String(subscription.id),
+          raw: true,
+        });
+        expect(updatedSubscription.accountId ?? null).toBeNull();
+      });
     });
 
     describe('Idempotent archiving', () => {

--- a/packages/backend/src/services/accounts/archive-account.ts
+++ b/packages/backend/src/services/accounts/archive-account.ts
@@ -1,8 +1,8 @@
 import AccountGrouping from '@models/accounts-groups/account-grouping.model';
 import Accounts from '@models/accounts.model';
-import Subscriptions from '@models/subscriptions.model';
 
 import { unlinkAccountFromBankConnection } from './unlink-from-bank-connection';
+import { unlinkSubscriptionsFromAccount } from './unlink-subscriptions-from-account';
 
 interface ArchiveAccountPayload {
   account: Accounts;
@@ -33,5 +33,5 @@ export const archiveAccount = async ({ account, userId }: ArchiveAccountPayload)
   await AccountGrouping.destroy({ where: { accountId } });
 
   // 3. Unlink subscriptions
-  await Subscriptions.update({ accountId: null }, { where: { accountId } });
+  await unlinkSubscriptionsFromAccount({ accountId });
 };

--- a/packages/backend/src/services/accounts/delete-account.e2e.ts
+++ b/packages/backend/src/services/accounts/delete-account.e2e.ts
@@ -1,4 +1,9 @@
-import { API_ERROR_CODES, TRANSACTION_TRANSFER_NATURE, type RecordId } from '@bt/shared/types';
+import {
+  API_ERROR_CODES,
+  SUBSCRIPTION_FREQUENCIES,
+  TRANSACTION_TRANSFER_NATURE,
+  type RecordId,
+} from '@bt/shared/types';
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import * as helpers from '@tests/helpers';
 
@@ -199,6 +204,35 @@ describe('Delete Account', () => {
 
       const accountsAfter = await helpers.getAccounts();
       expect(accountsAfter.some((acc) => acc.id === sourceAccount.id)).toBe(true);
+    });
+  });
+
+  describe('Account deletion with subscriptions', () => {
+    it('deletes an account whose subscription has auto-record enabled', async () => {
+      const account = await helpers.createAccount({ raw: true });
+
+      const subscription = await helpers.createSubscription({
+        name: 'Auto-record Subscription',
+        frequency: SUBSCRIPTION_FREQUENCIES.monthly,
+        startDate: new Date().toISOString(),
+        accountId: account.id,
+        expectedAmount: 10,
+        expectedCurrencyCode: account.currencyCode,
+        autoRecord: true,
+        raw: true,
+      });
+
+      const response = await helpers.deleteAccount({ id: account.id, raw: false });
+      expect(response.statusCode).toBe(200);
+
+      const accountsAfter = await helpers.getAccounts();
+      expect(accountsAfter.some((acc) => acc.id === account.id)).toBe(false);
+
+      const updatedSubscription = await helpers.getSubscriptionById({
+        id: String(subscription.id),
+        raw: true,
+      });
+      expect(updatedSubscription.accountId ?? null).toBeNull();
     });
   });
 });

--- a/packages/backend/src/services/accounts/unlink-subscriptions-from-account.ts
+++ b/packages/backend/src/services/accounts/unlink-subscriptions-from-account.ts
@@ -1,0 +1,12 @@
+import Subscriptions from '@models/subscriptions.model';
+
+/**
+ * Detaches every subscription from an account that is going away (archived or
+ * deleted). `autoRecord` is cleared in the same write because the
+ * `chk_subscriptions_auto_record_requires_booking_inputs` check constraint
+ * requires an `accountId` whenever auto-record is on — nulling the account
+ * alone makes the row unsaveable.
+ */
+export const unlinkSubscriptionsFromAccount = async ({ accountId }: { accountId: string }) => {
+  await Subscriptions.update({ accountId: null, autoRecord: false }, { where: { accountId } });
+};

--- a/packages/backend/src/services/subscriptions/detect-candidates.e2e.ts
+++ b/packages/backend/src/services/subscriptions/detect-candidates.e2e.ts
@@ -689,6 +689,49 @@ describe('Subscription Candidate Detection', () => {
       }
     });
 
+    it('skips sample transactions that were deleted after detection', async () => {
+      const account = await helpers.createAccount({ raw: true });
+
+      const txs = await createRecurringTransactions({
+        accountId: account.id,
+        note: 'VANISHING SERVICE',
+        amount: 9,
+        count: 4,
+        intervalDays: 30,
+      });
+
+      const detection = await helpers.detectSubscriptionCandidates({ raw: true });
+      const candidate = detection.candidates.find((c) => c.suggestedName.includes('VANISHING'))!;
+      expect(candidate.sampleTransactionIds).toContain(txs[0]!.id);
+
+      const deletedTx = txs[0]!;
+      await helpers.deleteTransaction({ id: deletedTx.id });
+
+      const sub = await helpers.createSubscription({
+        name: 'Vanishing Service',
+        expectedAmount: 9,
+        expectedCurrencyCode: account.currencyCode,
+        frequency: SUBSCRIPTION_FREQUENCIES.monthly,
+        startDate: '2025-01-01',
+        raw: true,
+      });
+
+      const response = await helpers.acceptSubscriptionCandidate({
+        id: candidate.id,
+        subscriptionId: sub.id,
+      });
+
+      expect(response.statusCode).toBe(200);
+
+      const subDetail = await helpers.getSubscriptionById({ id: sub.id, raw: true });
+      const linkedTxIds = subDetail.transactions.map((t) => t.id);
+
+      expect(linkedTxIds).not.toContain(deletedTx.id);
+      for (const tx of txs.slice(1)) {
+        expect(linkedTxIds).toContain(tx.id);
+      }
+    });
+
     it('skips transactions that are already linked to another subscription', async () => {
       const account = await helpers.createAccount({ raw: true });
 

--- a/packages/backend/src/services/subscriptions/resolve-candidate.ts
+++ b/packages/backend/src/services/subscriptions/resolve-candidate.ts
@@ -3,6 +3,7 @@ import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
 import { ConflictError } from '@js/errors';
 import SubscriptionCandidates from '@models/subscription-candidates.model';
 import SubscriptionTransactions from '@models/subscription-transactions.model';
+import Transactions from '@models/transactions.model';
 import { withTransaction } from '@services/common/with-transaction';
 import { Op } from 'sequelize';
 
@@ -41,6 +42,17 @@ export const resolveCandidate = withTransaction(
       const sampleTxIds = candidate.sampleTransactionIds ?? [];
 
       if (sampleTxIds.length > 0) {
+        // `sampleTransactionIds` is a snapshot taken at detection time. Any of those
+        // transactions may have been deleted since (directly, or cascaded from an
+        // account delete), so link only the ones that still exist.
+        const existing = await Transactions.findAll({
+          where: { id: { [Op.in]: sampleTxIds }, userId },
+          attributes: ['id'],
+          raw: true,
+        });
+        const existingTxIdSet = new Set(existing.map((tx) => tx.id));
+        const existingTxIds = sampleTxIds.filter((id) => existingTxIdSet.has(id));
+
         const alreadyLinked = await SubscriptionTransactions.findAll({
           where: {
             transactionId: { [Op.in]: sampleTxIds },
@@ -51,7 +63,7 @@ export const resolveCandidate = withTransaction(
         });
 
         const alreadyLinkedSet = new Set(alreadyLinked.map((l) => l.transactionId));
-        const newTxIds = sampleTxIds.filter((id) => !alreadyLinkedSet.has(id));
+        const newTxIds = existingTxIds.filter((id) => !alreadyLinkedSet.has(id));
 
         if (newTxIds.length > 0) {
           await SubscriptionTransactions.bulkCreate(


### PR DESCRIPTION
Archiving or deleting an account left auto-record subscriptions in a state the check constraint rejects, and accepting a candidate linked sample transactions that no longer exist

Fixes MONEY-MATTER-BACKEND-9P
Fixes MONEY-MATTER-BACKEND-9Q
Fixes MONEY-MATTER-BACKEND-9R