### PR TITLE
fix(ai): cap model output and reject truncated extractions

### DIFF
--- a/packages/backend/src/services/ai-categorization/categorization-service.ts
+++ b/packages/backend/src/services/ai-categorization/categorization-service.ts
@@ -13,6 +13,7 @@ import Payees from '@models/payees.model';
 import Transactions from '@models/transactions.model';
 import {
   AIClientResult,
+  AI_MAX_OUTPUT_TOKENS,
   type AiCallFailureKind,
   CUSTOM_ENDPOINT_UNREACHABLE_ERROR_MESSAGE,
   aiCallGuards,
@@ -20,6 +21,7 @@ import {
   classifyAiCallFailure,
   createAIClient,
   describeMissingAiConfiguration,
+  hitOutputCeiling,
   markCustomEndpointUnreachable,
 } from '@services/ai';
 import { sseManager } from '@services/common/sse';
@@ -122,12 +124,18 @@ async function categorizeBatch({
     // A hung or trickling endpoint must abort instead of pinning a worker slot forever.
     const { abortSignal, maxRetries } = aiCallGuards({ provider: aiClient.provider });
 
+    // A batch is up to BATCH_SIZE transactions and the model answers one line per
+    // transaction, which can outgrow a provider's default output cap. Anything the
+    // reply omits is already reported as `failed` below and retried, so a cut-off
+    // response costs a retry rather than miscategorising -- but the cap still has to
+    // be raised, or a large batch can never complete.
     const { text, usage, finishReason } = await generateText({
       model: aiClient.model,
       system: systemPrompt,
       prompt: userMessage,
       abortSignal,
       maxRetries,
+      maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
     });
 
     const inputTokens = usage?.inputTokens ?? 0;
@@ -168,7 +176,13 @@ async function categorizeBatch({
     // declined them (prose refusals land here wholesale). Any other finish — truncation,
     // content filter, provider error, empty text — proves nothing about those rows, and
     // the skip stamp is permanent, so they stay candidates for the next run instead.
-    const completedNormally = finishReason === 'stop' && text.trim().length > 0;
+    //
+    // `finishReason` alone would miss the truncation case: a gateway that cuts a reply
+    // off at the output ceiling can still report `stop`, and that answer would then
+    // stamp every unanswered row as a permanent skip. `hitOutputCeiling` also treats
+    // spending the whole allowance as being cut off at it.
+    const completedNormally =
+      finishReason === 'stop' && text.trim().length > 0 && !hitOutputCeiling({ finishReason, usage });
     const failed: string[] = [];
     for (const transaction of transactions) {
       if (successfulIds.has(transaction.id) || skipReasonById.has(transaction.id)) continue;

--- a/packages/backend/src/services/ai/ai-output-limit.ts
+++ b/packages/backend/src/services/ai/ai-output-limit.ts
@@ -1,0 +1,42 @@
+import type { FinishReason, LanguageModelUsage } from 'ai';
+
+/**
+ * Ceiling for the model's own output, in tokens.
+ *
+ * Every row-emitting AI call needs one. Left unset, the provider applies its
+ * own default -- 4096 tokens on some OpenAI-compatible gateways -- and a long
+ * statement outgrows it. Reasoning models make this sharper: thinking is billed
+ * as output and is spent *before* any rows are emitted, so the whole allowance
+ * can go on reasoning and the response comes back empty.
+ *
+ * 32k leaves room for reasoning plus a long CSV body while staying inside the
+ * per-response output limit of the models these features are used with.
+ */
+export const AI_MAX_OUTPUT_TOKENS = 32_000;
+
+/**
+ * Whether a response was cut off at the output ceiling rather than finished.
+ *
+ * `finishReason` alone is not enough. An OpenAI-compatible gateway sitting in
+ * front of another provider can report `stop` on a response it truncated
+ * itself, so the token count is checked too: spending the entire allowance is
+ * only explicable as having been cut off at it.
+ *
+ * This matters because truncated output is not obviously broken. A cut-off CSV
+ * still parses cleanly up to the cut, so the rows that never arrived are
+ * indistinguishable from rows the document never had -- a silently partial
+ * import rather than a visible failure.
+ */
+export function hitOutputCeiling({
+  finishReason,
+  usage,
+}: {
+  finishReason: FinishReason;
+  usage: LanguageModelUsage | undefined;
+}): boolean {
+  return finishReason === 'length' || (usage?.outputTokens ?? 0) >= AI_MAX_OUTPUT_TOKENS;
+}
+
+/** Shared wording, so every parser explains a truncated response the same way. */
+export const AI_OUTPUT_TRUNCATED_MESSAGE =
+  'The document is too long to transcribe in a single response. Please import it in smaller parts.';

--- a/packages/backend/src/services/ai/ai-output-limit.unit.ts
+++ b/packages/backend/src/services/ai/ai-output-limit.unit.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import type { LanguageModelUsage } from 'ai';
+
+import { AI_MAX_OUTPUT_TOKENS, hitOutputCeiling } from './ai-output-limit';
+
+function buildUsage({ outputTokens }: { outputTokens: number | undefined }): LanguageModelUsage {
+  return {
+    inputTokens: 1200,
+    inputTokenDetails: { noCacheTokens: 1200, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    outputTokens,
+    outputTokenDetails: { textTokens: outputTokens, reasoningTokens: 0 },
+    totalTokens: 1200 + (outputTokens ?? 0),
+  };
+}
+
+describe('hitOutputCeiling', () => {
+  it('detects the provider reporting the cut-off itself', () => {
+    expect(hitOutputCeiling({ finishReason: 'length', usage: buildUsage({ outputTokens: 4096 }) })).toBe(true);
+  });
+
+  it('treats spending the whole allowance as a cut-off even when the reason says otherwise', () => {
+    // A gateway fronting another provider can truncate and still report a normal stop,
+    // which is the case a finishReason-only check misses.
+    expect(hitOutputCeiling({ finishReason: 'stop', usage: buildUsage({ outputTokens: AI_MAX_OUTPUT_TOKENS }) })).toBe(
+      true,
+    );
+  });
+
+  it('passes a reply that finished well inside the allowance', () => {
+    // Normal extraction runs land in the low thousands.
+    expect(hitOutputCeiling({ finishReason: 'stop', usage: buildUsage({ outputTokens: 4984 }) })).toBe(false);
+  });
+
+  it('does not accuse a response whose usage the provider omitted', () => {
+    expect(hitOutputCeiling({ finishReason: 'stop', usage: undefined })).toBe(false);
+    expect(hitOutputCeiling({ finishReason: 'stop', usage: buildUsage({ outputTokens: undefined }) })).toBe(false);
+  });
+
+  it('reports a cut-off on length even when usage is missing', () => {
+    expect(hitOutputCeiling({ finishReason: 'length', usage: undefined })).toBe(true);
+  });
+
+  it('leaves other abnormal finishes to their own handling', () => {
+    // `error` and `content-filter` are real failures, but not truncation, and the
+    // callers classify them separately.
+    expect(hitOutputCeiling({ finishReason: 'content-filter', usage: buildUsage({ outputTokens: 12 }) })).toBe(false);
+    expect(hitOutputCeiling({ finishReason: 'error', usage: buildUsage({ outputTokens: 0 }) })).toBe(false);
+  });
+});

--- a/packages/backend/src/services/ai/index.ts
+++ b/packages/backend/src/services/ai/index.ts
@@ -1,5 +1,6 @@
 export { createAIClient, type AIClientResult } from './ai-client-factory';
 export { aiCallGuards } from './ai-call-guards';
+export { AI_MAX_OUTPUT_TOKENS, AI_OUTPUT_TRUNCATED_MESSAGE, hitOutputCeiling } from './ai-output-limit';
 export { buildModelNotServedMessage, classifyAiCallFailure, type AiCallFailureKind } from './ai-error-classifiers';
 export {
   CUSTOM_ENDPOINT_UNREACHABLE_ERROR_MESSAGE,

--- a/packages/backend/src/services/import-export/core/ai-extraction-failure.ts
+++ b/packages/backend/src/services/import-export/core/ai-extraction-failure.ts
@@ -11,7 +11,13 @@ import { markApiKeyInvalid } from '@services/user-settings/ai-api-key';
 import { markCustomEndpointInvalid } from '@services/user-settings/ai-custom-endpoint';
 
 export interface AIExtractionError {
-  code: 'NO_AI_CONFIGURED' | 'AI_ERROR' | 'EXTRACTION_FAILED' | 'NO_TRANSACTIONS_FOUND' | 'RATE_LIMITED';
+  code:
+    | 'NO_AI_CONFIGURED'
+    | 'AI_ERROR'
+    | 'EXTRACTION_FAILED'
+    | 'NO_TRANSACTIONS_FOUND'
+    | 'RATE_LIMITED'
+    | 'OUTPUT_TRUNCATED';
   message: string;
   details?: string;
 }

--- a/packages/backend/src/services/import-export/investment-transactions-parser/ai-extraction.service.ts
+++ b/packages/backend/src/services/import-export/investment-transactions-parser/ai-extraction.service.ts
@@ -2,7 +2,14 @@
  * AI extraction for investment transactions.
  */
 import { AI_FEATURE } from '@bt/shared/types';
-import { aiCallGuards, createAIClient, describeMissingAiConfiguration } from '@services/ai';
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_OUTPUT_TRUNCATED_MESSAGE,
+  aiCallGuards,
+  createAIClient,
+  describeMissingAiConfiguration,
+  hitOutputCeiling,
+} from '@services/ai';
 import { type AIExtractionError, resolveAiExtractionFailure } from '@services/import-export/core/ai-extraction-failure';
 import { generateText } from 'ai';
 
@@ -57,13 +64,30 @@ export async function extractInvestmentTransactionsWithAI({
 
     const { abortSignal, maxRetries } = aiCallGuards({ provider: aiClient.provider });
 
-    const { text: responseText, usage } = await generateText({
+    const {
+      text: responseText,
+      usage,
+      finishReason,
+    } = await generateText({
       model: aiClient.model,
       system: systemPrompt,
       prompt: createTextExtractionPrompt({ text }),
       abortSignal,
       maxRetries,
+      maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
     });
+
+    // Truncated rows parse as a complete-looking but short import, so refuse them.
+    if (hitOutputCeiling({ finishReason, usage })) {
+      return {
+        success: false,
+        error: {
+          code: 'OUTPUT_TRUNCATED',
+          message: AI_OUTPUT_TRUNCATED_MESSAGE,
+          details: `Generation stopped at the ${AI_MAX_OUTPUT_TOKENS}-token output limit (used ${usage?.outputTokens ?? 0}, finishReason: ${finishReason}).`,
+        },
+      };
+    }
 
     const { rows, droppedRowCount } = parseAIResponse({ response: responseText });
 

--- a/packages/backend/src/services/import-export/statement-parser/ai-extraction.service.ts
+++ b/packages/backend/src/services/import-export/statement-parser/ai-extraction.service.ts
@@ -9,7 +9,14 @@ import type {
 } from '@bt/shared/types';
 import { AI_FEATURE } from '@bt/shared/types';
 import { logger } from '@js/utils';
-import { aiCallGuards, createAIClient, describeMissingAiConfiguration } from '@services/ai';
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_OUTPUT_TRUNCATED_MESSAGE,
+  aiCallGuards,
+  createAIClient,
+  describeMissingAiConfiguration,
+  hitOutputCeiling,
+} from '@services/ai';
 import { type AIExtractionError, resolveAiExtractionFailure } from '@services/import-export/core/ai-extraction-failure';
 import { generateText } from 'ai';
 
@@ -56,15 +63,34 @@ export async function extractTransactionsWithAI({
 
     const { abortSignal, maxRetries } = aiCallGuards({ provider: aiClient.provider });
 
-    const { text: responseText, usage } = await generateText({
+    const {
+      text: responseText,
+      usage,
+      finishReason,
+    } = await generateText({
       model: aiClient.model,
       system: STATEMENT_EXTRACTION_SYSTEM_PROMPT,
       prompt: createTextExtractionPrompt({ text }),
       abortSignal,
       maxRetries,
+      maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
     });
 
-    logger.info('[Statement Parser] AI answered', { responseLength: responseText.length, usage });
+    logger.info('[Statement Parser] AI answered', { responseLength: responseText.length, usage, finishReason });
+
+    // A truncated CSV still parses cleanly up to the cut, so without this the
+    // transactions that never arrived would look exactly like transactions the
+    // statement never had -- a wrong balance instead of an error.
+    if (hitOutputCeiling({ finishReason, usage })) {
+      return {
+        success: false,
+        error: {
+          code: 'OUTPUT_TRUNCATED',
+          message: AI_OUTPUT_TRUNCATED_MESSAGE,
+          details: `Generation stopped at the ${AI_MAX_OUTPUT_TOKENS}-token output limit (used ${usage?.outputTokens ?? 0}, finishReason: ${finishReason}).`,
+        },
+      };
+    }
 
     // Parse AI response
     const parsed = parseAIResponse({ response: responseText });

--- a/packages/shared/src/types/investments/transactions-import.ts
+++ b/packages/shared/src/types/investments/transactions-import.ts
@@ -206,7 +206,9 @@ export interface InvestmentImportError {
     | 'AI_ERROR'
     | 'RATE_LIMITED'
     | 'TOKEN_LIMIT_EXCEEDED'
-    | 'NOT_IMPLEMENTED';
+    | 'NOT_IMPLEMENTED'
+    /** The model's reply was cut off at its output limit, so the rows are incomplete. */
+    | 'OUTPUT_TRUNCATED';
   message: string;
   details?: string;
 }

--- a/packages/shared/src/types/statement-parser.ts
+++ b/packages/shared/src/types/statement-parser.ts
@@ -123,7 +123,9 @@ export interface StatementExtractError {
     | 'NO_TRANSACTIONS_FOUND'
     | 'AI_ERROR'
     | 'RATE_LIMITED'
-    | 'TOKEN_LIMIT_EXCEEDED';
+    | 'TOKEN_LIMIT_EXCEEDED'
+    /** The model's reply was cut off at its output limit, so the rows are incomplete. */
+    | 'OUTPUT_TRUNCATED';
   /** Human-readable error message */
   message: string;
   /** Additional details */


### PR DESCRIPTION
Fixes #450.

### The bug

The AI calls that emit one row per transaction never pass `maxOutputTokens`, so the provider's own default applies. On an OpenAI-compatible gateway that default can be 4096 tokens, which this prompt outgrows on a statement of roughly 40+ rows.

Reasoning models make it sharper: thinking is billed as output and spent before any CSV is emitted, so the whole allowance can go on reasoning and the reply comes back empty. That surfaces as *"the output was not in expected format"*, which points at the parser instead of the token limit.

Truncation is the worse half, because it's silent. A cut-off CSV parses cleanly up to the cut, so rows that never arrived look exactly like rows the statement never had — a wrong balance rather than a visible failure. On a 59-transaction statement I saw 50 rows imported with no warning at all.

### The fix

New `services/ai/ai-output-limit.ts` holding the shared cap and one predicate:

```ts
export const AI_MAX_OUTPUT_TOKENS = 32_000;

export function hitOutputCeiling({ finishReason, usage }): boolean {
  return finishReason === 'length' || (usage?.outputTokens ?? 0) >= AI_MAX_OUTPUT_TOKENS;
}
```

The `outputTokens >= cap` half is not redundant. With a deliberate 200-token cap the gateway returned exactly 200 output tokens and `finishReason: "stop"` — a gateway fronting another provider can truncate and still report a normal stop, so a `finishReason`-only check never fires. Spending the entire allowance is treated as truncation on its own.

It lives under `services/ai/` rather than `import-export/core/` so `ai-categorization` can import it without depending on the import-export domain, and it sits next to `aiCallGuards`, which solves the same class of problem for timeouts.

Applied at all three unbounded call sites:

| Call site | Cap | Rejects on truncation |
|---|---|---|
| `statement-parser/ai-extraction.service.ts` | yes | yes — new `OUTPUT_TRUNCATED` |
| `investment-transactions-parser/ai-extraction.service.ts` | yes | yes — new `OUTPUT_TRUNCATED` |
| `ai-categorization/categorization-service.ts` | yes | no, deliberately |

Categorization gets the cap but no rejection: anything the reply omits is already reported as `failed` and retried, so a cut-off response costs a retry rather than miscategorising. It still needs the cap, though — `BATCH_SIZE = 500` means a full batch can never complete under a 4096-token default.

`OUTPUT_TRUNCATED` is added to the shared `AIExtractionError` union and to both API-contract unions in `packages/shared`, so the frontend can handle it as a distinct case.

### Why 32k

Comfortably above the largest realistic single statement while staying inside the output window of every model in the catalog. It's a ceiling for detecting runaway output, not a target — normal runs land in the 3–5k range.

### Verified

Same statement, same model, through the real SDK path:

```
no cap:      transactions=50/59   outputTokens=4096   finishReason=stop
cap 32000:   transactions=59/59   outputTokens=4984   finishReason=stop
```

The `finishReason=stop` on both lines is the point — the before case was truncated and said so nowhere.

Also running in production on a self-hosted instance, where it fixed the reported statement.

### Checks

- `tsc --noEmit` (backend) — 0 errors
- `vue-tsc --noEmit` (frontend) — 0 errors
- backend + frontend lint — clean
- `test:unit` — 117 suites, 1599 passed, 15 skipped
- `knip` — clean
- `npm run format` — no changes

### Note

Separate from #449, which is a frontend-only change. No overlapping files.
