### PR TITLE
fix: Bank sync issues

### DIFF
--- a/packages/backend/src/controllers/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/controllers/accounts/link-to-bank-connection.ts
@@ -25,10 +25,8 @@ export default createController(
       data: {
         account: result.account,
         balanceDifference: result.balanceDifference,
-        balanceAdjustmentTransaction: result.balanceAdjustmentTransaction || null,
-        message: result.balanceAdjustmentTransaction
-          ? `Account linked successfully. Balance adjusted by ${result.balanceDifference}.`
-          : 'Account linked successfully.',
+        balanceAdjustmentTransaction: null,
+        message: 'Account linked successfully.',
       },
     };
   },

--- a/packages/backend/src/services/accounts/absorb-balance-adjustment.ts
+++ b/packages/backend/src/services/accounts/absorb-balance-adjustment.ts
@@ -5,7 +5,7 @@ import { logger } from '@js/utils/logger';
 import Accounts, * as AccountsModel from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import { namespace } from '@models/connection';
-import { assertNotDedicatedFlowAccount } from '@services/import-export/core/dedicated-flow-guard';
+import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
 
 import { withTransaction } from '../common/with-transaction';
 import { measureSpotRefBalance } from './measure-spot-ref-balance';
@@ -53,7 +53,7 @@ export const absorbBalanceAdjustment = withTransaction(
     if (!account) {
       throw new ValidationError({ message: `Account with ID ${accountId} not found` });
     }
-    assertNotDedicatedFlowAccount({ account, actionPhrase: 'take a balance adjustment' });
+    assertNotDerivedBalanceAccount({ account, actionPhrase: 'take a balance adjustment' });
 
     const isSystem = account.type === ACCOUNT_TYPES.system;
     const newCurrentBalance = account.currentBalance.add(amountDelta);

--- a/packages/backend/src/services/accounts/absorb-balance-adjustment.unit.ts
+++ b/packages/backend/src/services/accounts/absorb-balance-adjustment.unit.ts
@@ -127,7 +127,7 @@ beforeEach(() => {
   updateAccountByIdMock.mockResolvedValue({ id: 'updated-sentinel' } as never);
   // 1:1 spot conversion – ref assertions read as plain native numbers.
   calculateRefAmountMock.mockImplementation(async ({ amount }) => amount);
-  restampMock.mockResolvedValue(undefined as never);
+  restampMock.mockResolvedValue('restamped');
   setTodayRowToSpotMock.mockResolvedValue(undefined as never);
 });
 

--- a/packages/backend/src/services/accounts/absorb-link-residual.ts
+++ b/packages/backend/src/services/accounts/absorb-link-residual.ts
@@ -1,0 +1,139 @@
+import { type AccountExternalData, TRANSACTION_TYPES } from '@bt/shared/types';
+import { Money } from '@common/types/money';
+import { UnexpectedError } from '@js/errors';
+import { logger } from '@js/utils/logger';
+import Accounts from '@models/accounts.model';
+import Balances from '@models/balances.model';
+import { namespace } from '@models/connection';
+import Transactions from '@models/transactions.model';
+import { restampRefInitialBalance } from '@services/accounts/restamp-ref-initial-balance';
+import { withTransaction } from '@services/common/with-transaction';
+import { QueryTypes } from 'sequelize';
+
+/**
+ * Restores `initialBalance + Σsigned(tx) = currentBalance` after a post-link
+ * sync force-wrote the bank balance. Only the opening balance moves: the bank
+ * owns `currentBalance`, and the residual is history the provider never handed
+ * us. Returns the absorbed residual in cents.
+ */
+export const absorbLinkResidualIntoOpeningBalance = withTransaction(
+  async ({ accountId, userId }: { accountId: string; userId: number }): Promise<number> => {
+    const sequelizeTx = namespace.get('transaction');
+
+    // Lock before summing: a concurrent sync blocks on this row lock, so summing
+    // first would pair a pre-sync ledger sum with a post-sync currentBalance and
+    // absorb the concurrent delta into the opening balance.
+    const account = await Accounts.findOne({
+      where: { id: accountId, userId },
+      transaction: sequelizeTx,
+      lock: sequelizeTx?.LOCK.UPDATE,
+    });
+    if (!account) {
+      logger.error(
+        {
+          message: 'Account missing when absorbing the post-link balance residual',
+          error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
+        },
+        { code: 'ACCOUNT_LINK_RESIDUAL_ACCOUNT_MISSED', accountId, userId },
+      );
+      return 0;
+    }
+
+    const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
+      `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
+       FROM "Transactions" WHERE "accountId" = :accountId`,
+      {
+        replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
+        type: QueryTypes.SELECT,
+        transaction: sequelizeTx,
+      },
+    );
+
+    const signedSumCents = Number(row?.signedSum ?? 0);
+    const initialBalanceBefore = account.initialBalance;
+    const identityGapCents = account.currentBalance.toCents() - (initialBalanceBefore.toCents() + signedSumCents);
+    if (identityGapCents === 0) return 0;
+
+    const initialBalanceAfter = initialBalanceBefore.add(Money.fromCents(identityGapCents));
+    await Accounts.update({ initialBalance: initialBalanceAfter }, { where: { id: accountId, userId } });
+
+    // A failed restamp would pair the moved opening balance with a stale
+    // base-currency stamp; throw so the whole absorb rolls back.
+    const restampOutcome = await restampRefInitialBalance({ accountId, allowProviderAccount: true });
+    if (restampOutcome === 'failed') {
+      throw new UnexpectedError({
+        message:
+          'Failed to restate the opening balance in the base currency; the link was not applied. Please try again.',
+      });
+    }
+
+    // The restamp cascade shifts every Balances row, including today's, which the
+    // sync pinned to the bank's authoritative balance. Re-pin it from the
+    // post-restamp row.
+    const restamped = await Accounts.findOne({ where: { id: accountId, userId }, transaction: sequelizeTx });
+    if (restamped) {
+      await Balances.setTodayRowToSpot({ account: restamped });
+    } else {
+      logger.error(
+        {
+          message: 'Account re-read after restampRefInitialBalance missed; the current-day balance row stays cascaded',
+          error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
+        },
+        { code: 'ACCOUNT_LINK_RESIDUAL_REREAD_MISSED', accountId, userId },
+      );
+    }
+
+    logger.info('Absorbed post-link balance residual into the opening balance', {
+      accountId,
+      userId,
+      signedSumCents,
+      identityGapCents,
+      initialBalanceBeforeCents: initialBalanceBefore.toCents(),
+      initialBalanceAfterCents: initialBalanceAfter.toCents(),
+    });
+
+    return identityGapCents;
+  },
+);
+
+/**
+ * Runs the absorb that linking deferred via `pendingAbsorb` (queue-synced
+ * providers persist nothing inline, so no residual exists until the worker
+ * finishes) and records the outcome in the reconciliation snapshot. Without
+ * the marker it no-ops returning null, so it is safe after every sync group.
+ */
+export const runPendingLinkAbsorb = withTransaction(
+  async ({ accountId, userId }: { accountId: string; userId: number }): Promise<number | null> => {
+    const account = await Accounts.findOne({ where: { id: accountId, userId } });
+    const externalData = (account?.externalData ?? {}) as AccountExternalData;
+    const reconciliation = externalData.bankConnection?.balanceReconciliation;
+
+    if (!account || !reconciliation?.pendingAbsorb) return null;
+
+    const absorbedResidual = await absorbLinkResidualIntoOpeningBalance({ accountId, userId });
+
+    // Re-read: the absorb rewrote initialBalance behind this instance.
+    const fresh = await Accounts.findOne({ where: { id: accountId, userId } });
+    if (!fresh) return absorbedResidual;
+
+    const freshExternalData = (fresh.externalData ?? {}) as AccountExternalData;
+    const freshConnectionMeta = freshExternalData.bankConnection;
+    if (!freshConnectionMeta) return absorbedResidual;
+
+    await fresh.update({
+      externalData: {
+        ...freshExternalData,
+        bankConnection: {
+          ...freshConnectionMeta,
+          balanceReconciliation: {
+            ...freshConnectionMeta.balanceReconciliation,
+            pendingAbsorb: false,
+            ...(absorbedResidual !== 0 ? { absorbedResidual } : {}),
+          },
+        },
+      },
+    });
+
+    return absorbedResidual;
+  },
+);

--- a/packages/backend/src/services/accounts/absorb-link-residual.unit.ts
+++ b/packages/backend/src/services/accounts/absorb-link-residual.unit.ts
@@ -1,0 +1,424 @@
+import type { AccountExternalData } from '@bt/shared/types';
+import { generateRandomRecordId } from '@common/lib/record-id-helpers';
+import { Money } from '@common/types/money';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { UnexpectedError } from '@js/errors';
+
+// ── Mocks (hoisted before importing the module under test) ──────────────────
+
+// The service locks/re-reads the account through the model's default export and
+// moves the opening balance through the static `update`.
+jest.mock('@models/accounts.model', () => ({
+  __esModule: true,
+  default: { findOne: jest.fn(), update: jest.fn() },
+}));
+// The ledger sum is a raw SELECT off the Transactions model's sequelize handle,
+// which is undefined outside an initialized connection.
+jest.mock('@models/transactions.model', () => ({
+  __esModule: true,
+  default: { sequelize: { query: jest.fn() } },
+}));
+jest.mock('./restamp-ref-initial-balance', () => ({
+  __esModule: true,
+  restampRefInitialBalance: jest.fn(),
+}));
+jest.mock('@models/balances.model', () => ({
+  __esModule: true,
+  default: { setTodayRowToSpot: jest.fn() },
+}));
+jest.mock('@js/utils/logger', () => ({
+  __esModule: true,
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+// `withTransaction` runs the body inside `connection.sequelize.transaction` when
+// no ambient CLS transaction exists. The stub runs the callback straight through
+// and reports no ambient transaction, so the row-lock read passes
+// `transaction: undefined` and `lock: undefined`.
+jest.mock('@models/connection', () => ({
+  __esModule: true,
+  connection: {
+    sequelize: {
+      transaction: (cb: () => Promise<unknown>) => cb(),
+    },
+  },
+  namespace: { get: () => undefined },
+}));
+
+import { logger } from '@js/utils/logger';
+/* eslint-disable import/first */
+import Accounts from '@models/accounts.model';
+import Balances from '@models/balances.model';
+import Transactions from '@models/transactions.model';
+
+import { absorbLinkResidualIntoOpeningBalance, runPendingLinkAbsorb } from './absorb-link-residual';
+import { restampRefInitialBalance } from './restamp-ref-initial-balance';
+/* eslint-enable import/first */
+
+const findOneMock = jest.mocked(Accounts.findOne);
+const accountsUpdateMock = jest.mocked(Accounts.update);
+const queryMock = jest.mocked(Transactions.sequelize!.query);
+const restampMock = jest.mocked(restampRefInitialBalance);
+const setTodayRowToSpotMock = jest.mocked(Balances.setTodayRowToSpot);
+const loggerErrorMock = jest.mocked(logger.error);
+
+type AccountRow = InstanceType<typeof Accounts>;
+
+const USER_ID = 42;
+
+function buildAccount({
+  id = generateRandomRecordId(),
+  currentBalance = Money.zero(),
+  initialBalance = Money.zero(),
+  externalData = null,
+}: {
+  id?: string;
+  currentBalance?: Money;
+  initialBalance?: Money;
+  externalData?: AccountExternalData | null;
+} = {}): AccountRow & { update: jest.Mock } {
+  return {
+    id,
+    currentBalance,
+    initialBalance,
+    externalData,
+    update: jest.fn(async () => undefined),
+  } as unknown as AccountRow & { update: jest.Mock };
+}
+
+function buildReconciliation({
+  pendingAbsorb,
+  extra = {},
+}: {
+  pendingAbsorb?: boolean;
+  extra?: Record<string, unknown>;
+} = {}): AccountExternalData {
+  return {
+    someUnrelatedKey: 'keep-me',
+    bankConnection: {
+      linkedAt: '2024-06-01T00:00:00.000Z',
+      linkingStrategy: 'forward-only',
+      balanceReconciliation: {
+        systemBalance: 10,
+        externalBalance: 12,
+        difference: 2,
+        adjustmentTransactionId: null,
+        ...(pendingAbsorb === undefined ? {} : { pendingAbsorb }),
+      },
+      ...extra,
+    },
+  };
+}
+
+/** Sets the ledger sum the raw SELECT reports back, in cents. */
+const mockSignedSum = (cents: number) => queryMock.mockResolvedValue([{ signedSum: String(cents) }] as never);
+
+const lastUpdatePayload = () => accountsUpdateMock.mock.calls[0]![0] as unknown as { initialBalance: Money };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  findOneMock.mockResolvedValue(null as never);
+  accountsUpdateMock.mockResolvedValue([1] as never);
+  mockSignedSum(0);
+  restampMock.mockResolvedValue('restamped');
+  setTodayRowToSpotMock.mockResolvedValue(undefined as never);
+});
+
+describe('absorbLinkResidualIntoOpeningBalance', () => {
+  it('returns 0 and writes nothing when the account is missing', async () => {
+    findOneMock.mockResolvedValue(null as never);
+
+    const result = await absorbLinkResidualIntoOpeningBalance({
+      accountId: generateRandomRecordId(),
+      userId: USER_ID,
+    });
+
+    expect(result).toBe(0);
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ code: 'ACCOUNT_LINK_RESIDUAL_ACCOUNT_MISSED' }),
+    );
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(accountsUpdateMock).not.toHaveBeenCalled();
+    expect(restampMock).not.toHaveBeenCalled();
+    expect(setTodayRowToSpotMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 and writes nothing when the ledger identity already holds', async () => {
+    const accountId = generateRandomRecordId();
+    findOneMock.mockResolvedValue(
+      buildAccount({
+        id: accountId,
+        currentBalance: Money.fromDecimal(150),
+        initialBalance: Money.fromDecimal(50),
+      }) as never,
+    );
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+    expect(result).toBe(0);
+    expect(accountsUpdateMock).not.toHaveBeenCalled();
+    expect(restampMock).not.toHaveBeenCalled();
+    expect(setTodayRowToSpotMock).not.toHaveBeenCalled();
+  });
+
+  it('folds a positive gap into the opening balance, restamps it, and re-pins today’s row', async () => {
+    const accountId = generateRandomRecordId();
+    const account = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(200),
+      initialBalance: Money.fromDecimal(50),
+    });
+    const restampedRow = buildAccount({ id: accountId, initialBalance: Money.fromDecimal(100) });
+    findOneMock.mockResolvedValueOnce(account as never).mockResolvedValueOnce(restampedRow as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(50).toCents());
+    expect(accountsUpdateMock).toHaveBeenCalledTimes(1);
+    expect(lastUpdatePayload().initialBalance.toCents()).toBe(Money.fromDecimal(100).toCents());
+    expect(accountsUpdateMock.mock.calls[0]![1]).toEqual(
+      expect.objectContaining({ where: { id: accountId, userId: USER_ID } }),
+    );
+    expect(restampMock).toHaveBeenCalledWith({ accountId, allowProviderAccount: true });
+    expect(setTodayRowToSpotMock).toHaveBeenCalledWith({ account: restampedRow });
+  });
+
+  it('folds a negative gap into the opening balance', async () => {
+    const accountId = generateRandomRecordId();
+    const account = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(120),
+      initialBalance: Money.fromDecimal(50),
+    });
+    findOneMock.mockResolvedValue(account as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(-30).toCents());
+    expect(lastUpdatePayload().initialBalance.toCents()).toBe(Money.fromDecimal(20).toCents());
+    expect(restampMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a missing sum row as an empty ledger', async () => {
+    const accountId = generateRandomRecordId();
+    findOneMock.mockResolvedValue(
+      buildAccount({
+        id: accountId,
+        currentBalance: Money.fromDecimal(70),
+        initialBalance: Money.fromDecimal(10),
+      }) as never,
+    );
+    queryMock.mockResolvedValue([] as never);
+
+    const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(60).toCents());
+    expect(lastUpdatePayload().initialBalance.toCents()).toBe(Money.fromDecimal(70).toCents());
+  });
+
+  it('throws UnexpectedError and stops before re-pinning when the restamp fails', async () => {
+    const accountId = generateRandomRecordId();
+    findOneMock.mockResolvedValue(
+      buildAccount({
+        id: accountId,
+        currentBalance: Money.fromDecimal(200),
+        initialBalance: Money.fromDecimal(50),
+      }) as never,
+    );
+    mockSignedSum(Money.fromDecimal(100).toCents());
+    restampMock.mockResolvedValue('failed');
+
+    await expect(absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID })).rejects.toThrow(UnexpectedError);
+
+    expect(accountsUpdateMock).toHaveBeenCalledTimes(1);
+    expect(findOneMock).toHaveBeenCalledTimes(1);
+    expect(setTodayRowToSpotMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['restamped', 'unchanged', 'skipped'] as const)(
+    'completes the absorb when the restamp reports %s',
+    async (outcome) => {
+      const accountId = generateRandomRecordId();
+      findOneMock.mockResolvedValue(
+        buildAccount({
+          id: accountId,
+          currentBalance: Money.fromDecimal(200),
+          initialBalance: Money.fromDecimal(50),
+        }) as never,
+      );
+      mockSignedSum(Money.fromDecimal(100).toCents());
+      restampMock.mockResolvedValue(outcome);
+
+      const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+      expect(result).toBe(Money.fromDecimal(50).toCents());
+      expect(setTodayRowToSpotMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it('still returns the gap, logging instead of re-pinning, when the post-restamp re-read misses', async () => {
+    const accountId = generateRandomRecordId();
+    const account = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(200),
+      initialBalance: Money.fromDecimal(50),
+    });
+    findOneMock.mockResolvedValueOnce(account as never).mockResolvedValueOnce(null as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await absorbLinkResidualIntoOpeningBalance({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(50).toCents());
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ code: 'ACCOUNT_LINK_RESIDUAL_REREAD_MISSED' }),
+    );
+    expect(setTodayRowToSpotMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('runPendingLinkAbsorb', () => {
+  it('returns null without absorbing when the account is missing', async () => {
+    findOneMock.mockResolvedValue(null as never);
+
+    const result = await runPendingLinkAbsorb({ accountId: generateRandomRecordId(), userId: USER_ID });
+
+    expect(result).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(accountsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['no bankConnection metadata', null],
+    ['a reconciliation snapshot without the marker', buildReconciliation()],
+    ['the marker explicitly cleared', buildReconciliation({ pendingAbsorb: false })],
+  ])('returns null without absorbing for %s', async (_label, externalData) => {
+    const accountId = generateRandomRecordId();
+    findOneMock.mockResolvedValue(buildAccount({ id: accountId, externalData }) as never);
+
+    const result = await runPendingLinkAbsorb({ accountId, userId: USER_ID });
+
+    expect(result).toBeNull();
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(accountsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the marker and records the residual when the absorb moved the opening balance', async () => {
+    const accountId = generateRandomRecordId();
+    const pending = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(200),
+      initialBalance: Money.fromDecimal(50),
+      externalData: buildReconciliation({ pendingAbsorb: true, extra: { providerName: 'monobank' } }),
+    });
+    const fresh = buildAccount({
+      id: accountId,
+      externalData: buildReconciliation({ pendingAbsorb: true, extra: { providerName: 'monobank' } }),
+    });
+    findOneMock
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(fresh as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await runPendingLinkAbsorb({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(50).toCents());
+    expect(fresh.update).toHaveBeenCalledTimes(1);
+    expect(fresh.update.mock.calls[0]![0]).toEqual({
+      externalData: {
+        someUnrelatedKey: 'keep-me',
+        bankConnection: {
+          linkedAt: '2024-06-01T00:00:00.000Z',
+          linkingStrategy: 'forward-only',
+          providerName: 'monobank',
+          balanceReconciliation: {
+            systemBalance: 10,
+            externalBalance: 12,
+            difference: 2,
+            adjustmentTransactionId: null,
+            pendingAbsorb: false,
+            absorbedResidual: Money.fromDecimal(50).toCents(),
+          },
+        },
+      },
+    });
+  });
+
+  it('clears the marker without recording a residual when the absorb found no gap', async () => {
+    const accountId = generateRandomRecordId();
+    const pending = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(150),
+      initialBalance: Money.fromDecimal(50),
+      externalData: buildReconciliation({ pendingAbsorb: true }),
+    });
+    const fresh = buildAccount({
+      id: accountId,
+      externalData: buildReconciliation({ pendingAbsorb: true }),
+    });
+    findOneMock
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(fresh as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await runPendingLinkAbsorb({ accountId, userId: USER_ID });
+
+    expect(result).toBe(0);
+    expect(accountsUpdateMock).not.toHaveBeenCalled();
+    expect(fresh.update).toHaveBeenCalledTimes(1);
+    const written = fresh.update.mock.calls[0]![0] as { externalData: AccountExternalData };
+    const reconciliation = written.externalData.bankConnection!.balanceReconciliation;
+    expect(reconciliation.pendingAbsorb).toBe(false);
+    expect(reconciliation).not.toHaveProperty('absorbedResidual');
+  });
+
+  it('returns the absorbed residual without writing when the post-absorb re-read misses', async () => {
+    const accountId = generateRandomRecordId();
+    const pending = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(200),
+      initialBalance: Money.fromDecimal(50),
+      externalData: buildReconciliation({ pendingAbsorb: true }),
+    });
+    findOneMock
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(null as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await runPendingLinkAbsorb({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(50).toCents());
+    expect(pending.update).not.toHaveBeenCalled();
+  });
+
+  it('returns the absorbed residual without writing when the re-read row lost its bankConnection metadata', async () => {
+    const accountId = generateRandomRecordId();
+    const pending = buildAccount({
+      id: accountId,
+      currentBalance: Money.fromDecimal(200),
+      initialBalance: Money.fromDecimal(50),
+      externalData: buildReconciliation({ pendingAbsorb: true }),
+    });
+    const fresh = buildAccount({ id: accountId, externalData: { someUnrelatedKey: 'keep-me' } });
+    findOneMock
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(pending as never)
+      .mockResolvedValueOnce(fresh as never);
+    mockSignedSum(Money.fromDecimal(100).toCents());
+
+    const result = await runPendingLinkAbsorb({ accountId, userId: USER_ID });
+
+    expect(result).toBe(Money.fromDecimal(50).toCents());
+    expect(fresh.update).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/accounts/derived-balance-guard.ts
+++ b/packages/backend/src/services/accounts/derived-balance-guard.ts
@@ -2,17 +2,18 @@ import { type ACCOUNT_CATEGORIES, isDedicatedFlowAccountCategory } from '@bt/sha
 import { ValidationError } from '@js/errors';
 
 /**
- * Vehicle and loan balances are owned by their dedicated flows (depreciation
- * model / loan events); importing rows into such an account, or shifting its
- * balance directly, desyncs the managed anchor exactly as a raw `currentBalance`
- * write in `updateAccount` would. The import UI filters these categories out of
- * the link-target list, so this guard only fires on crafted payloads.
+ * Vehicle and loan balances are derived by their dedicated flows (depreciation
+ * model / loan events), not built from transactions; importing rows into such an
+ * account, shifting its balance, or handing it to a bank connection desyncs the
+ * managed anchor exactly as a raw `currentBalance` write in `updateAccount`
+ * would. UIs filter these categories out of the relevant pickers, so this guard
+ * only fires on crafted payloads.
  *
  * `actionPhrase` completes the sentence "…account and cannot <actionPhrase>." so
  * each caller keeps its own wording (e.g. "be an import target", "take a balance
  * adjustment").
  */
-export function assertNotDedicatedFlowAccount({
+export function assertNotDerivedBalanceAccount({
   account,
   actionPhrase,
 }: {

--- a/packages/backend/src/services/accounts/derived-balance-guard.ts
+++ b/packages/backend/src/services/accounts/derived-balance-guard.ts
@@ -3,15 +3,12 @@ import { ValidationError } from '@js/errors';
 
 /**
  * Vehicle and loan balances are derived by their dedicated flows (depreciation
- * model / loan events), not built from transactions; importing rows into such an
- * account, shifting its balance, or handing it to a bank connection desyncs the
- * managed anchor exactly as a raw `currentBalance` write in `updateAccount`
- * would. UIs filter these categories out of the relevant pickers, so this guard
- * only fires on crafted payloads.
+ * model / loan events), not built from transactions; importing rows, shifting
+ * the balance, or linking a bank connection desyncs the managed anchor. UIs
+ * filter these categories out of the pickers, so this guard only fires on
+ * crafted payloads.
  *
- * `actionPhrase` completes the sentence "…account and cannot <actionPhrase>." so
- * each caller keeps its own wording (e.g. "be an import target", "take a balance
- * adjustment").
+ * `actionPhrase` completes the sentence "…account and cannot <actionPhrase>."
  */
 export function assertNotDerivedBalanceAccount({
   account,

--- a/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
+++ b/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
@@ -2,6 +2,7 @@ import {
   API_ERROR_CODES,
   BANK_PROVIDER_TYPE,
   TRANSACTION_TRANSFER_NATURE,
+  TRANSACTION_TYPES,
   VEHICLE_CLASS,
   asDecimal,
 } from '@bt/shared/types';
@@ -48,10 +49,13 @@ const setupLinkedScenario = async ({
   initialBalance,
   bankBalance,
   bankTransactions,
+  beforeLink,
 }: {
   initialBalance: number;
   bankBalance: number;
   bankTransactions: ReturnType<typeof getMockedLunchFlowTransactions>;
+  /** Seeds account state (e.g. manual transactions) between creation and linking. */
+  beforeLink?: ({ accountId }: { accountId: Accounts['id'] }) => Promise<void>;
 }) => {
   await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
 
@@ -63,6 +67,8 @@ const setupLinkedScenario = async ({
     }),
     raw: true,
   });
+
+  if (beforeLink) await beforeLink({ accountId: account.id });
 
   const { connectionId } = await helpers.bankDataProviders.connectProvider({
     providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
@@ -158,6 +164,70 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     const todayRow = await readTodayBalanceRow({ accountId: account.id });
     expect(todayRow).not.toBeNull();
     expect(todayRow!.amount.toCents()).toBe(updatedAccount.refCurrentBalance.toCents());
+  });
+
+  it('absorbs only the unexplained residual when the account already carries manual transactions', async () => {
+    // Manual history: 1000 opening − 200 expense + 50 income = 850 tracked.
+    // The bank reports 1200 with one +100 transaction, so the books explain
+    // 1000 − 200 + 50 + 100 = 950 and exactly 250 is residual — NOT the full
+    // pre-link gap of 1200 − 850 = 350.
+    let manualRowsBefore: Transactions[] = [];
+
+    const bankTransactions = getMockedLunchFlowTransactions(1);
+    bankTransactions.transactions[0]!.amount = asDecimal(100);
+    bankTransactions.transactions[0]!.date = subDays(new Date(), 1).toISOString();
+
+    const { account } = await setupLinkedScenario({
+      initialBalance: 1000,
+      bankBalance: 1200,
+      bankTransactions,
+      beforeLink: async ({ accountId }) => {
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId,
+            amount: 200,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: subDays(new Date(), 10).toISOString(),
+          }),
+          raw: true,
+        });
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId,
+            amount: 50,
+            transactionType: TRANSACTION_TYPES.income,
+            time: subDays(new Date(), 5).toISOString(),
+          }),
+          raw: true,
+        });
+        manualRowsBefore = await Transactions.findAll({ where: { accountId }, raw: true });
+      },
+    });
+
+    const updatedAccount = (await Accounts.findByPk(account.id))!;
+    const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+    const syncedRows = transactions.filter((tx) => tx.originalId !== null);
+    expect(syncedRows.length).toBe(1);
+
+    // The manual rows must survive the link untouched.
+    const manualRowsAfter = transactions.filter((tx) => tx.originalId === null);
+    expect(manualRowsAfter.length).toBe(2);
+    expect(manualRowsBefore.length).toBe(2);
+    for (const before of manualRowsBefore) {
+      const after = manualRowsAfter.find((tx) => tx.id === before.id);
+      expect(after).toBeDefined();
+      expect(after!.time).toEqual(before.time);
+      expect(Number(after!.amount)).toBe(Number(before.amount));
+      expect(after!.transactionType).toBe(before.transactionType);
+      expect(after!.transferNature).toBe(before.transferNature);
+    }
+
+    expect(updatedAccount.currentBalance.toNumber()).toBe(1200);
+    expect(updatedAccount.initialBalance.toNumber()).toBe(1250);
+    expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+      updatedAccount.currentBalance.toCents(),
+    );
   });
 
   it('keeps the ledger intact across an unlink → relink cycle with unchanged bank state', async () => {

--- a/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
+++ b/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
@@ -1,6 +1,13 @@
-import { BANK_PROVIDER_TYPE, TRANSACTION_TRANSFER_NATURE, asDecimal } from '@bt/shared/types';
+import {
+  API_ERROR_CODES,
+  BANK_PROVIDER_TYPE,
+  TRANSACTION_TRANSFER_NATURE,
+  VEHICLE_CLASS,
+  asDecimal,
+} from '@bt/shared/types';
 import { describe, expect, it } from '@jest/globals';
 import Accounts from '@models/accounts.model';
+import Balances from '@models/balances.model';
 import Transactions from '@models/transactions.model';
 import * as helpers from '@tests/helpers';
 import { getMockedLunchFlowTransactions } from '@tests/mocks/lunchflow/data';
@@ -9,7 +16,7 @@ import {
   getLunchFlowBalanceMock,
   getLunchFlowTransactionsMock,
 } from '@tests/mocks/lunchflow/mock-api';
-import { subDays } from 'date-fns';
+import { format, subDays, subYears } from 'date-fns';
 
 /**
  * Linking an existing system account to a bank connection must reconcile the
@@ -22,6 +29,10 @@ import { subDays } from 'date-fns';
  */
 
 const LUNCHFLOW_EXTERNAL_ACCOUNT_ID = '1001';
+
+/** Reads the error envelope (`code` + `message`) from a failed helper response. */
+const extractError = (response: unknown) =>
+  (response as helpers.CustomResponse<unknown>).body.response as unknown as { code: string; message: string };
 
 /** Bank-reported balance, in dollars (LunchFlow account 1001 is USD). */
 const mockBankBalance = ({ amount }: { amount: number }) =>
@@ -64,6 +75,8 @@ const setupLinkedScenario = async ({
     mockBankBalance({ amount: bankBalance }),
   );
 
+  const preLinkAccount = (await Accounts.findByPk(account.id))!;
+
   const linkResponse = await helpers.linkAccountToBankConnection({
     id: account.id,
     connectionId,
@@ -72,8 +85,11 @@ const setupLinkedScenario = async ({
   });
   expect(linkResponse.statusCode).toBe(200);
 
-  return { account };
+  return { account, preLinkAccount, connectionId };
 };
+
+const readTodayBalanceRow = async ({ accountId }: { accountId: string }) =>
+  Balances.findOne({ where: { accountId, date: format(new Date(), 'yyyy-MM-dd') } });
 
 describe('Balance reconciliation when linking account to a bank connection', () => {
   it('does not create an adjustment transaction when the gap is fully explained by synced transactions', async () => {
@@ -110,7 +126,7 @@ describe('Balance reconciliation when linking account to a bank connection', () 
   });
 
   it('absorbs a residual difference into initialBalance when the bank returns no transactions', async () => {
-    const { account } = await setupLinkedScenario({
+    const { account, preLinkAccount } = await setupLinkedScenario({
       initialBalance: 1000,
       bankBalance: 1100,
       bankTransactions: { transactions: [], total: 0 },
@@ -130,6 +146,18 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
       updatedAccount.currentBalance.toCents(),
     );
+
+    // The USD opening balance moved, so its base-currency stamp must be re-derived
+    // rather than left on the pre-link value.
+    expect(updatedAccount.refInitialBalance).not.toBeNull();
+    expect(updatedAccount.refInitialBalance.toCents()).not.toBe(preLinkAccount.refInitialBalance.toCents());
+    expect(updatedAccount.refInitialBalance.toCents()).toBeGreaterThan(preLinkAccount.refInitialBalance.toCents());
+
+    // The restamp cascade shifts every Balances row, including today's — which the
+    // sync pinned to the bank's authoritative balance. It has to stay pinned.
+    const todayRow = await readTodayBalanceRow({ accountId: account.id });
+    expect(todayRow).not.toBeNull();
+    expect(todayRow!.amount.toCents()).toBe(updatedAccount.refCurrentBalance.toCents());
   });
 
   it('keeps the ledger intact across an unlink → relink cycle with unchanged bank state', async () => {
@@ -178,5 +206,62 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
       updatedAccount.currentBalance.toCents(),
     );
+  });
+
+  // Loan and vehicle balances are owned by their dedicated flows, so a bank sync
+  // force-writing `currentBalance` would desync the managed anchor.
+  describe('dedicated-flow accounts are rejected up front', () => {
+    const connectLunchFlow = async () => {
+      await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
+      const { connectionId } = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
+        credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+        raw: true,
+      });
+      return connectionId;
+    };
+
+    const expectLinkRejected = async ({ accountId, connectionId }: { accountId: string; connectionId: string }) => {
+      const response = await helpers.linkAccountToBankConnection({
+        id: accountId,
+        connectionId,
+        externalAccountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID,
+        raw: false,
+      });
+
+      expect(response.statusCode).toBe(422);
+      expect(extractError(response).code).toBe(API_ERROR_CODES.validationError);
+    };
+
+    it('rejects linking a loan-category account', async () => {
+      const connectionId = await connectLunchFlow();
+      const loan = await helpers.createLoan({
+        payload: helpers.buildCreateLoanPayload({
+          currencyCode: 'USD',
+          initialBalance: 1_000,
+          originalPrincipal: 1_000,
+        }),
+        raw: true,
+      });
+
+      await expectLinkRejected({ accountId: loan.id, connectionId });
+    });
+
+    it('rejects linking a vehicle-category account', async () => {
+      const connectionId = await connectLunchFlow();
+      const vehicle = await helpers.createVehicle({
+        name: 'Toyota Camry 2020',
+        currencyCode: 'USD',
+        make: 'Toyota',
+        model: 'Camry',
+        year: 2020,
+        vehicleClass: VEHICLE_CLASS.sedan,
+        purchasePrice: 25_000,
+        purchaseDate: format(subYears(new Date(), 3), 'yyyy-MM-dd'),
+        raw: true,
+      });
+
+      await expectLinkRejected({ accountId: vehicle.accountId, connectionId });
+    });
   });
 });

--- a/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
+++ b/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
@@ -1,0 +1,182 @@
+import { BANK_PROVIDER_TYPE, TRANSACTION_TRANSFER_NATURE, asDecimal } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import Accounts from '@models/accounts.model';
+import Transactions from '@models/transactions.model';
+import * as helpers from '@tests/helpers';
+import { getMockedLunchFlowTransactions } from '@tests/mocks/lunchflow/data';
+import {
+  VALID_LUNCHFLOW_API_KEY,
+  getLunchFlowBalanceMock,
+  getLunchFlowTransactionsMock,
+} from '@tests/mocks/lunchflow/mock-api';
+import { subDays } from 'date-fns';
+
+/**
+ * Linking an existing system account to a bank connection must reconcile the
+ * balance WITHOUT minting `transfer_out_wallet` "Balance adjustment" rows:
+ * the post-link sync backfills the gap transactions and force-writes the
+ * bank's authoritative balance, so an adjustment created up-front both spams
+ * the transaction feed and double-counts the gap in the ledger.
+ *
+ * The invariant checked throughout: initialBalance + Σsigned(tx) === currentBalance.
+ */
+
+const LUNCHFLOW_EXTERNAL_ACCOUNT_ID = '1001';
+
+/** Bank-reported balance, in dollars (LunchFlow account 1001 is USD). */
+const mockBankBalance = ({ amount }: { amount: number }) =>
+  getLunchFlowBalanceMock({
+    accountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID,
+    response: { balance: { amount: asDecimal(amount), currency: 'USD' } },
+  });
+
+const sumSignedCents = (transactions: Transactions[]) =>
+  transactions.reduce((acc, tx) => acc + (tx.transactionType === 'income' ? Number(tx.amount) : -Number(tx.amount)), 0);
+
+const setupLinkedScenario = async ({
+  initialBalance,
+  bankBalance,
+  bankTransactions,
+}: {
+  initialBalance: number;
+  bankBalance: number;
+  bankTransactions: ReturnType<typeof getMockedLunchFlowTransactions>;
+}) => {
+  await helpers.addUserCurrencies({ currencyCodes: ['USD'], raw: true });
+
+  const account = await helpers.createAccount({
+    payload: helpers.buildAccountPayload({
+      name: 'Linkable system account',
+      currencyCode: 'USD',
+      initialBalance,
+    }),
+    raw: true,
+  });
+
+  const { connectionId } = await helpers.bankDataProviders.connectProvider({
+    providerType: BANK_PROVIDER_TYPE.LUNCHFLOW,
+    credentials: { apiKey: VALID_LUNCHFLOW_API_KEY },
+    raw: true,
+  });
+
+  global.mswMockServer.use(
+    getLunchFlowTransactionsMock({ response: bankTransactions, accountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID }),
+    mockBankBalance({ amount: bankBalance }),
+  );
+
+  const linkResponse = await helpers.linkAccountToBankConnection({
+    id: account.id,
+    connectionId,
+    externalAccountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID,
+    raw: false,
+  });
+  expect(linkResponse.statusCode).toBe(200);
+
+  return { account };
+};
+
+describe('Balance reconciliation when linking account to a bank connection', () => {
+  it('does not create an adjustment transaction when the gap is fully explained by synced transactions', async () => {
+    // Bank: 1000 (matches system balance) + 100 income from the gap = 1100.
+    const bankTransactions = getMockedLunchFlowTransactions(1);
+    bankTransactions.transactions[0]!.amount = asDecimal(100);
+    bankTransactions.transactions[0]!.date = subDays(new Date(), 1).toISOString();
+
+    const { account } = await setupLinkedScenario({
+      initialBalance: 1000,
+      bankBalance: 1100,
+      bankTransactions,
+    });
+
+    const updatedAccount = (await Accounts.findByPk(account.id))!;
+    const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+    // The gap income must be synced exactly once.
+    const syncedIncomes = transactions.filter((tx) => tx.originalId !== null);
+    expect(syncedIncomes.length).toBe(1);
+
+    // The sync backfills the +100 and force-writes the bank balance, so an
+    // up-front adjustment both spams the feed and double-counts the gap.
+    const adjustments = transactions.filter(
+      (tx) => tx.transferNature === TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    );
+    expect(adjustments.length).toBe(0);
+
+    expect(updatedAccount.currentBalance.toNumber()).toBe(1100);
+    // Ledger identity: the books must explain the balance.
+    expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+      updatedAccount.currentBalance.toCents(),
+    );
+  });
+
+  it('absorbs a residual difference into initialBalance when the bank returns no transactions', async () => {
+    const { account } = await setupLinkedScenario({
+      initialBalance: 1000,
+      bankBalance: 1100,
+      bankTransactions: { transactions: [], total: 0 },
+    });
+
+    const updatedAccount = (await Accounts.findByPk(account.id))!;
+    const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+    const adjustments = transactions.filter(
+      (tx) => tx.transferNature === TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    );
+    expect(adjustments.length).toBe(0);
+
+    expect(updatedAccount.currentBalance.toNumber()).toBe(1100);
+    // The unexplainable +100 must land in initialBalance, not in a visible row.
+    expect(updatedAccount.initialBalance.toNumber()).toBe(1100);
+    expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+      updatedAccount.currentBalance.toCents(),
+    );
+  });
+
+  it('keeps the ledger intact across an unlink → relink cycle with unchanged bank state', async () => {
+    const bankTransactions = getMockedLunchFlowTransactions(1);
+    bankTransactions.transactions[0]!.amount = asDecimal(100);
+    bankTransactions.transactions[0]!.date = subDays(new Date(), 1).toISOString();
+
+    const { account } = await setupLinkedScenario({
+      initialBalance: 1000,
+      bankBalance: 1100,
+      bankTransactions,
+    });
+
+    await helpers.unlinkAccountFromBankConnection({ id: account.id, raw: true });
+
+    // Same bank state: same transactions, same balance.
+    const { connections } = await helpers.bankDataProviders.listUserConnections({ raw: true });
+    global.mswMockServer.use(
+      getLunchFlowTransactionsMock({ response: bankTransactions, accountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID }),
+      mockBankBalance({ amount: 1100 }),
+    );
+
+    const relinkResponse = await helpers.linkAccountToBankConnection({
+      id: account.id,
+      connectionId: connections[0]!.id,
+      externalAccountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID,
+      raw: false,
+    });
+    expect(relinkResponse.statusCode).toBe(200);
+
+    const updatedAccount = (await Accounts.findByPk(account.id))!;
+    const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+    const adjustments = transactions.filter(
+      (tx) => tx.transferNature === TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    );
+    expect(adjustments.length).toBe(0);
+
+    // The gap income must not be duplicated by the relink sync.
+    const nonAdjustment = transactions.filter(
+      (tx) => tx.transferNature !== TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    );
+    expect(nonAdjustment.length).toBe(1);
+
+    expect(updatedAccount.currentBalance.toNumber()).toBe(1100);
+    expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+      updatedAccount.currentBalance.toCents(),
+    );
+  });
+});

--- a/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
+++ b/packages/backend/src/services/accounts/link-balance-reconciliation.e2e.ts
@@ -1,15 +1,19 @@
 import {
   API_ERROR_CODES,
   BANK_PROVIDER_TYPE,
+  type ExternalMonobankTransactionResponse,
   TRANSACTION_TRANSFER_NATURE,
   TRANSACTION_TYPES,
   VEHICLE_CLASS,
+  asCents,
   asDecimal,
 } from '@bt/shared/types';
 import { describe, expect, it } from '@jest/globals';
 import Accounts from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import Transactions from '@models/transactions.model';
+import { redisClient } from '@root/redis-client';
+import { REDIS_KEYS, SyncStatus } from '@services/bank-data-providers/sync/sync-status-tracker';
 import * as helpers from '@tests/helpers';
 import { getMockedLunchFlowTransactions } from '@tests/mocks/lunchflow/data';
 import {
@@ -17,21 +21,21 @@ import {
   getLunchFlowBalanceMock,
   getLunchFlowTransactionsMock,
 } from '@tests/mocks/lunchflow/mock-api';
-import { format, subDays, subYears } from 'date-fns';
+import { MONOBANK_URLS_MOCK, getMonobankTransactionsMock } from '@tests/mocks/monobank/mock-api';
+import { format, subDays, subMinutes, subYears } from 'date-fns';
+import { HttpResponse, http } from 'msw';
 
 /**
- * Linking an existing system account to a bank connection must reconcile the
- * balance WITHOUT minting `transfer_out_wallet` "Balance adjustment" rows:
- * the post-link sync backfills the gap transactions and force-writes the
- * bank's authoritative balance, so an adjustment created up-front both spams
- * the transaction feed and double-counts the gap in the ledger.
- *
- * The invariant checked throughout: initialBalance + Σsigned(tx) === currentBalance.
+ * Linking must reconcile the balance without minting `transfer_out_wallet`
+ * "Balance adjustment" rows: the bank balance is force-written, the
+ * unexplained residual moves into the opening balance, and (forward-only rule)
+ * pre-link statement rows are never imported over manual history, whose bank
+ * copies dedup cannot recognize. Only an account with no rows backfills.
+ * Invariant checked throughout: initialBalance + Σsigned(tx) === currentBalance.
  */
 
 const LUNCHFLOW_EXTERNAL_ACCOUNT_ID = '1001';
 
-/** Reads the error envelope (`code` + `message`) from a failed helper response. */
 const extractError = (response: unknown) =>
   (response as helpers.CustomResponse<unknown>).body.response as unknown as { code: string; message: string };
 
@@ -117,15 +121,12 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     const syncedIncomes = transactions.filter((tx) => tx.originalId !== null);
     expect(syncedIncomes.length).toBe(1);
 
-    // The sync backfills the +100 and force-writes the bank balance, so an
-    // up-front adjustment both spams the feed and double-counts the gap.
     const adjustments = transactions.filter(
       (tx) => tx.transferNature === TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
     );
     expect(adjustments.length).toBe(0);
 
     expect(updatedAccount.currentBalance.toNumber()).toBe(1100);
-    // Ledger identity: the books must explain the balance.
     expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
       updatedAccount.currentBalance.toCents(),
     );
@@ -159,18 +160,19 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     expect(updatedAccount.refInitialBalance.toCents()).not.toBe(preLinkAccount.refInitialBalance.toCents());
     expect(updatedAccount.refInitialBalance.toCents()).toBeGreaterThan(preLinkAccount.refInitialBalance.toCents());
 
-    // The restamp cascade shifts every Balances row, including today's — which the
-    // sync pinned to the bank's authoritative balance. It has to stay pinned.
+    // The restamp cascade shifts every Balances row, including today's, which
+    // the sync pinned to the bank's authoritative balance. It must stay pinned.
     const todayRow = await readTodayBalanceRow({ accountId: account.id });
     expect(todayRow).not.toBeNull();
     expect(todayRow!.amount.toCents()).toBe(updatedAccount.refCurrentBalance.toCents());
   });
 
-  it('absorbs only the unexplained residual when the account already carries manual transactions', async () => {
+  it('absorbs the whole pre-link gap without importing pre-link bank history over manual rows', async () => {
     // Manual history: 1000 opening − 200 expense + 50 income = 850 tracked.
-    // The bank reports 1200 with one +100 transaction, so the books explain
-    // 1000 − 200 + 50 + 100 = 950 and exactly 250 is residual — NOT the full
-    // pre-link gap of 1200 − 850 = 350.
+    // The bank reports 1200 plus a +100 row from yesterday. Forward-only
+    // linking must not import that pre-link row (the manual ledger owns
+    // pre-link history, whose bank copies dedup cannot recognize), so the
+    // full 350 gap moves to the opening balance.
     let manualRowsBefore: Transactions[] = [];
 
     const bankTransactions = getMockedLunchFlowTransactions(1);
@@ -208,7 +210,7 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
 
     const syncedRows = transactions.filter((tx) => tx.originalId !== null);
-    expect(syncedRows.length).toBe(1);
+    expect(syncedRows.length).toBe(0);
 
     // The manual rows must survive the link untouched.
     const manualRowsAfter = transactions.filter((tx) => tx.originalId === null);
@@ -224,7 +226,53 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     }
 
     expect(updatedAccount.currentBalance.toNumber()).toBe(1200);
-    expect(updatedAccount.initialBalance.toNumber()).toBe(1250);
+    expect(updatedAccount.initialBalance.toNumber()).toBe(1350);
+    expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+      updatedAccount.currentBalance.toCents(),
+    );
+  });
+
+  it('does not duplicate a manually-logged purchase whose bank timestamp falls inside the pre-link window', async () => {
+    // The user logged the purchase at T; the bank stamped its copy at T+30m
+    // (backdated entry or settlement delay). Forward-only linking must not
+    // re-import the bank's copy: the pre-link gap belongs to the opening
+    // balance, not to a duplicated row.
+    const manualTime = subMinutes(new Date(), 180);
+    const bankTime = subMinutes(new Date(), 150);
+
+    const bankTransactions = getMockedLunchFlowTransactions(1);
+    bankTransactions.transactions[0]!.amount = asDecimal(-30);
+    bankTransactions.transactions[0]!.date = bankTime.toISOString();
+
+    const { account } = await setupLinkedScenario({
+      initialBalance: 1000,
+      bankBalance: 1200,
+      bankTransactions,
+      beforeLink: async ({ accountId }) => {
+        await helpers.createTransaction({
+          payload: helpers.buildTransactionPayload({
+            accountId,
+            amount: 30,
+            transactionType: TRANSACTION_TYPES.expense,
+            time: manualTime.toISOString(),
+          }),
+          raw: true,
+        });
+      },
+    });
+
+    const updatedAccount = (await Accounts.findByPk(account.id))!;
+    const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+    // Only the manual row must exist: the bank's copy of the same purchase
+    // must not have been imported as a second row.
+    expect(transactions.length).toBe(1);
+    expect(transactions.filter((tx) => tx.originalId !== null).length).toBe(0);
+
+    expect(updatedAccount.currentBalance.toNumber()).toBe(1200);
+    // Tracked state was 1000 − 30 = 970, bank says 1200: the whole 230 gap is
+    // opening-balance history the provider never handed us.
+    expect(updatedAccount.initialBalance.toNumber()).toBe(1230);
     expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
       updatedAccount.currentBalance.toCents(),
     );
@@ -243,7 +291,6 @@ describe('Balance reconciliation when linking account to a bank connection', () 
 
     await helpers.unlinkAccountFromBankConnection({ id: account.id, raw: true });
 
-    // Same bank state: same transactions, same balance.
     const { connections } = await helpers.bankDataProviders.listUserConnections({ raw: true });
     global.mswMockServer.use(
       getLunchFlowTransactionsMock({ response: bankTransactions, accountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID }),
@@ -276,6 +323,242 @@ describe('Balance reconciliation when linking account to a bank connection', () 
     expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
       updatedAccount.currentBalance.toCents(),
     );
+  });
+
+  // Monobank linking enqueues a BullMQ job and returns, so the reconciliation
+  // contract must hold across the async boundary: bank balance at link time,
+  // residual absorb after the worker finishes.
+  describe('queued provider (Monobank)', () => {
+    const MONOBANK_EXTERNAL_ID = 'linkable-mono-account';
+
+    /** UAH client-info override with a controlled bank balance, in cents. */
+    const mockMonobankClientInfo = ({ balanceCents }: { balanceCents: number }) =>
+      http.get(MONOBANK_URLS_MOCK.clientInfo, () =>
+        HttpResponse.json({
+          clientId: 'link-test-client',
+          name: 'Link Test User',
+          webHookUrl: '',
+          permissions: '',
+          accounts: [
+            {
+              id: MONOBANK_EXTERNAL_ID,
+              sendId: 'link-test-send-id',
+              balance: asCents(balanceCents),
+              creditLimit: asCents(0),
+              type: 'black',
+              currencyCode: 980,
+              cashbackType: 'Miles',
+              maskedPan: [],
+              iban: 'UA000000000000000000000000000',
+            },
+          ],
+          jars: [],
+        }),
+      );
+
+    const buildBankStatementTx = ({
+      id,
+      time,
+      amountCents,
+      balanceCents,
+    }: {
+      id: string;
+      time: Date;
+      amountCents: number;
+      balanceCents: number;
+    }): ExternalMonobankTransactionResponse => ({
+      id,
+      time: Math.floor(time.getTime() / 1000),
+      description: 'Statement row',
+      mcc: 4829,
+      originalMcc: 4829,
+      hold: false,
+      amount: asCents(amountCents),
+      operationAmount: asCents(amountCents),
+      currencyCode: 980,
+      commissionRate: asCents(0),
+      cashbackAmount: asCents(0),
+      balance: asCents(balanceCents),
+      comment: '',
+      receiptId: '',
+      invoiceId: '',
+      counterEdrpou: '',
+      counterIban: '',
+      counterName: 'Link Test Counterparty',
+    });
+
+    /** The queued sync settles out-of-request; poll Redis for a terminal status. */
+    const waitForQueuedSyncToSettle = async ({
+      accountId,
+      timeoutMs = 15_000,
+    }: {
+      accountId: string;
+      timeoutMs?: number;
+    }): Promise<SyncStatus> => {
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < timeoutMs) {
+        const raw = await redisClient.get(REDIS_KEYS.accountSyncStatus(accountId));
+        if (raw) {
+          const { status } = JSON.parse(raw) as { status: SyncStatus };
+          if (status === SyncStatus.COMPLETED || status === SyncStatus.FAILED) return status;
+        }
+        await helpers.sleep(150);
+      }
+      throw new Error(`Queued Monobank sync did not settle within ${timeoutMs}ms for account ${accountId}`);
+    };
+
+    const setupMonobankLink = async ({
+      initialBalance,
+      bankBalanceCents,
+      bankStatement,
+      apiToken,
+      beforeLink,
+    }: {
+      initialBalance: number;
+      bankBalanceCents: number;
+      bankStatement: ExternalMonobankTransactionResponse[];
+      /** Unique per test: token hash keys the BullMQ queue lane and the client-info cache. */
+      apiToken: string;
+      beforeLink?: ({ accountId }: { accountId: Accounts['id'] }) => Promise<void>;
+    }) => {
+      await helpers.addUserCurrencies({ currencyCodes: ['UAH'], raw: true });
+
+      const account = await helpers.createAccount({
+        payload: helpers.buildAccountPayload({
+          name: 'Linkable Monobank account',
+          currencyCode: 'UAH',
+          initialBalance,
+        }),
+        raw: true,
+      });
+
+      if (beforeLink) await beforeLink({ accountId: account.id });
+
+      global.mswMockServer.use(
+        mockMonobankClientInfo({ balanceCents: bankBalanceCents }),
+        getMonobankTransactionsMock({ response: bankStatement, respectDateRange: true }),
+      );
+
+      const { connectionId } = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.MONOBANK,
+        credentials: { apiToken },
+        raw: true,
+      });
+
+      const linkResponse = await helpers.linkAccountToBankConnection({
+        id: account.id,
+        connectionId,
+        externalAccountId: MONOBANK_EXTERNAL_ID,
+        raw: false,
+      });
+      expect(linkResponse.statusCode).toBe(200);
+
+      const settled = await waitForQueuedSyncToSettle({ accountId: account.id });
+      expect(settled).toBe(SyncStatus.COMPLETED);
+
+      return { account };
+    };
+
+    it('updates the balance to the bank figure when the sync window returns no transactions', async () => {
+      // Dormant account: the statement window returns zero rows, and the bank
+      // balance must still land.
+      const { account } = await setupMonobankLink({
+        initialBalance: 900,
+        bankBalanceCents: 100_000,
+        bankStatement: [],
+        apiToken: 'link-mono-token-stale-balance',
+      });
+
+      const updatedAccount = (await Accounts.findByPk(account.id))!;
+      const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+      expect(transactions.length).toBe(0);
+      expect(updatedAccount.currentBalance.toNumber()).toBe(1000);
+      // The unexplainable +100 must land in the opening balance.
+      expect(updatedAccount.initialBalance.toNumber()).toBe(1000);
+      expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+        updatedAccount.currentBalance.toCents(),
+      );
+    });
+
+    it('does not re-import a manually-logged purchase whose bank timestamp falls inside the pre-link window', async () => {
+      // Manual row at T, the bank's copy stamped T+30m. Dedup by originalId
+      // cannot catch it (manual rows have none), so the sync window must not
+      // reach back past the link.
+      const manualTime = subMinutes(new Date(), 180);
+      const bankTime = subMinutes(new Date(), 150);
+
+      const { account } = await setupMonobankLink({
+        initialBalance: 1000,
+        bankBalanceCents: 120_000,
+        bankStatement: [
+          buildBankStatementTx({
+            id: 'bank-copy-of-manual-row',
+            time: bankTime,
+            amountCents: -5_000,
+            balanceCents: 120_000,
+          }),
+        ],
+        apiToken: 'link-mono-token-duplicates',
+        beforeLink: async ({ accountId }) => {
+          await helpers.createTransaction({
+            payload: helpers.buildTransactionPayload({
+              accountId,
+              amount: 50,
+              transactionType: TRANSACTION_TYPES.expense,
+              time: manualTime.toISOString(),
+            }),
+            raw: true,
+          });
+        },
+      });
+
+      const updatedAccount = (await Accounts.findByPk(account.id))!;
+      const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+      expect(transactions.length).toBe(1);
+      expect(transactions.filter((tx) => tx.originalId !== null).length).toBe(0);
+
+      expect(updatedAccount.currentBalance.toNumber()).toBe(1200);
+      // Tracked 1000 − 50 = 950 against the bank's 1200: the 250 gap is
+      // pre-link history, absorbed into the opening balance.
+      expect(updatedAccount.initialBalance.toNumber()).toBe(1250);
+      expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+        updatedAccount.currentBalance.toCents(),
+      );
+    });
+
+    it('keeps the ledger identity when the backfill imports transactions on an empty account', async () => {
+      // Empty account: the sync backfills history and force-writes the bank
+      // balance from the newest row; the absorb must then explain the rest via
+      // the opening balance after the worker finishes, not before.
+      const { account } = await setupMonobankLink({
+        initialBalance: 500,
+        bankBalanceCents: 100_000,
+        bankStatement: [
+          buildBankStatementTx({
+            id: 'backfilled-income',
+            time: subDays(new Date(), 5),
+            amountCents: 20_000,
+            balanceCents: 100_000,
+          }),
+        ],
+        apiToken: 'link-mono-token-backfill',
+      });
+
+      const updatedAccount = (await Accounts.findByPk(account.id))!;
+      const transactions = await Transactions.findAll({ where: { accountId: account.id }, raw: true });
+
+      expect(transactions.length).toBe(1);
+      expect(transactions[0]!.originalId).toBe('backfilled-income');
+
+      expect(updatedAccount.currentBalance.toNumber()).toBe(1000);
+      // 1000 bank − 200 imported = 800 of opening-balance history.
+      expect(updatedAccount.initialBalance.toNumber()).toBe(800);
+      expect(updatedAccount.initialBalance.toCents() + sumSignedCents(transactions)).toBe(
+        updatedAccount.currentBalance.toCents(),
+      );
+    });
   });
 
   // Loan and vehicle balances are owned by their dedicated flows, so a bank sync

--- a/packages/backend/src/services/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/services/accounts/link-to-bank-connection.ts
@@ -7,17 +7,19 @@ import {
 } from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { NotFoundError, ValidationError } from '@js/errors';
+import { logger } from '@js/utils/logger';
 import AccountGrouping from '@models/accounts-groups/account-grouping.model';
 import AccountGroup from '@models/accounts-groups/account-groups.model';
 import Accounts, { getAccountById } from '@models/accounts.model';
+import Balances from '@models/balances.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import { namespace } from '@models/connection';
 import Transactions from '@models/transactions.model';
+import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
 import { restampRefInitialBalance } from '@services/accounts/restamp-ref-initial-balance';
 import { bankProviderRegistry } from '@services/bank-data-providers';
 import { syncTransactionsForAccount } from '@services/bank-data-providers/connection/sync-transactions-for-account';
 import { withTransaction } from '@services/common/with-transaction';
-import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
 import { QueryTypes } from 'sequelize';
 
 const PROVIDER_TO_ACCOUNT_TYPE: Record<BANK_PROVIDER_TYPE, ACCOUNT_TYPES> = {
@@ -40,45 +42,6 @@ interface LinkResult {
   balanceAdjustmentTransaction: null;
   balanceDifference: number;
 }
-
-/**
- * Restores `initialBalance + Σsigned(tx) = currentBalance` after the post-link
- * sync backfilled the provider's transactions and force-wrote its authoritative
- * balance. Only the opening balance moves: the bank owns `currentBalance`, and
- * the residual is by definition history the provider never handed us.
- */
-const absorbLinkResidualIntoOpeningBalance = async ({
-  accountId,
-  userId,
-}: {
-  accountId: string;
-  userId: number;
-}): Promise<void> => {
-  const sequelizeTx = namespace.get('transaction');
-
-  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
-    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
-     FROM "Transactions" WHERE "accountId" = :accountId`,
-    {
-      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
-      type: QueryTypes.SELECT,
-      transaction: sequelizeTx,
-    },
-  );
-
-  const account = await Accounts.findOne({ where: { id: accountId, userId }, transaction: sequelizeTx });
-  if (!account) return;
-
-  const signedSumCents = Number(row?.signedSum ?? 0);
-  const identityGapCents = account.currentBalance.toCents() - (account.initialBalance.toCents() + signedSumCents);
-  if (identityGapCents === 0) return;
-
-  await Accounts.update(
-    { initialBalance: Money.fromCents(account.initialBalance.toCents() + identityGapCents) },
-    { where: { id: accountId, userId } },
-  );
-  await restampRefInitialBalance({ accountId, allowProviderAccount: true });
-};
 
 /**
  * Links a system account to a bank connection using forward-only strategy.
@@ -233,15 +196,115 @@ export const linkAccountToBankConnection = withTransaction(
     // 12. Re-anchor the opening balance against what the sync actually wrote.
     // Providers that enqueue their sync (Monobank) have changed nothing yet, so
     // the gap is zero and this is a no-op for them.
-    await absorbLinkResidualIntoOpeningBalance({ accountId, userId });
+    const absorbedResidual = await absorbLinkResidualIntoOpeningBalance({ accountId, userId });
 
     // 13. Fetch and return the updated account
-    const updatedAccount = await Accounts.findByPk(accountId);
+    const updatedAccount = (await Accounts.findByPk(accountId))!;
+
+    // 14. Record what the absorb moved, alongside the reconciliation snapshot
+    // written in step 7 (before the sync had run and could produce a residual).
+    if (absorbedResidual !== 0) {
+      const currentExternalData = (updatedAccount.externalData || {}) as AccountExternalData;
+      const connectionMeta = currentExternalData.bankConnection ?? updatedExternalData.bankConnection!;
+
+      await updatedAccount.update({
+        externalData: {
+          ...currentExternalData,
+          bankConnection: {
+            ...connectionMeta,
+            balanceReconciliation: { ...connectionMeta.balanceReconciliation, absorbedResidual },
+          },
+        },
+      });
+    }
 
     return {
-      account: updatedAccount!,
+      account: updatedAccount,
       balanceAdjustmentTransaction: null,
       balanceDifference,
     };
   },
 );
+
+/**
+ * Restores `initialBalance + Σsigned(tx) = currentBalance` after the post-link
+ * sync backfilled the provider's transactions and force-wrote its authoritative
+ * balance. Only the opening balance moves: the bank owns `currentBalance`, and
+ * the residual is by definition history the provider never handed us.
+ *
+ * The account row is read under SELECT ... FOR UPDATE so the read-compute-write
+ * serializes against a concurrent import or sync absorbing into the same account.
+ *
+ * Returns the absorbed residual in cents (0 when the identity already holds).
+ */
+const absorbLinkResidualIntoOpeningBalance = async ({
+  accountId,
+  userId,
+}: {
+  accountId: string;
+  userId: number;
+}): Promise<number> => {
+  const sequelizeTx = namespace.get('transaction');
+
+  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
+    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
+     FROM "Transactions" WHERE "accountId" = :accountId`,
+    {
+      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
+      type: QueryTypes.SELECT,
+      transaction: sequelizeTx,
+    },
+  );
+
+  const account = await Accounts.findOne({
+    where: { id: accountId, userId },
+    transaction: sequelizeTx,
+    lock: sequelizeTx?.LOCK.UPDATE,
+  });
+  if (!account) {
+    logger.error(
+      {
+        message: 'Account missing when absorbing the post-link balance residual',
+        error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
+      },
+      { code: 'ACCOUNT_LINK_RESIDUAL_ACCOUNT_MISSED', accountId, userId },
+    );
+    return 0;
+  }
+
+  const signedSumCents = Number(row?.signedSum ?? 0);
+  const initialBalanceBefore = account.initialBalance;
+  const identityGapCents = account.currentBalance.toCents() - (initialBalanceBefore.toCents() + signedSumCents);
+  if (identityGapCents === 0) return 0;
+
+  const initialBalanceAfter = initialBalanceBefore.add(Money.fromCents(identityGapCents));
+  await Accounts.update({ initialBalance: initialBalanceAfter }, { where: { id: accountId, userId } });
+  await restampRefInitialBalance({ accountId, allowProviderAccount: true });
+
+  // The restamp cascade shifts every Balances row by the opening-balance diff,
+  // including today's — which the sync just pinned to the bank's authoritative
+  // balance. Re-pin it from the post-restamp row so the spot value survives.
+  const restamped = await Accounts.findOne({ where: { id: accountId, userId }, transaction: sequelizeTx });
+  if (restamped) {
+    await Balances.setTodayRowToSpot({ account: restamped });
+  } else {
+    logger.error(
+      {
+        message: 'Account re-read after restampRefInitialBalance missed; the current-day balance row stays cascaded',
+        error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
+      },
+      { code: 'ACCOUNT_LINK_RESIDUAL_REREAD_MISSED', accountId, userId },
+    );
+  }
+
+  logger.info('Absorbed post-link balance residual into the opening balance', {
+    accountId,
+    userId,
+    signedSumCents,
+    identityGapCents,
+    initialBalanceBeforeCents: initialBalanceBefore.toCents(),
+    initialBalanceAfterCents: initialBalanceAfter.toCents(),
+  });
+
+  return identityGapCents;
+};

--- a/packages/backend/src/services/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/services/accounts/link-to-bank-connection.ts
@@ -3,7 +3,7 @@ import {
   API_ERROR_CODES,
   type AccountExternalData,
   BANK_PROVIDER_TYPE,
-  TRANSACTION_TYPES,
+  type RecordId,
 } from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { NotFoundError, ValidationError } from '@js/errors';
@@ -11,16 +11,15 @@ import { logger } from '@js/utils/logger';
 import AccountGrouping from '@models/accounts-groups/account-grouping.model';
 import AccountGroup from '@models/accounts-groups/account-groups.model';
 import Accounts, { getAccountById } from '@models/accounts.model';
-import Balances from '@models/balances.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import { namespace } from '@models/connection';
-import Transactions from '@models/transactions.model';
+import { absorbLinkResidualIntoOpeningBalance } from '@services/accounts/absorb-link-residual';
 import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
-import { restampRefInitialBalance } from '@services/accounts/restamp-ref-initial-balance';
 import { bankProviderRegistry } from '@services/bank-data-providers';
 import { syncTransactionsForAccount } from '@services/bank-data-providers/connection/sync-transactions-for-account';
+import { SyncStatus, setAccountSyncStatus } from '@services/bank-data-providers/sync/sync-status-tracker';
+import { writeBankBalanceWithHistory } from '@services/bank-data-providers/utils/write-bank-balance-with-history';
 import { withTransaction } from '@services/common/with-transaction';
-import { QueryTypes } from 'sequelize';
 
 const PROVIDER_TO_ACCOUNT_TYPE: Record<BANK_PROVIDER_TYPE, ACCOUNT_TYPES> = {
   [BANK_PROVIDER_TYPE.MONOBANK]: ACCOUNT_TYPES.monobank,
@@ -44,18 +43,11 @@ interface LinkResult {
 }
 
 /**
- * Links a system account to a bank connection using forward-only strategy.
- * This operation:
- * 1. Validates the account is a system account
- * 2. Fetches current balance from external provider
- * 3. Validates currency match between system and external accounts
- * 4. Updates account type to match provider (e.g., 'monobank')
- * 5. Stores linking metadata in account's externalData
- * 6. Syncs the provider's transactions, then absorbs whatever balance residual
- *    those transactions do not explain into the opening balance
- *
- * Note: Existing transactions remain as 'system' type to preserve data integrity.
- * Only newly synced transactions will have the external account type.
+ * Swaps a system account to the provider's type, syncs the provider's
+ * transactions, and absorbs the unexplained balance residual into the opening
+ * balance. Queue-synced providers (metadata.features.queuedSync) get the bank
+ * balance written inline and the sync plus residual absorb deferred to the
+ * queue via the `pendingAbsorb` marker.
  */
 export const linkAccountToBankConnection = withTransaction(
   async ({
@@ -64,7 +56,6 @@ export const linkAccountToBankConnection = withTransaction(
     externalAccountId,
     userId,
   }: LinkAccountToBankConnectionPayload): Promise<LinkResult> => {
-    // 1. Fetch and validate the account (owner-scoped: the where-clause can't match another user's row)
     const account = await getAccountById({ id: accountId, userId });
 
     if (!account) {
@@ -74,7 +65,6 @@ export const linkAccountToBankConnection = withTransaction(
       });
     }
 
-    // Verify account is a system account
     if (account.type !== ACCOUNT_TYPES.system) {
       throw new ValidationError({
         message: 'Only system accounts can be linked to a bank connection.',
@@ -83,7 +73,6 @@ export const linkAccountToBankConnection = withTransaction(
 
     assertNotDerivedBalanceAccount({ account, actionPhrase: 'be linked to a bank connection' });
 
-    // 2. Fetch and validate the bank connection
     const bankConnection = await BankDataProviderConnections.findOne({
       where: {
         id: connectionId,
@@ -104,7 +93,6 @@ export const linkAccountToBankConnection = withTransaction(
       });
     }
 
-    // 3. Get provider and fetch external account details
     const provider = bankProviderRegistry.get(bankConnection.providerType as BANK_PROVIDER_TYPE);
     const externalAccounts = await provider.fetchAccounts(connectionId);
 
@@ -117,25 +105,23 @@ export const linkAccountToBankConnection = withTransaction(
       });
     }
 
-    // 4. Verify currency match
     if (externalAccount.currency.toLowerCase() !== account.currencyCode.toLowerCase()) {
       throw new ValidationError({
         message: `Currency mismatch: System account uses ${account.currencyCode}, but external account uses ${externalAccount.currency}. Only accounts with matching currencies can be linked.`,
       });
     }
 
-    // 5. Calculate balance difference
     const systemBalance = account.currentBalance.toCents();
     const externalBalance = externalAccount.balance;
     const balanceDifference = externalBalance - systemBalance;
 
-    // 6. Store current state in account metadata before linking
+    const isQueuedSyncProvider = provider.metadata.features.queuedSync === true;
+
     const existingExternalData = account.externalData || {};
     const linkedAt = new Date().toISOString();
 
-    // 7. Update account metadata with linking information
-    // Include external account metadata (iban, product, ownerName, etc.) to ensure
-    // IBAN is stored for account matching during reconnection flows
+    // External account metadata (iban, ownerName, ...) is stored so reconnection
+    // flows can match accounts by IBAN.
     const updatedExternalData: AccountExternalData = {
       ...existingExternalData,
       ...externalAccount.metadata,
@@ -147,11 +133,11 @@ export const linkAccountToBankConnection = withTransaction(
           externalBalance,
           difference: balanceDifference,
           adjustmentTransactionId: null,
+          ...(isQueuedSyncProvider ? { pendingAbsorb: true } : {}),
         },
       },
     };
 
-    // 8. Update account to external type
     const newAccountType = PROVIDER_TO_ACCOUNT_TYPE[bankConnection.providerType as BANK_PROVIDER_TYPE];
 
     await account.update({
@@ -161,15 +147,11 @@ export const linkAccountToBankConnection = withTransaction(
       bankDataProviderConnectionId: connectionId,
     });
 
-    // Note: We intentionally do NOT convert existing system transactions to the new account type.
-    // Existing transactions remain as 'system' type (or whatever they are at this point of time)
-    // to maintain data integrity and audit trail.
-    // Only new transactions synced from the provider will have the external account type.
+    // Existing transactions keep their current type as an audit trail; only
+    // newly synced rows get the provider account type.
 
-    // 9. Update connection's last sync timestamp
     await bankConnection.update({ lastSyncAt: new Date() });
 
-    // 10. Add account to the connection's AccountGroup if it exists and account is ungrouped
     const connectionGroup = await AccountGroup.findOne({
       where: { bankDataProviderConnectionId: connectionId, userId },
     });
@@ -184,25 +166,57 @@ export const linkAccountToBankConnection = withTransaction(
       }
     }
 
-    // 11. Trigger automatic transaction sync for the newly linked account
-    // This uses the syncTransactionsForAccount service which handles all the logic
-    // including checking correct from-to dates, rate limits, and provider-specific behavior
+    if (isQueuedSyncProvider) {
+      // The bank balance is already in hand from fetchAccounts; write it now
+      // or the account keeps the stale pre-link figure while the queue drains,
+      // forever when the sync window returns nothing.
+      await writeBankBalanceWithHistory({ account, balance: Money.fromCents(externalBalance) });
+
+      // Enqueue only after this transaction commits: the first queue batch
+      // runs immediately, and a worker racing an uncommitted link would read
+      // pre-link account state and commit rows that corrupt the residual math.
+      const sequelizeTx = namespace.get('transaction');
+      const startPostLinkSync = () => {
+        syncTransactionsForAccount({ connectionId, userId, accountId }).catch(async (error: Error) => {
+          logger.error(
+            { message: 'Post-link transaction sync failed to start', error },
+            { code: 'ACCOUNT_LINK_POST_COMMIT_SYNC_FAILED', accountId, connectionId, userId },
+          );
+          // The link already returned 200; without this the account shows no
+          // sync state at all and the failure is invisible until the next sync.
+          await setAccountSyncStatus({
+            accountId: accountId as RecordId,
+            status: SyncStatus.FAILED,
+            error: error.message,
+            userId,
+          }).catch(() => {});
+        });
+      };
+      if (sequelizeTx) {
+        sequelizeTx.afterCommit(startPostLinkSync);
+      } else {
+        startPostLinkSync();
+      }
+
+      const updatedAccount = (await Accounts.findByPk(accountId))!;
+
+      return {
+        account: updatedAccount,
+        balanceAdjustmentTransaction: null,
+        balanceDifference,
+      };
+    }
+
     await syncTransactionsForAccount({
       connectionId,
       userId,
       accountId,
     });
 
-    // 12. Re-anchor the opening balance against what the sync actually wrote.
-    // Providers that enqueue their sync (Monobank) have changed nothing yet, so
-    // the gap is zero and this is a no-op for them.
     const absorbedResidual = await absorbLinkResidualIntoOpeningBalance({ accountId, userId });
 
-    // 13. Fetch and return the updated account
     const updatedAccount = (await Accounts.findByPk(accountId))!;
 
-    // 14. Record what the absorb moved, alongside the reconciliation snapshot
-    // written in step 7 (before the sync had run and could produce a residual).
     if (absorbedResidual !== 0) {
       const currentExternalData = (updatedAccount.externalData || {}) as AccountExternalData;
       const connectionMeta = currentExternalData.bankConnection ?? updatedExternalData.bankConnection!;
@@ -225,90 +239,3 @@ export const linkAccountToBankConnection = withTransaction(
     };
   },
 );
-
-/**
- * Restores `initialBalance + Σsigned(tx) = currentBalance` after the post-link
- * sync backfilled the provider's transactions and force-wrote its authoritative
- * balance. Only the opening balance moves: the bank owns `currentBalance`, and
- * the residual is by definition history the provider never handed us.
- *
- * The account row is read under SELECT ... FOR UPDATE so the read-compute-write
- * serializes against a concurrent import or sync absorbing into the same account.
- *
- * Returns the absorbed residual in cents (0 when the identity already holds).
- */
-const absorbLinkResidualIntoOpeningBalance = async ({
-  accountId,
-  userId,
-}: {
-  accountId: string;
-  userId: number;
-}): Promise<number> => {
-  const sequelizeTx = namespace.get('transaction');
-
-  // The lock must be taken BEFORE the ledger sum: a concurrent sync blocks on
-  // this row lock, so summing first would pair a pre-sync transaction sum with
-  // a post-sync currentBalance and absorb the concurrent delta into the
-  // opening balance.
-  const account = await Accounts.findOne({
-    where: { id: accountId, userId },
-    transaction: sequelizeTx,
-    lock: sequelizeTx?.LOCK.UPDATE,
-  });
-  if (!account) {
-    logger.error(
-      {
-        message: 'Account missing when absorbing the post-link balance residual',
-        error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
-      },
-      { code: 'ACCOUNT_LINK_RESIDUAL_ACCOUNT_MISSED', accountId, userId },
-    );
-    return 0;
-  }
-
-  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
-    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
-     FROM "Transactions" WHERE "accountId" = :accountId`,
-    {
-      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
-      type: QueryTypes.SELECT,
-      transaction: sequelizeTx,
-    },
-  );
-
-  const signedSumCents = Number(row?.signedSum ?? 0);
-  const initialBalanceBefore = account.initialBalance;
-  const identityGapCents = account.currentBalance.toCents() - (initialBalanceBefore.toCents() + signedSumCents);
-  if (identityGapCents === 0) return 0;
-
-  const initialBalanceAfter = initialBalanceBefore.add(Money.fromCents(identityGapCents));
-  await Accounts.update({ initialBalance: initialBalanceAfter }, { where: { id: accountId, userId } });
-  await restampRefInitialBalance({ accountId, allowProviderAccount: true });
-
-  // The restamp cascade shifts every Balances row by the opening-balance diff,
-  // including today's — which the sync just pinned to the bank's authoritative
-  // balance. Re-pin it from the post-restamp row so the spot value survives.
-  const restamped = await Accounts.findOne({ where: { id: accountId, userId }, transaction: sequelizeTx });
-  if (restamped) {
-    await Balances.setTodayRowToSpot({ account: restamped });
-  } else {
-    logger.error(
-      {
-        message: 'Account re-read after restampRefInitialBalance missed; the current-day balance row stays cascaded',
-        error: new Error(`Accounts.findOne returned null for accountId=${accountId}`),
-      },
-      { code: 'ACCOUNT_LINK_RESIDUAL_REREAD_MISSED', accountId, userId },
-    );
-  }
-
-  logger.info('Absorbed post-link balance residual into the opening balance', {
-    accountId,
-    userId,
-    signedSumCents,
-    identityGapCents,
-    initialBalanceBeforeCents: initialBalanceBefore.toCents(),
-    initialBalanceAfterCents: initialBalanceAfter.toCents(),
-  });
-
-  return identityGapCents;
-};

--- a/packages/backend/src/services/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/services/accounts/link-to-bank-connection.ts
@@ -246,16 +246,10 @@ const absorbLinkResidualIntoOpeningBalance = async ({
 }): Promise<number> => {
   const sequelizeTx = namespace.get('transaction');
 
-  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
-    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
-     FROM "Transactions" WHERE "accountId" = :accountId`,
-    {
-      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
-      type: QueryTypes.SELECT,
-      transaction: sequelizeTx,
-    },
-  );
-
+  // The lock must be taken BEFORE the ledger sum: a concurrent sync blocks on
+  // this row lock, so summing first would pair a pre-sync transaction sum with
+  // a post-sync currentBalance and absorb the concurrent delta into the
+  // opening balance.
   const account = await Accounts.findOne({
     where: { id: accountId, userId },
     transaction: sequelizeTx,
@@ -271,6 +265,16 @@ const absorbLinkResidualIntoOpeningBalance = async ({
     );
     return 0;
   }
+
+  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
+    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
+     FROM "Transactions" WHERE "accountId" = :accountId`,
+    {
+      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
+      type: QueryTypes.SELECT,
+      transaction: sequelizeTx,
+    },
+  );
 
   const signedSumCents = Number(row?.signedSum ?? 0);
   const initialBalanceBefore = account.initialBalance;

--- a/packages/backend/src/services/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/services/accounts/link-to-bank-connection.ts
@@ -17,6 +17,7 @@ import { restampRefInitialBalance } from '@services/accounts/restamp-ref-initial
 import { bankProviderRegistry } from '@services/bank-data-providers';
 import { syncTransactionsForAccount } from '@services/bank-data-providers/connection/sync-transactions-for-account';
 import { withTransaction } from '@services/common/with-transaction';
+import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
 import { QueryTypes } from 'sequelize';
 
 const PROVIDER_TO_ACCOUNT_TYPE: Record<BANK_PROVIDER_TYPE, ACCOUNT_TYPES> = {
@@ -116,6 +117,8 @@ export const linkAccountToBankConnection = withTransaction(
         message: 'Only system accounts can be linked to a bank connection.',
       });
     }
+
+    assertNotDerivedBalanceAccount({ account, actionPhrase: 'be linked to a bank connection' });
 
     // 2. Fetch and validate the bank connection
     const bankConnection = await BankDataProviderConnections.findOne({

--- a/packages/backend/src/services/accounts/link-to-bank-connection.ts
+++ b/packages/backend/src/services/accounts/link-to-bank-connection.ts
@@ -3,8 +3,6 @@ import {
   API_ERROR_CODES,
   type AccountExternalData,
   BANK_PROVIDER_TYPE,
-  PAYMENT_TYPES,
-  TRANSACTION_TRANSFER_NATURE,
   TRANSACTION_TYPES,
 } from '@bt/shared/types';
 import { Money } from '@common/types/money';
@@ -13,11 +11,13 @@ import AccountGrouping from '@models/accounts-groups/account-grouping.model';
 import AccountGroup from '@models/accounts-groups/account-groups.model';
 import Accounts, { getAccountById } from '@models/accounts.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import { namespace } from '@models/connection';
 import Transactions from '@models/transactions.model';
+import { restampRefInitialBalance } from '@services/accounts/restamp-ref-initial-balance';
 import { bankProviderRegistry } from '@services/bank-data-providers';
 import { syncTransactionsForAccount } from '@services/bank-data-providers/connection/sync-transactions-for-account';
 import { withTransaction } from '@services/common/with-transaction';
-import { createTransaction } from '@services/transactions/create-transaction';
+import { QueryTypes } from 'sequelize';
 
 const PROVIDER_TO_ACCOUNT_TYPE: Record<BANK_PROVIDER_TYPE, ACCOUNT_TYPES> = {
   [BANK_PROVIDER_TYPE.MONOBANK]: ACCOUNT_TYPES.monobank,
@@ -36,9 +36,48 @@ interface LinkAccountToBankConnectionPayload {
 
 interface LinkResult {
   account: Accounts;
-  balanceAdjustmentTransaction?: Transactions | null;
+  balanceAdjustmentTransaction: null;
   balanceDifference: number;
 }
+
+/**
+ * Restores `initialBalance + Σsigned(tx) = currentBalance` after the post-link
+ * sync backfilled the provider's transactions and force-wrote its authoritative
+ * balance. Only the opening balance moves: the bank owns `currentBalance`, and
+ * the residual is by definition history the provider never handed us.
+ */
+const absorbLinkResidualIntoOpeningBalance = async ({
+  accountId,
+  userId,
+}: {
+  accountId: string;
+  userId: number;
+}): Promise<void> => {
+  const sequelizeTx = namespace.get('transaction');
+
+  const [row] = await Transactions.sequelize!.query<{ signedSum: string }>(
+    `SELECT COALESCE(SUM(CASE WHEN "transactionType" = :incomeType THEN "amount" ELSE -"amount" END), 0) AS "signedSum"
+     FROM "Transactions" WHERE "accountId" = :accountId`,
+    {
+      replacements: { accountId, incomeType: TRANSACTION_TYPES.income },
+      type: QueryTypes.SELECT,
+      transaction: sequelizeTx,
+    },
+  );
+
+  const account = await Accounts.findOne({ where: { id: accountId, userId }, transaction: sequelizeTx });
+  if (!account) return;
+
+  const signedSumCents = Number(row?.signedSum ?? 0);
+  const identityGapCents = account.currentBalance.toCents() - (account.initialBalance.toCents() + signedSumCents);
+  if (identityGapCents === 0) return;
+
+  await Accounts.update(
+    { initialBalance: Money.fromCents(account.initialBalance.toCents() + identityGapCents) },
+    { where: { id: accountId, userId } },
+  );
+  await restampRefInitialBalance({ accountId, allowProviderAccount: true });
+};
 
 /**
  * Links a system account to a bank connection using forward-only strategy.
@@ -46,9 +85,10 @@ interface LinkResult {
  * 1. Validates the account is a system account
  * 2. Fetches current balance from external provider
  * 3. Validates currency match between system and external accounts
- * 4. Creates balance adjustment transaction if there's a difference
- * 5. Updates account type to match provider (e.g., 'monobank')
- * 6. Stores linking metadata in account's externalData
+ * 4. Updates account type to match provider (e.g., 'monobank')
+ * 5. Stores linking metadata in account's externalData
+ * 6. Syncs the provider's transactions, then absorbs whatever balance residual
+ *    those transactions do not explain into the opening balance
  *
  * Note: Existing transactions remain as 'system' type to preserve data integrity.
  * Only newly synced transactions will have the external account type.
@@ -127,40 +167,7 @@ export const linkAccountToBankConnection = withTransaction(
     const existingExternalData = account.externalData || {};
     const linkedAt = new Date().toISOString();
 
-    // 7. Create balance adjustment transaction if needed
-    let balanceAdjustmentTransaction: Transactions | null = null;
-
-    if (balanceDifference !== 0) {
-      // Create transfer_out_wallet transaction to reconcile the difference
-      // Note: The transaction hook will automatically update the account balance
-      const [createdTransaction] = await createTransaction({
-        userId,
-        accountId: account.id,
-        amount: Money.fromCents(Math.abs(balanceDifference)),
-        time: new Date(),
-        transactionType: balanceDifference > 0 ? TRANSACTION_TYPES.income : TRANSACTION_TYPES.expense,
-        transferNature: TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
-        // At this point of time transactions should still be "system" because its
-        // behaviour is system-like one
-        accountType: ACCOUNT_TYPES.system,
-        paymentType: PAYMENT_TYPES.bankTransfer, // Balance adjustment from bank connection
-        note: `Balance adjustment when linking to bank connection. System: ${systemBalance}, External: ${externalBalance}`,
-        externalData: {
-          type: 'bank_connection_balance_adjustment',
-          connectionId,
-          linkedAt,
-          balances: {
-            system: systemBalance,
-            external: externalBalance,
-            difference: balanceDifference,
-          },
-        },
-      });
-
-      balanceAdjustmentTransaction = createdTransaction;
-    }
-
-    // 8. Update account metadata with linking information
+    // 7. Update account metadata with linking information
     // Include external account metadata (iban, product, ownerName, etc.) to ensure
     // IBAN is stored for account matching during reconnection flows
     const updatedExternalData: AccountExternalData = {
@@ -173,12 +180,12 @@ export const linkAccountToBankConnection = withTransaction(
           systemBalance,
           externalBalance,
           difference: balanceDifference,
-          adjustmentTransactionId: balanceAdjustmentTransaction?.id || null,
+          adjustmentTransactionId: null,
         },
       },
     };
 
-    // 9. Update account to external type
+    // 8. Update account to external type
     const newAccountType = PROVIDER_TO_ACCOUNT_TYPE[bankConnection.providerType as BANK_PROVIDER_TYPE];
 
     await account.update({
@@ -193,10 +200,10 @@ export const linkAccountToBankConnection = withTransaction(
     // to maintain data integrity and audit trail.
     // Only new transactions synced from the provider will have the external account type.
 
-    // 10. Update connection's last sync timestamp
+    // 9. Update connection's last sync timestamp
     await bankConnection.update({ lastSyncAt: new Date() });
 
-    // 11. Add account to the connection's AccountGroup if it exists and account is ungrouped
+    // 10. Add account to the connection's AccountGroup if it exists and account is ungrouped
     const connectionGroup = await AccountGroup.findOne({
       where: { bankDataProviderConnectionId: connectionId, userId },
     });
@@ -211,7 +218,7 @@ export const linkAccountToBankConnection = withTransaction(
       }
     }
 
-    // 12. Trigger automatic transaction sync for the newly linked account
+    // 11. Trigger automatic transaction sync for the newly linked account
     // This uses the syncTransactionsForAccount service which handles all the logic
     // including checking correct from-to dates, rate limits, and provider-specific behavior
     await syncTransactionsForAccount({
@@ -220,12 +227,17 @@ export const linkAccountToBankConnection = withTransaction(
       accountId,
     });
 
+    // 12. Re-anchor the opening balance against what the sync actually wrote.
+    // Providers that enqueue their sync (Monobank) have changed nothing yet, so
+    // the gap is zero and this is a no-op for them.
+    await absorbLinkResidualIntoOpeningBalance({ accountId, userId });
+
     // 13. Fetch and return the updated account
     const updatedAccount = await Accounts.findByPk(accountId);
 
     return {
       account: updatedAccount!,
-      balanceAdjustmentTransaction,
+      balanceAdjustmentTransaction: null,
       balanceDifference,
     };
   },

--- a/packages/backend/src/services/accounts/restamp-ref-initial-balance.ts
+++ b/packages/backend/src/services/accounts/restamp-ref-initial-balance.ts
@@ -9,28 +9,19 @@ import { Op } from 'sequelize';
 import { withTransaction } from '../common/with-transaction';
 
 /**
- * Re-stamps `refInitialBalance` at the exchange rate of the account's ledger
- * boundary — the date the opening balance actually existed.
- *
- * For a tx-backed system account, `initialBalance` is the balance immediately
- * BEFORE the earliest transaction, so its base-currency value uses that date's
- * rate. Converting at the account's creation date instead (e.g. an import of
- * years-old history) mixes an import-day rate into a ledger whose transactions
- * each carry their own historical rate.
- *
- * The boundary moves whenever a transaction older than all existing ones is added
- * or the earliest is deleted/re-dated, so this runs from the per-transaction
- * balance hook. With no transactions there is no boundary: the opening balance is
- * stamped at the latest rate, matching account creation.
- *
- * Scope: system accounts, excluding loans and vehicles. Bank-provider accounts
- * keep their provider-owned opening snapshot, a loan's `refInitialBalance` is its
- * balance-anchor value stamped by `updateLoan`, and a vehicle's opening is its
- * purchase value with no transactions to define a boundary.
- *
- * `allowProviderAccount` opts a bank-provider account in, for the callers that
- * deliberately rewrite its `initialBalance` (linking an existing account to a
- * connection) and therefore own the ref stamp too.
+ * 'failed' keeps the previous stamp: hook callers tolerate it (a missing rate
+ * must not fail a transaction write); callers that just rewrote
+ * `initialBalance` must not.
+ */
+type RestampOutcome = 'restamped' | 'unchanged' | 'skipped' | 'failed';
+
+/**
+ * Re-stamps `refInitialBalance` at the exchange rate of the ledger boundary:
+ * the date immediately before the account's earliest transaction (now, when
+ * there are none). Stamping at any other date mixes a foreign rate into a
+ * ledger whose transactions each carry their own historical rate. Scope:
+ * system accounts minus loans and vehicles, whose stamps are owned by their
+ * dedicated flows.
  */
 async function restampRefInitialBalanceImpl({
   accountId,
@@ -43,16 +34,20 @@ async function restampRefInitialBalanceImpl({
    * BeforeDestroy hook, where it still exists.
    */
   excludeTransactionId?: string;
+  /**
+   * Opts a bank-provider account in, for a caller that deliberately rewrote
+   * `initialBalance` and therefore owns the ref stamp too.
+   */
   allowProviderAccount?: boolean;
-}): Promise<void> {
+}): Promise<RestampOutcome> {
   const account = await Accounts.findOne({ where: { id: accountId } });
-  if (!account) return;
+  if (!account) return 'skipped';
   if (
     (account.type !== ACCOUNT_TYPES.system && !allowProviderAccount) ||
     account.accountCategory === ACCOUNT_CATEGORIES.loan ||
     account.accountCategory === ACCOUNT_CATEGORIES.vehicle
   ) {
-    return;
+    return 'skipped';
   }
 
   const earliestTxTime = (await Transactions.min('time', {
@@ -82,10 +77,10 @@ async function restampRefInitialBalanceImpl({
       },
       { code: 'ACCOUNT_REF_INITIAL_RESTAMP_FAILED', accountId, userId: account.userId },
     );
-    return;
+    return 'failed';
   }
 
-  if (refInitialBalance.equals(account.refInitialBalance)) return;
+  if (refInitialBalance.equals(account.refInitialBalance)) return 'unchanged';
 
   await Accounts.update({ refInitialBalance }, { where: { id: accountId } });
 
@@ -95,9 +90,8 @@ async function restampRefInitialBalanceImpl({
   if (updated) {
     await Balances.handleAccountChange({ account: updated, prevAccount: account });
   } else {
-    // The row was just updated above, so a miss is an impossible-state (concurrent
-    // delete / id drift). `refInitialBalance` persisted but the history cascade is
-    // skipped — the chart diverges from the new stamp until the next full rebuild.
+    // Impossible state: the row was updated above. The stamp persisted but the
+    // history cascade is skipped, so the chart diverges until the next rebuild.
     logger.error(
       {
         message:
@@ -106,6 +100,7 @@ async function restampRefInitialBalanceImpl({
       { code: 'ACCOUNT_REF_INITIAL_RESTAMP_REREAD_MISSED', accountId, userId: account.userId },
     );
   }
+  return 'restamped';
 }
 
 export const restampRefInitialBalance = withTransaction(restampRefInitialBalanceImpl);

--- a/packages/backend/src/services/accounts/restamp-ref-initial-balance.ts
+++ b/packages/backend/src/services/accounts/restamp-ref-initial-balance.ts
@@ -27,10 +27,15 @@ import { withTransaction } from '../common/with-transaction';
  * keep their provider-owned opening snapshot, a loan's `refInitialBalance` is its
  * balance-anchor value stamped by `updateLoan`, and a vehicle's opening is its
  * purchase value with no transactions to define a boundary.
+ *
+ * `allowProviderAccount` opts a bank-provider account in, for the callers that
+ * deliberately rewrite its `initialBalance` (linking an existing account to a
+ * connection) and therefore own the ref stamp too.
  */
 async function restampRefInitialBalanceImpl({
   accountId,
   excludeTransactionId,
+  allowProviderAccount = false,
 }: {
   accountId: string;
   /**
@@ -38,11 +43,12 @@ async function restampRefInitialBalanceImpl({
    * BeforeDestroy hook, where it still exists.
    */
   excludeTransactionId?: string;
+  allowProviderAccount?: boolean;
 }): Promise<void> {
   const account = await Accounts.findOne({ where: { id: accountId } });
   if (!account) return;
   if (
-    account.type !== ACCOUNT_TYPES.system ||
+    (account.type !== ACCOUNT_TYPES.system && !allowProviderAccount) ||
     account.accountCategory === ACCOUNT_CATEGORIES.loan ||
     account.accountCategory === ACCOUNT_CATEGORIES.vehicle
   ) {

--- a/packages/backend/src/services/bank-data-providers/connection/transaction-sync.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/transaction-sync.e2e.ts
@@ -1070,8 +1070,8 @@ describe.skip('Bank Data Provider Transaction Sync E2E', () => {
         raw: true,
       });
 
-      // Should have 5 synced transactions + 1 balance adjustment transaction from linking
-      expect(transactions.length).toBe(6);
+      // Should have 5 synced transactions; linking itself creates no rows
+      expect(transactions.length).toBe(5);
 
       // Find external transactions (those with originalId)
       const externalTransactions = transactions.filter((tx) => tx.originalId !== null);
@@ -1185,9 +1185,8 @@ describe.skip('Bank Data Provider Transaction Sync E2E', () => {
         raw: true,
       });
 
-      // Should have: 1 balance adjustment + 5 original external + 1 manual + 3 new external + 1 new balance adjustment = 11 transactions
-      // Or it might be fewer if there's no balance adjustment on second link
-      expect(transactions.length).toBeGreaterThanOrEqual(10);
+      // Should have: 5 original external + 1 manual + 3 new external = 9 transactions
+      expect(transactions.length).toBeGreaterThanOrEqual(9);
 
       // 14. Verify account balance updated (we don't check exact amount due to complex balance logic)
       account = (await Accounts.findByPk(systemAccount.id))!;

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -731,6 +731,42 @@ describe('Enable Banking dedup improvements (E2E)', () => {
       expect(externalData.entryReference).toBe('booked_ref_647');
     });
 
+    it('does not let a reference-less booked copy consume a pending row that carries an entry_reference', async () => {
+      helpers.enablebanking.setFixedTransactions([
+        {
+          ...CARD_PENDING,
+          amount: '77.15',
+          transactionDate: '2025-04-10',
+          remittanceInformation: ['PENDING WITH REFERENCE'],
+          entryReference: 'pending_ref_X',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const afterPendingSync = await listTransactions({ accountId });
+      expect(afterPendingSync.length).toBe(1);
+      const pendingTx = afterPendingSync[0]!;
+      expect((await readExternalData({ id: pendingTx.id })).entryReference).toBe('pending_ref_X');
+
+      // No entry_reference on the incoming payload means tier 1 never ran, so the
+      // stored reference was never compared. Consuming the row would be a guess.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          ...CARD_BOOKED,
+          amount: '77.15',
+          bookingDate: '2025-04-11',
+          remittanceInformation: ['BOOKED WITHOUT REFERENCE'],
+        },
+      ]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const finalRows = await listTransactions({ accountId });
+      expect(finalRows.length).toBe(2);
+      const stillPending = await readExternalData({ id: pendingTx.id });
+      expect(stillPending.rawTransaction?.status).toBe('PDNG');
+      expect(stillPending.entryReference).toBe('pending_ref_X');
+    });
+
     it('pairs a booked re-issue with its nearest pending row, not the first candidate', async () => {
       helpers.enablebanking.setFixedTransactions([
         { ...CARD_PENDING, amount: '25.00', transactionDate: '2025-02-03', remittanceInformation: ['PENDING EARLY'] },

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -689,10 +689,9 @@ describe('Enable Banking dedup improvements (E2E)', () => {
     });
 
     it('upgrades a pending row carrying an entry_reference when its booked copy arrives under a different reference', async () => {
-      // Some ASPSPs stamp an entry_reference on the pending authorisation and a
-      // DIFFERENT one on the booked copy: tier 1 misses (references differ) and
-      // the hash misses (it is derived from the reference), so the pending tier
-      // is the only path left.
+      // Some ASPSPs stamp different entry_references on the pending
+      // authorisation and its booked copy: tier 1 and the reference-derived
+      // hash both miss, so the pending tier is the only path left.
       helpers.enablebanking.setFixedTransactions([
         {
           ...CARD_PENDING,

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -688,6 +688,49 @@ describe('Enable Banking dedup improvements (E2E)', () => {
       expect(externalData.entryReference).toBe('booked_ref_001');
     });
 
+    it('upgrades a pending row carrying an entry_reference when its booked copy arrives under a different reference', async () => {
+      // Some ASPSPs stamp an entry_reference on the pending authorisation and a
+      // DIFFERENT one on the booked copy: tier 1 misses (references differ) and
+      // the hash misses (it is derived from the reference), so the pending tier
+      // is the only path left.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          ...CARD_PENDING,
+          amount: '647.31',
+          transactionDate: '2025-03-02',
+          remittanceInformation: ['LIDL254STHLMAKALLA STOCKHOLM'],
+          entryReference: 'pending_ref_647',
+        },
+      ]);
+      const { connectionId, accountId } = await setupConnectionWithAccount();
+
+      const afterPendingSync = await listTransactions({ accountId });
+      expect(afterPendingSync.length).toBe(1);
+      const pendingTx = afterPendingSync[0]!;
+      expect((await readExternalData({ id: pendingTx.id })).rawTransaction?.status).toBe('PDNG');
+      expect((await readExternalData({ id: pendingTx.id })).entryReference).toBe('pending_ref_647');
+
+      helpers.enablebanking.setFixedTransactions([
+        {
+          ...CARD_BOOKED,
+          amount: '647.31',
+          bookingDate: '2025-03-03',
+          remittanceInformation: ['LIDL254STHLMAKALLA K5529 Kortköp/uttag'],
+          entryReference: 'booked_ref_647',
+        },
+      ]);
+      await helpers.bankDataProviders.syncTransactionsForAccount({ connectionId, accountId, raw: true });
+
+      const afterBookedSync = await listTransactions({ accountId });
+      expect(afterBookedSync.length).toBe(1);
+      const upgraded = afterBookedSync[0]!;
+      expect(upgraded.id).toBe(pendingTx.id);
+
+      const externalData = await readExternalData({ id: upgraded.id });
+      expect(externalData.rawTransaction?.status).toBe('BOOK');
+      expect(externalData.entryReference).toBe('booked_ref_647');
+    });
+
     it('pairs a booked re-issue with its nearest pending row, not the first candidate', async () => {
       helpers.enablebanking.setFixedTransactions([
         { ...CARD_PENDING, amount: '25.00', transactionDate: '2025-02-03', remittanceInformation: ['PENDING EARLY'] },

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -1572,7 +1572,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     // the sync where an entry_reference-less row finally gets one. Requires a
     // matching counterparty IBAN so recurring same-amount payments to different
     // parties don't collapse, and only considers rows with no stored
-    // entryReference – a row carrying one is either the same transaction (already
+    // entryReference: a row carrying one is either the same transaction (already
     // returned by tier 1) or a different one. The pending-upgrade exception, where
     // the booked copy arrives under a fresh reference, is tier 4's job.
     if (counterpartyIban) {

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -806,7 +806,6 @@ export class EnableBankingProvider extends BaseBankDataProvider {
           // sync every row is unmatched. Flips to true as soon as this run stores a
           // pending row so a same-batch booked copy can still upgrade it.
           let accountHasPendingRows = await this.accountHasPendingRows({ accountId: account.id });
-          let pendingWithEntryReferenceCount = 0;
           let stalePendingIgnoredCount = 0;
           let revokedRemovedCount = 0;
           let revokedKeptCount = 0;
@@ -967,9 +966,6 @@ export class EnableBankingProvider extends BaseBankDataProvider {
 
             if (isPreBookingStatus({ status: incomingStatus })) {
               accountHasPendingRows = true;
-              if (getRawTransaction({ externalData: tx.metadata })?.entry_reference != null) {
-                pendingWithEntryReferenceCount++;
-              }
             }
           }
 
@@ -983,14 +979,6 @@ export class EnableBankingProvider extends BaseBankDataProvider {
           ) {
             logger.info(
               `Enable Banking sync: ${createdTransactionIds.length} created, ${updatedCount} updated, ${stalePendingIgnoredCount} stale pending ignored, ${revokedRemovedCount} revoked removed, ${revokedKeptCount} revoked kept for account ${account.id}`,
-            );
-          }
-
-          if (pendingWithEntryReferenceCount > 0) {
-            // The pending-upgrade tier only considers rows without an entry reference,
-            // so this bank's pending rows can never be adopted by their booked copy.
-            logger.info(
-              `Enable Banking sync: account ${account.id} stored ${pendingWithEntryReferenceCount} pre-booking row(s) carrying an entry_reference; pending upgrade cannot see them`,
             );
           }
 
@@ -1604,11 +1592,12 @@ export class EnableBankingProvider extends BaseBankDataProvider {
       if (byFingerprint) return byFingerprint;
     }
 
-    // (4) Pending upgrade. A card purchase first arrives as PDNG or HOLD with no
-    // entry_reference and is re-issued as BOOK with a fresh reference and
-    // different remittance text, so no earlier tier sees it. Safety comes from
+    // (4) Pending upgrade. A card purchase first arrives as PDNG or HOLD and is
+    // re-issued as BOOK with different remittance text and, on some ASPSPs, a
+    // different entry_reference, so no earlier tier sees it. Safety comes from
     // the pre-booking-only candidate pool, exact amount/currency/type equality, the
     // conditional IBAN gate below, and the caller flipping the matched row to BOOK.
+    // A candidate whose reference equals the incoming one already returned in (1).
     if (!accountHasPendingRows) return null;
     if (getRawTransactionStatus({ externalData: tx.metadata }) !== TransactionStatus.BOOK) return null;
 
@@ -1622,7 +1611,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         time: {
           [Op.between]: [subDays(tx.date, PENDING_UPGRADE_WINDOW_DAYS), addDays(tx.date, PENDING_UPGRADE_WINDOW_DAYS)],
         },
-        [Op.and]: [wherePreBookingStatus(), whereNoEntryReference()],
+        [Op.and]: [wherePreBookingStatus()],
       },
     });
 

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -1572,7 +1572,9 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     // the sync where an entry_reference-less row finally gets one. Requires a
     // matching counterparty IBAN so recurring same-amount payments to different
     // parties don't collapse, and only considers rows with no stored
-    // entryReference – a row carrying a different one is a different transaction.
+    // entryReference – a row carrying one is either the same transaction (already
+    // returned by tier 1) or a different one. The pending-upgrade exception, where
+    // the booked copy arrives under a fresh reference, is tier 4's job.
     if (counterpartyIban) {
       const byFingerprint = await Transactions.findOne({
         where: {
@@ -1597,7 +1599,10 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     // different entry_reference, so no earlier tier sees it. Safety comes from
     // the pre-booking-only candidate pool, exact amount/currency/type equality, the
     // conditional IBAN gate below, and the caller flipping the matched row to BOOK.
-    // A candidate whose reference equals the incoming one already returned in (1).
+    // A stored entryReference is only tolerated when the incoming payload carries
+    // one too: then tier 1 has already ruled out an equal-reference row, so the
+    // mismatch is the fresh-reference re-issue. A reference-less payload never
+    // reaches tier 1, so it may only consume reference-less candidates.
     if (!accountHasPendingRows) return null;
     if (getRawTransactionStatus({ externalData: tx.metadata }) !== TransactionStatus.BOOK) return null;
 
@@ -1611,7 +1616,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         time: {
           [Op.between]: [subDays(tx.date, PENDING_UPGRADE_WINDOW_DAYS), addDays(tx.date, PENDING_UPGRADE_WINDOW_DAYS)],
         },
-        [Op.and]: [wherePreBookingStatus()],
+        [Op.and]: entryReference ? [wherePreBookingStatus()] : [wherePreBookingStatus(), whereNoEntryReference()],
       },
     });
 

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
@@ -1178,7 +1178,7 @@ describe('LunchFlow Data Provider E2E', () => {
         raw: true,
       });
 
-      // Must be exactly MOCK_AMOUNT — no duplicates, and linking mints no rows of its own
+      // Must be exactly MOCK_AMOUNT: no duplicates, and linking mints no rows of its own
       expect(syncedTx.length).toBe(MOCK_AMOUNT);
 
       // Date filtering means only transactions on or after the latest existing date
@@ -1300,7 +1300,7 @@ describe('LunchFlow Data Provider E2E', () => {
         raw: true,
       });
 
-      // 5. Verify: old bank transactions were NOT re-processed (filtered by date),
+      // 5. Verify: old bank transactions were NOT re-created as duplicates,
       //    only the 2 new ones were created
       const finalTx = await Transactions.findAll({
         where: { accountId },
@@ -1316,13 +1316,13 @@ describe('LunchFlow Data Provider E2E', () => {
       );
       expect(newSyncedTx.length).toBe(2);
 
-      // Verify the original 5 bank transactions still have originalId = null
-      // (they were NOT re-processed because their dates are before the latest tx).
-      // The 5 unlinked bank txs have originalId = null WITH originalSource.
-      const unlinkedBankTx = finalTx.filter(
-        (tx) => tx.originalId === null && (tx.externalData as Record<string, unknown>)?.originalSource,
+      // The original 5 bank rows matched by `externalData.originalSource`, so
+      // the relink restored their originalId instead of minting duplicates;
+      // future syncs dedup them through the fast primary path again.
+      const restoredBankTx = finalTx.filter(
+        (tx) => tx.originalId !== null && (tx.externalData as Record<string, unknown>)?.originalSource,
       );
-      expect(unlinkedBankTx.length).toBe(MOCK_AMOUNT);
+      expect(restoredBankTx.length).toBe(MOCK_AMOUNT);
     });
   });
 

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow-flow.e2e.ts
@@ -1173,17 +1173,12 @@ describe('LunchFlow Data Provider E2E', () => {
       });
 
       // 4. Verify no duplicates — should still have the same number of transactions
-      const afterRelinkTx = await Transactions.findAll({
+      const syncedTx = await Transactions.findAll({
         where: { accountId },
         raw: true,
       });
 
-      // The relink may create a balance adjustment transaction, so filter those out
-      const syncedTx = afterRelinkTx.filter(
-        (tx) => (tx.externalData as Record<string, unknown>)?.type !== 'bank_connection_balance_adjustment',
-      );
-
-      // Must be exactly MOCK_AMOUNT — no duplicates
+      // Must be exactly MOCK_AMOUNT — no duplicates, and linking mints no rows of its own
       expect(syncedTx.length).toBe(MOCK_AMOUNT);
 
       // Date filtering means only transactions on or after the latest existing date
@@ -1312,16 +1307,11 @@ describe('LunchFlow Data Provider E2E', () => {
         raw: true,
       });
 
-      // Filter out any balance adjustment transactions
-      const nonAdjustmentTx = finalTx.filter(
-        (tx) => (tx.externalData as Record<string, unknown>)?.type !== 'bank_connection_balance_adjustment',
-      );
-
       // 5 original bank txs + 1 manual tx + 2 new bank txs = 8
-      expect(nonAdjustmentTx.length).toBe(MOCK_AMOUNT + 1 + 2);
+      expect(finalTx.length).toBe(MOCK_AMOUNT + 1 + 2);
 
       // Verify the 2 new transactions were created with correct originalIds
-      const newSyncedTx = nonAdjustmentTx.filter(
+      const newSyncedTx = finalTx.filter(
         (tx) => tx.originalId === 'new-tx-after-manual-1' || tx.originalId === 'new-tx-after-manual-2',
       );
       expect(newSyncedTx.length).toBe(2);
@@ -1329,7 +1319,7 @@ describe('LunchFlow Data Provider E2E', () => {
       // Verify the original 5 bank transactions still have originalId = null
       // (they were NOT re-processed because their dates are before the latest tx).
       // The 5 unlinked bank txs have originalId = null WITH originalSource.
-      const unlinkedBankTx = nonAdjustmentTx.filter(
+      const unlinkedBankTx = finalTx.filter(
         (tx) => tx.originalId === null && (tx.externalData as Record<string, unknown>)?.originalSource,
       );
       expect(unlinkedBankTx.length).toBe(MOCK_AMOUNT);

--- a/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/lunchflow/lunchflow.provider.ts
@@ -25,8 +25,9 @@ import {
   ProviderTransaction,
 } from '@services/bank-data-providers';
 import { createTransaction } from '@services/transactions';
-import { Sequelize } from 'sequelize';
+import { Op, Sequelize } from 'sequelize';
 
+import { clampSyncStartToLink } from '../utils/clamp-sync-start-to-link';
 import { encryptCredentials } from '../utils/credential-encryption';
 import { writeBankBalanceWithHistory } from '../utils/write-bank-balance-with-history';
 import { LunchFlowApiClient } from './api-client';
@@ -296,19 +297,21 @@ export class LunchFlowProvider extends BaseBankDataProvider {
         }
 
         // Filter out pending transactions (those with null IDs)
-        let postedTransactions = transactionsResponse.transactions.filter((tx) => tx.id !== null);
+        const postedTransactions = transactionsResponse.transactions.filter((tx) => tx.id !== null);
 
-        // LunchFlow API doesn't support date-range filtering, so we filter in runtime.
-        // Only process transactions on or after the latest existing transaction date.
+        // LunchFlow has no server-side date filtering, so the window gates ROW
+        // CREATION only. Dedup and the unlink→relink originalId restoration
+        // below must see the whole feed: pre-window rows still match existing
+        // rows by originalSource. A future-dated planned row must not anchor
+        // the cutoff, or every genuinely new row is skipped until that date.
         const latestTransaction = await Transactions.findOne({
-          where: { accountId: account.id },
+          where: { accountId: account.id, time: { [Op.lte]: new Date() } },
           order: [['time', 'DESC']],
         });
 
-        if (latestTransaction) {
-          const fromDate = new Date(latestTransaction.time);
-          postedTransactions = postedTransactions.filter((tx) => new Date(tx.date) >= fromDate);
-        }
+        const createFromDate = latestTransaction
+          ? clampSyncStartToLink({ account, from: new Date(latestTransaction.time) })
+          : null;
 
         // Sort by date ascending
         postedTransactions.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
@@ -345,6 +348,12 @@ export class LunchFlowProvider extends BaseBankDataProvider {
           if (existingByOriginalSource) {
             // Restore the originalId so future syncs use the fast primary path
             await existingByOriginalSource.update({ originalId: tx.id! });
+            continue;
+          }
+
+          // Unmatched pre-window rows are pre-link/pre-existing history: the
+          // link residual absorb owns it, so never mint rows for it.
+          if (createFromDate && new Date(tx.date) < createFromDate) {
             continue;
           }
 

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
@@ -16,7 +16,9 @@ import {
   ProviderTransaction,
 } from '@services/bank-data-providers';
 import cc from 'currency-codes';
+import { Op } from 'sequelize';
 
+import { clampSyncStartToLink } from '../utils/clamp-sync-start-to-link';
 import { encryptCredentials } from '../utils/credential-encryption';
 import { writeBankBalanceWithHistory } from '../utils/write-bank-balance-with-history';
 import { MonobankApiClient } from './api-client';
@@ -38,6 +40,7 @@ export class MonobankProvider extends BaseBankDataProvider {
       requiresReauth: false,
       supportsManualSync: true,
       supportsAutoSync: true,
+      queuedSync: true,
       defaultSyncInterval: 4 * 60 * 60 * 1000, // 4 hours
       minSyncInterval: 60 * 1000, // 1 minute (Monobank API rate limit)
     },
@@ -208,17 +211,22 @@ export class MonobankProvider extends BaseBankDataProvider {
       enqueue: async () => {
         const account = await this.getSystemAccount(systemAccountId);
 
-        // Find the most recent transaction for this account
+        // A future-dated planned row must not anchor the window: it would push
+        // `from` past `to` and turn every sync into a no-op until that date
+        // passes.
         const latestTransaction = await Transactions.findOne({
           where: {
             accountId: account.id,
+            time: { [Op.lte]: new Date() },
           },
           order: [['time', 'DESC']],
         });
 
-        // Default to last 31 days if no transactions found
+        // Accounts with no rows at all backfill the provider's 31-day maximum:
+        // there is nothing to collide with, and the deferred residual absorb
+        // explains whatever the backfill doesn't.
         const from = latestTransaction
-          ? new Date(latestTransaction.time)
+          ? clampSyncStartToLink({ account, from: new Date(latestTransaction.time) })
           : new Date(Date.now() - 31 * 24 * 60 * 60 * 1000);
         const to = new Date();
 

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -17,6 +17,7 @@ import Transactions from '@models/transactions.model';
 import * as UserMerchantCategoryCodes from '@models/user-merchant-category-codes.model';
 import * as Users from '@models/users.model';
 import { redisClient } from '@root/redis-client';
+import { runPendingLinkAbsorb } from '@services/accounts/absorb-link-residual';
 import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import * as transactionsService from '@services/transactions';
 import { Job, Queue, UnrecoverableError, Worker } from 'bullmq';
@@ -197,10 +198,16 @@ function buildJobProcessor(queueName: string) {
           const account = await Accounts.findByPk(accountId);
 
           if (account) {
-            // Update sync timestamp in externalData (independent of the balance write).
-            const externalData = (account.externalData as Record<string, unknown>) || {};
-            externalData.lastSyncedAt = new Date().toISOString();
-            await account.update({ externalData });
+            // Stamp lastSyncedAt via jsonb_set: a whole-blob read-modify-write
+            // races concurrent metadata writers (the completion path clearing
+            // `pendingAbsorb`, the link flow writing bankConnection) and would
+            // resurrect cleared flags.
+            await Accounts.sequelize!.query(
+              `UPDATE "Accounts"
+               SET "externalData" = jsonb_set(COALESCE("externalData", '{}'::jsonb), '{lastSyncedAt}', to_jsonb(:lastSyncedAt::text))
+               WHERE "id" = :accountId`,
+              { replacements: { lastSyncedAt: new Date().toISOString(), accountId } },
+            );
 
             // Update account balance to reflect the current state from Monobank.
             // Monobank API returns transactions in chronological order (oldest to newest),
@@ -549,6 +556,48 @@ function jobGroupCompletionsKey(jobGroupId: string): string {
 }
 
 /**
+ * Runs the deferred post-link absorb before flipping the status to COMPLETED,
+ * so status waiters observe the reconciled account.
+ *
+ * `swallowAbsorbError` is safe only where no ambient CLS transaction exists
+ * (the worker's 'completed' event): there a failed absorb rolls itself back
+ * and the still-set `pendingAbsorb` retries next group. Inside an ambient
+ * transaction the error must propagate, or a half-applied opening-balance
+ * move commits.
+ */
+async function finalizeSyncGroup({
+  accountId,
+  userId,
+  connectionId,
+  swallowAbsorbError,
+}: {
+  accountId: RecordId;
+  userId: number;
+  connectionId: string;
+  swallowAbsorbError: boolean;
+}): Promise<void> {
+  if (swallowAbsorbError) {
+    try {
+      await runPendingLinkAbsorb({ accountId: String(accountId), userId });
+    } catch (error) {
+      logger.error(
+        { message: '[Monobank] Deferred post-link residual absorb failed', error: error as Error },
+        { accountId, userId },
+      );
+    }
+  } else {
+    await runPendingLinkAbsorb({ accountId: String(accountId), userId });
+  }
+
+  await Promise.all([
+    setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId }),
+    // Nothing else stamps the connection's lastSyncAt in the queued flow, so
+    // the list view's "Last synced" column would never move without this.
+    BankDataProviderConnections.update({ lastSyncAt: new Date() }, { where: { id: connectionId } }),
+  ]);
+}
+
+/**
  * Handles a batch job's 'completed' event.
  *
  * Uses an atomic Redis counter (INCR) keyed by jobGroupId rather than
@@ -575,14 +624,7 @@ export async function handleCompletedBatch(job: Job<TransactionSyncJobData>): Pr
 
   if (completedCount < totalBatches) return;
 
-  await Promise.all([
-    setAccountSyncStatus({ accountId, status: SyncStatus.COMPLETED, userId }),
-    // Mark the connection as synced. Enable Banking does this via
-    // base-provider's `updateLastSync`; Monobank's queue-based flow needs
-    // the equivalent write so the list view's "Last synced" column reflects
-    // reality for the connection, not just the account.
-    BankDataProviderConnections.update({ lastSyncAt: new Date() }, { where: { id: connectionId } }),
-  ]);
+  await finalizeSyncGroup({ accountId, userId, connectionId, swallowAbsorbError: true });
   await redisClient.del(counterKey);
   logger.info(`All batches completed for account ${accountId}, status set to COMPLETED`);
 }
@@ -636,6 +678,15 @@ export async function queueTransactionSync(params: {
 
   // Generate unique group ID for this sync operation
   const jobGroupId = `${userId}-${accountId}-${Date.now()}`;
+
+  // An empty window (from >= to, e.g. the forward-only clamp) enqueues no
+  // batches, so no worker completion ever fires: finalize here or the account
+  // sits in QUEUED forever and a pending link absorb never runs.
+  if (chunks.length === 0) {
+    await finalizeSyncGroup({ accountId, userId, connectionId, swallowAbsorbError: false });
+    logger.info(`[QUEUE] Empty sync window for account ${accountId} (group: ${jobGroupId}), finalized without batches`);
+    return { jobGroupId, totalBatches: 0, estimatedMinutes: 0 };
+  }
 
   // Queue jobs for each chunk, wrapped in a Sentry publish span
   await withQueuePublishSpan({

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.unit.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.unit.ts
@@ -1,0 +1,155 @@
+import type { RecordId } from '@bt/shared/types';
+import { generateRandomRecordId } from '@common/lib/record-id-helpers';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { Job } from 'bullmq';
+
+// ── Mocks (hoisted before importing the module under test) ──────────────────
+
+// The module builds a queue + worker pair lazily per API token; the constructors
+// are the only bullmq surface these tests reach.
+jest.mock('bullmq', () => ({
+  __esModule: true,
+  Queue: jest.fn().mockImplementation(() => ({ add: jest.fn(), on: jest.fn(), close: jest.fn() })),
+  Worker: jest.fn().mockImplementation(() => ({ on: jest.fn(), close: jest.fn() })),
+  UnrecoverableError: class UnrecoverableError extends Error {},
+}));
+jest.mock('@services/accounts/absorb-link-residual', () => ({
+  __esModule: true,
+  runPendingLinkAbsorb: jest.fn(),
+}));
+jest.mock('@models/bank-data-provider-connections.model', () => ({
+  __esModule: true,
+  default: { update: jest.fn() },
+}));
+jest.mock('../sync/sync-status-tracker', () => ({
+  __esModule: true,
+  ...(jest.requireActual('../sync/sync-status-tracker') as object),
+  setAccountSyncStatus: jest.fn(),
+}));
+jest.mock('@js/utils/logger', () => ({
+  __esModule: true,
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+/* eslint-disable import/first */
+import { logger } from '@js/utils/logger';
+import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import { redisClient } from '@root/redis-client';
+import { runPendingLinkAbsorb } from '@services/accounts/absorb-link-residual';
+
+import { SyncStatus, setAccountSyncStatus } from '../sync/sync-status-tracker';
+import { handleCompletedBatch, queueTransactionSync } from './transaction-sync-queue';
+/* eslint-enable import/first */
+
+const runPendingLinkAbsorbMock = jest.mocked(runPendingLinkAbsorb);
+const setAccountSyncStatusMock = jest.mocked(setAccountSyncStatus);
+const connectionsUpdateMock = jest.mocked(BankDataProviderConnections.update);
+const loggerErrorMock = jest.mocked(logger.error);
+const incrMock = jest.mocked(redisClient.incr);
+
+const USER_ID = 42;
+const CONNECTION_ID = 'connection-1';
+
+const buildCompletedJob = (accountId: string): Job =>
+  ({
+    id: 'group-1-0',
+    data: { totalBatches: 1, accountId, userId: USER_ID, connectionId: CONNECTION_ID },
+  }) as unknown as Job;
+
+/** An empty window (from >= to) is the only path that finalizes inline. */
+const queueEmptyWindow = (accountId: RecordId) =>
+  queueTransactionSync({
+    userId: USER_ID,
+    accountId,
+    connectionId: CONNECTION_ID,
+    externalAccountId: 'external-1',
+    apiToken: 'token-1',
+    from: new Date('2024-06-10T00:00:00.000Z'),
+    to: new Date('2024-06-01T00:00:00.000Z'),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  incrMock.mockResolvedValue(1 as never);
+  runPendingLinkAbsorbMock.mockResolvedValue(0);
+  setAccountSyncStatusMock.mockResolvedValue(undefined);
+  connectionsUpdateMock.mockResolvedValue([1] as never);
+});
+
+describe('finalizeSyncGroup via handleCompletedBatch (absorb errors swallowed)', () => {
+  it('completes the sync and stamps the connection when the deferred absorb succeeds', async () => {
+    const accountId = generateRandomRecordId();
+
+    await handleCompletedBatch(buildCompletedJob(accountId));
+
+    expect(runPendingLinkAbsorbMock).toHaveBeenCalledWith({ accountId, userId: USER_ID });
+    expect(setAccountSyncStatusMock).toHaveBeenCalledWith({
+      accountId,
+      status: SyncStatus.COMPLETED,
+      userId: USER_ID,
+    });
+    expect(connectionsUpdateMock).toHaveBeenCalledWith(
+      { lastSyncAt: expect.any(Date) },
+      { where: { id: CONNECTION_ID } },
+    );
+  });
+
+  it('logs and still completes the sync when the deferred absorb throws', async () => {
+    const accountId = generateRandomRecordId();
+    runPendingLinkAbsorbMock.mockRejectedValue(new Error('absorb blew up'));
+
+    await expect(handleCompletedBatch(buildCompletedJob(accountId))).resolves.toBeUndefined();
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.any(Error) }),
+      expect.objectContaining({ accountId, userId: USER_ID }),
+    );
+    expect(setAccountSyncStatusMock).toHaveBeenCalledWith({
+      accountId,
+      status: SyncStatus.COMPLETED,
+      userId: USER_ID,
+    });
+    expect(connectionsUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the group unfinalized until the last batch reports in', async () => {
+    const accountId = generateRandomRecordId();
+    const job = {
+      id: 'group-2-0',
+      data: { totalBatches: 3, accountId, userId: USER_ID, connectionId: CONNECTION_ID },
+    } as unknown as Job;
+
+    await handleCompletedBatch(job);
+
+    expect(runPendingLinkAbsorbMock).not.toHaveBeenCalled();
+    expect(setAccountSyncStatusMock).not.toHaveBeenCalled();
+    expect(connectionsUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizeSyncGroup via queueTransactionSync empty window (absorb errors propagate)', () => {
+  it('completes the sync and stamps the connection when the deferred absorb succeeds', async () => {
+    const accountId = generateRandomRecordId();
+
+    const result = await queueEmptyWindow(accountId);
+
+    expect(result.totalBatches).toBe(0);
+    expect(runPendingLinkAbsorbMock).toHaveBeenCalledWith({ accountId, userId: USER_ID });
+    expect(setAccountSyncStatusMock).toHaveBeenCalledWith({
+      accountId,
+      status: SyncStatus.COMPLETED,
+      userId: USER_ID,
+    });
+    expect(connectionsUpdateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the absorb failure and writes neither the status nor the connection stamp', async () => {
+    const accountId = generateRandomRecordId();
+    runPendingLinkAbsorbMock.mockRejectedValue(new Error('absorb blew up'));
+
+    await expect(queueEmptyWindow(accountId)).rejects.toThrow('absorb blew up');
+
+    expect(setAccountSyncStatusMock).not.toHaveBeenCalled();
+    expect(connectionsUpdateMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/services/bank-data-providers/types.ts
+++ b/packages/backend/src/services/bank-data-providers/types.ts
@@ -23,6 +23,12 @@ interface ProviderFeatures {
   supportsManualSync: boolean;
   /** Provider supports automatic scheduled sync */
   supportsAutoSync: boolean;
+  /**
+   * syncTransactions only enqueues background jobs instead of persisting
+   * inline. Work that needs post-sync state (balance reconciliation, residual
+   * absorb) must defer to the queue's completion path.
+   */
+  queuedSync?: boolean;
   /** Default interval between auto-syncs (milliseconds) */
   defaultSyncInterval?: number;
   /** Minimum interval between syncs due to rate limits (milliseconds) */

--- a/packages/backend/src/services/bank-data-providers/utils/clamp-sync-start-to-link.ts
+++ b/packages/backend/src/services/bank-data-providers/utils/clamp-sync-start-to-link.ts
@@ -1,0 +1,20 @@
+import type { AccountExternalData } from '@bt/shared/types';
+import type Accounts from '@models/accounts.model';
+
+/**
+ * Clamps a sync-window start to `bankConnection.linkedAt`: forward-only
+ * linking. A window anchored at the newest row can reach back to a manual
+ * entry whose bank-side copy has no `originalId` for dedup to match and would
+ * re-import as a duplicate. Pre-link history belongs to the link residual
+ * absorb, never to the statement import. Without linking metadata (accounts
+ * created directly from the provider), `from` passes through unchanged.
+ */
+export function clampSyncStartToLink({ account, from }: { account: Accounts; from: Date }): Date {
+  const linkedAtIso = (account.externalData as AccountExternalData | null)?.bankConnection?.linkedAt;
+  if (!linkedAtIso) return from;
+
+  const linkedAt = new Date(linkedAtIso);
+  if (Number.isNaN(linkedAt.getTime())) return from;
+
+  return linkedAt > from ? linkedAt : from;
+}

--- a/packages/backend/src/services/bank-data-providers/utils/clamp-sync-start-to-link.unit.ts
+++ b/packages/backend/src/services/bank-data-providers/utils/clamp-sync-start-to-link.unit.ts
@@ -1,0 +1,73 @@
+import type { AccountExternalData } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import type Accounts from '@models/accounts.model';
+
+import { clampSyncStartToLink } from './clamp-sync-start-to-link';
+
+type AccountRow = InstanceType<typeof Accounts>;
+
+const buildAccount = (externalData: AccountExternalData | null): AccountRow =>
+  ({ externalData }) as unknown as AccountRow;
+
+const buildLinkedAccount = (linkedAt: string): AccountRow =>
+  buildAccount({
+    bankConnection: {
+      linkedAt,
+      linkingStrategy: 'forward-only',
+      balanceReconciliation: {
+        systemBalance: 0,
+        externalBalance: 0,
+        difference: 0,
+        adjustmentTransactionId: null,
+      },
+    },
+  });
+
+const FROM = new Date('2024-06-01T00:00:00.000Z');
+
+describe('clampSyncStartToLink', () => {
+  it('passes `from` through when the account has no externalData', () => {
+    expect(clampSyncStartToLink({ account: buildAccount(null), from: FROM })).toBe(FROM);
+  });
+
+  it('passes `from` through when externalData carries no bankConnection', () => {
+    expect(clampSyncStartToLink({ account: buildAccount({ someOtherKey: 'value' }), from: FROM })).toBe(FROM);
+  });
+
+  it('passes `from` through when the bankConnection has no linkedAt', () => {
+    const account = buildAccount({
+      bankConnection: {
+        linkingStrategy: 'forward-only',
+        balanceReconciliation: {
+          systemBalance: 0,
+          externalBalance: 0,
+          difference: 0,
+          adjustmentTransactionId: null,
+        },
+      },
+    } as unknown as AccountExternalData);
+
+    expect(clampSyncStartToLink({ account, from: FROM })).toBe(FROM);
+  });
+
+  it('passes `from` through when linkedAt is an unparsable date string', () => {
+    expect(clampSyncStartToLink({ account: buildLinkedAccount('not-a-date'), from: FROM })).toBe(FROM);
+  });
+
+  it('clamps forward to linkedAt when the link happened after the requested window start', () => {
+    const result = clampSyncStartToLink({
+      account: buildLinkedAccount('2024-07-15T09:30:00.000Z'),
+      from: FROM,
+    });
+
+    expect(result.toISOString()).toBe('2024-07-15T09:30:00.000Z');
+  });
+
+  it('keeps `from` when the link predates the requested window start', () => {
+    expect(clampSyncStartToLink({ account: buildLinkedAccount('2024-01-01T00:00:00.000Z'), from: FROM })).toBe(FROM);
+  });
+
+  it('keeps `from` when linkedAt equals the requested window start', () => {
+    expect(clampSyncStartToLink({ account: buildLinkedAccount(FROM.toISOString()), from: FROM })).toBe(FROM);
+  });
+});

--- a/packages/backend/src/services/import-export/core/reconcile-account-balances.ts
+++ b/packages/backend/src/services/import-export/core/reconcile-account-balances.ts
@@ -381,7 +381,7 @@ export async function startBalanceReconciliation({
       throw new ValidationError({ message: `Account with ID ${accountId} not found` });
     }
     if (isDedicatedFlowAccountCategory(account.accountCategory)) {
-      // Unreachable through the importers — `assertNotDedicatedFlowAccount`
+      // Unreachable through the importers — `assertNotDerivedBalanceAccount`
       // rejects vehicle/loan targets before execution. A caller that skips that
       // guard would otherwise lose this account's capture silently and
       // permanently shift its balance when `finalize` runs without it.

--- a/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
+++ b/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
@@ -4,7 +4,7 @@ import { Money } from '@common/types/money';
 import { ValidationError } from '@js/errors';
 import * as Accounts from '@models/accounts.model';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
-import { assertNotDedicatedFlowAccount } from '@services/import-export/core/dedicated-flow-guard';
+import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
 
 interface CreateAccountsIfNeededParams {
   userId: number;
@@ -126,7 +126,7 @@ export async function createAccountsIfNeeded({
         message: `Account with ID ${id} not found`,
       });
     }
-    assertNotDedicatedFlowAccount({ account, actionPhrase: 'be an import target' });
+    assertNotDerivedBalanceAccount({ account, actionPhrase: 'be an import target' });
     return account;
   };
 

--- a/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
+++ b/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
@@ -3,8 +3,8 @@ import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES } from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { ValidationError } from '@js/errors';
 import * as Accounts from '@models/accounts.model';
-import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
+import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 
 interface CreateAccountsIfNeededParams {
   userId: number;

--- a/packages/backend/src/tests/mocks/monobank/mock-api.ts
+++ b/packages/backend/src/tests/mocks/monobank/mock-api.ts
@@ -13,13 +13,32 @@ export const MONOBANK_URLS_MOCK = Object.freeze({
 export const getMonobankTransactionsMock = ({
   response = [],
   accountId,
-}: { response?: ExternalMonobankTransactionResponse[]; accountId?: string | number } = {}) => {
+  respectDateRange = false,
+}: {
+  response?: ExternalMonobankTransactionResponse[];
+  accountId?: string | number;
+  /**
+   * Filter the response by the `{from}/{to}` unix-second segments of the
+   * statement URL, like the real API. Off by default: most tests want a fixed
+   * payload regardless of the requested window.
+   */
+  respectDateRange?: boolean;
+} = {}) => {
   const urlPattern = accountId
     ? new RegExp(`${MONOBANK_URLS_MOCK.personalStatement.source}/${accountId}`)
     : MONOBANK_URLS_MOCK.personalStatement;
 
-  return http.get(urlPattern, () => {
-    return HttpResponse.json(response);
+  return http.get(urlPattern, ({ request }) => {
+    if (!respectDateRange) {
+      return HttpResponse.json(response);
+    }
+
+    // URL shape: .../personal/statement/{account}/{from}/{to}
+    const segments = new URL(request.url).pathname.split('/').filter(Boolean);
+    const from = Number(segments.at(-2));
+    const to = Number(segments.at(-1));
+
+    return HttpResponse.json(response.filter((tx) => tx.time >= from && tx.time <= to));
   });
 };
 

--- a/packages/shared/src/types/db-models.ts
+++ b/packages/shared/src/types/db-models.ts
@@ -84,6 +84,8 @@ export interface AccountExternalData {
       externalBalance: number;
       difference: number;
       adjustmentTransactionId: RecordId | null;
+      /** Residual the post-link sync left unexplained, in cents, folded into the opening balance. */
+      absorbedResidual?: number;
     };
   };
   // Allow any additional custom fields

--- a/packages/shared/src/types/db-models.ts
+++ b/packages/shared/src/types/db-models.ts
@@ -86,6 +86,12 @@ export interface AccountExternalData {
       adjustmentTransactionId: RecordId | null;
       /** Residual the post-link sync left unexplained, in cents, folded into the opening balance. */
       absorbedResidual?: number;
+      /**
+       * Set at link time for queue-synced providers, whose residual cannot be
+       * measured until the worker persists the sync. The queue's completion
+       * path runs the deferred absorb and clears this.
+       */
+      pendingAbsorb?: boolean;
     };
   };
   // Allow any additional custom fields


### PR DESCRIPTION
## Bank account linking: balance and sync fixes

- Linking a system account no longer creates a `transfer_out_wallet` transaction to close the balance gap. The unexplained residual goes into the opening balance instead (`absorb-link-residual.ts`), restoring `initialBalance + Σtx = currentBalance` and leaving `currentBalance` to the bank.
- Monobank writes the bank balance inline at link time and defers the sync plus residual absorb to the queue completion path via a `pendingAbsorb` marker, since nothing persists until the worker finishes. Empty sync windows finalize without batches instead of stranding the account in `QUEUED`.
- New `clampSyncStartToLink` pins sync start to `bankConnection.linkedAt` for Monobank and LunchFlow, so pre-link manual history stops coming back as duplicates. Future-dated planned rows can no longer anchor the window and freeze syncing.
- `restampRefInitialBalance` now returns an outcome, so the absorb rolls back when the restamp fails instead of pairing a moved opening balance with a stale base-currency stamp. After the cascade, the code re-pins today's `Balances` row to the bank balance.
- Enable Banking dedup: a booked copy carrying an `entry_reference` can upgrade a pending row that holds a different reference. A reference-less payload consumes only reference-less candidates.
- Loan and vehicle accounts reject linking. Their dedicated flows own those balances (shared `assertNotDerivedBalanceAccount` guard).
- Link enqueues the sync `afterCommit`, and a failed start marks the account `FAILED` instead of leaving it with no sync state.
- Monobank stamps `lastSyncedAt` with `jsonb_set` rather than a whole-blob read-modify-write, so concurrent writers stop resurrecting cleared flags.