### PR TITLE
Add exclude-transactions settings to latest records widget

### DIFF
--- a/packages/frontend/src/components/widgets/components/latest-records-settings-popover.vue
+++ b/packages/frontend/src/components/widgets/components/latest-records-settings-popover.vue
@@ -1,0 +1,156 @@
+<template>
+  <Popover v-model:open="isOpen">
+    <PopoverTrigger as-child>
+      <Button size="icon-sm" variant="ghost" :aria-label="$t('common.actions.settings')">
+        <SettingsIcon class="text-muted-foreground size-4" />
+      </Button>
+    </PopoverTrigger>
+    <PopoverContent class="w-72 overflow-hidden p-0" align="end">
+      <SlidingPanels v-model="view" :panels="['main', 'exclusions']">
+        <template #main>
+          <div class="flex flex-col">
+            <header class="border-b px-3 py-2 text-sm font-medium">
+              {{ $t('common.actions.settings') }}
+            </header>
+
+            <div class="flex flex-col p-2">
+              <button
+                type="button"
+                class="hover:bg-accent flex items-center justify-between gap-2 rounded-md px-2 py-2 text-left transition-colors"
+                @click="goTo('exclusions')"
+              >
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium">
+                    {{ $t('widgets.latestRecords.settings.excludeTitle') }}
+                  </span>
+                  <span class="text-muted-foreground text-xs">
+                    {{ exclusionsSummary }}
+                  </span>
+                </span>
+                <ChevronRightIcon class="text-muted-foreground size-4" />
+              </button>
+            </div>
+          </div>
+        </template>
+
+        <template #exclusions>
+          <div class="flex flex-col">
+            <header class="flex items-center gap-2 border-b px-2 py-2">
+              <Button
+                size="icon-sm"
+                variant="ghost"
+                type="button"
+                :aria-label="$t('common.actions.back')"
+                @click="goTo('main')"
+              >
+                <ArrowLeftIcon class="size-4" />
+              </Button>
+              <span class="text-sm font-medium">
+                {{ $t('widgets.latestRecords.settings.excludeTitle') }}
+              </span>
+            </header>
+
+            <div class="flex flex-col p-2">
+              <div class="flex items-center justify-between gap-2 rounded-md px-2 py-2">
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium">{{
+                    $t('transactions.filters.transferNature.commonTransfer')
+                  }}</span>
+                  <span class="text-muted-foreground text-xs">
+                    {{ $t('widgets.latestRecords.settings.excludeTransfersDescription') }}
+                  </span>
+                </span>
+                <Switch
+                  :model-value="exclusions.excludeTransfers"
+                  :disabled="isUpdating"
+                  @update:model-value="(value) => persistConfig({ excludeTransfers: !!value })"
+                />
+              </div>
+
+              <div class="flex items-center justify-between gap-2 rounded-md px-2 py-2">
+                <span class="flex flex-col">
+                  <span class="text-sm font-medium">{{ $t('transactions.filters.transferNature.outOfWallet') }}</span>
+                  <span class="text-muted-foreground text-xs">
+                    {{ $t('widgets.latestRecords.settings.excludeOutOfWalletDescription') }}
+                  </span>
+                </span>
+                <Switch
+                  :model-value="exclusions.excludeOutOfWallet"
+                  :disabled="isUpdating"
+                  @update:model-value="(value) => persistConfig({ excludeOutOfWallet: !!value })"
+                />
+              </div>
+            </div>
+          </div>
+        </template>
+      </SlidingPanels>
+    </PopoverContent>
+  </Popover>
+</template>
+
+<script lang="ts" setup>
+import type { DashboardWidgetConfig } from '@/api/user-settings';
+import SlidingPanels from '@/components/common/sliding-panels.vue';
+import { Button } from '@/components/lib/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/lib/ui/popover';
+import { Switch } from '@/components/lib/ui/switch';
+import { useUserSettings } from '@/composable/data-queries/user-settings';
+import { ArrowLeftIcon, ChevronRightIcon, SettingsIcon } from '@lucide/vue';
+import type { Ref } from 'vue';
+import { computed, inject, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { readLatestRecordsExclusions } from '../latest-records-config';
+
+const PANEL_TRANSITION_DURATION = 320;
+
+const { t } = useI18n({ useScope: 'global' });
+const widgetConfigRef = inject<Ref<DashboardWidgetConfig> | null>('dashboard-widget-config', null);
+const { data: userSettingsData, mutateAsync: saveUserSettings, isUpdating } = useUserSettings();
+
+const isOpen = ref(false);
+type View = 'main' | 'exclusions';
+const view = ref<View>('main');
+
+const exclusions = computed(() => readLatestRecordsExclusions({ widgetConfig: widgetConfigRef?.value }));
+
+const exclusionsSummary = computed(() => {
+  const excluded: string[] = [];
+  if (exclusions.value.excludeTransfers) {
+    excluded.push(t('transactions.filters.transferNature.commonTransfer'));
+  }
+  if (exclusions.value.excludeOutOfWallet) {
+    excluded.push(t('transactions.filters.transferNature.outOfWallet'));
+  }
+  return excluded.length === 0 ? t('widgets.latestRecords.settings.nothingExcluded') : excluded.join(', ');
+});
+
+// Reset to the main view after the popover finishes closing.
+watch(isOpen, (open) => {
+  if (!open) {
+    setTimeout(() => {
+      view.value = 'main';
+    }, PANEL_TRANSITION_DURATION);
+  }
+});
+
+function goTo(target: View) {
+  view.value = target;
+}
+
+async function persistConfig(patch: Record<string, unknown>) {
+  const settings = userSettingsData.value;
+  if (!settings || !widgetConfigRef?.value) return;
+
+  const widgets = [...(settings.dashboard?.widgets ?? [])];
+  const idx = widgets.findIndex((w) => w.widgetId === widgetConfigRef.value!.widgetId);
+  if (idx === -1) return;
+
+  widgets[idx] = {
+    ...widgets[idx]!,
+    config: { ...widgets[idx]!.config, ...patch },
+  };
+
+  await saveUserSettings({ ...settings, dashboard: { widgets } });
+}
+</script>

--- a/packages/frontend/src/components/widgets/latest-records-config.spec.ts
+++ b/packages/frontend/src/components/widgets/latest-records-config.spec.ts
@@ -1,0 +1,53 @@
+import { TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
+import { describe, expect, it } from 'vitest';
+
+import { buildLatestRecordsTransferNatures, readLatestRecordsExclusions } from './latest-records-config';
+
+const widgetConfig = (config?: Record<string, unknown>) => ({ widgetId: 'latest-records', colSpan: 1, config });
+
+describe('readLatestRecordsExclusions', () => {
+  it('hides out-of-wallet and keeps transfers when nothing is stored', () => {
+    expect(readLatestRecordsExclusions({ widgetConfig: widgetConfig() })).toEqual({
+      excludeTransfers: false,
+      excludeOutOfWallet: true,
+    });
+  });
+
+  it('falls back to defaults without an injected widget config', () => {
+    expect(readLatestRecordsExclusions({ widgetConfig: null })).toEqual({
+      excludeTransfers: false,
+      excludeOutOfWallet: true,
+    });
+  });
+
+  it('reads stored values', () => {
+    expect(
+      readLatestRecordsExclusions({
+        widgetConfig: widgetConfig({ excludeTransfers: true, excludeOutOfWallet: false }),
+      }),
+    ).toEqual({ excludeTransfers: true, excludeOutOfWallet: false });
+  });
+});
+
+describe('buildLatestRecordsTransferNatures', () => {
+  it('returns undefined when nothing is excluded', () => {
+    expect(buildLatestRecordsTransferNatures({ excludeTransfers: false, excludeOutOfWallet: false })).toBeUndefined();
+  });
+
+  it('keeps plain transactions and every nature but the excluded one', () => {
+    const natures = buildLatestRecordsTransferNatures({ excludeTransfers: false, excludeOutOfWallet: true });
+
+    expect(natures).toContain(TRANSACTION_TRANSFER_NATURE.not_transfer);
+    expect(natures).toContain(TRANSACTION_TRANSFER_NATURE.common_transfer);
+    expect(natures).not.toContain(TRANSACTION_TRANSFER_NATURE.transfer_out_wallet);
+  });
+
+  it('drops both natures when both exclusions are on', () => {
+    const natures = buildLatestRecordsTransferNatures({ excludeTransfers: true, excludeOutOfWallet: true });
+
+    expect(natures).not.toContain(TRANSACTION_TRANSFER_NATURE.common_transfer);
+    expect(natures).not.toContain(TRANSACTION_TRANSFER_NATURE.transfer_out_wallet);
+    expect(natures).toContain(TRANSACTION_TRANSFER_NATURE.not_transfer);
+    expect(natures).toContain(TRANSACTION_TRANSFER_NATURE.transfer_to_loan);
+  });
+});

--- a/packages/frontend/src/components/widgets/latest-records-config.ts
+++ b/packages/frontend/src/components/widgets/latest-records-config.ts
@@ -1,0 +1,40 @@
+import type { DashboardWidgetConfig } from '@/api/user-settings';
+import { TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
+
+export interface LatestRecordsExclusions {
+  excludeTransfers: boolean;
+  excludeOutOfWallet: boolean;
+}
+
+/** Out-of-wallet transfers are hidden unless the user opts back in. */
+export const readLatestRecordsExclusions = ({
+  widgetConfig,
+}: {
+  widgetConfig: DashboardWidgetConfig | null | undefined;
+}): LatestRecordsExclusions => {
+  const config = widgetConfig?.config;
+
+  return {
+    excludeTransfers: config?.excludeTransfers === true,
+    excludeOutOfWallet: config?.excludeOutOfWallet !== false,
+  };
+};
+
+/**
+ * The transactions endpoint has no exclude-list for transfer natures: `transferNatures`
+ * is an include-list that supersedes `transferFilter`, so exclusions are expressed as
+ * "every nature but these". `undefined` means no narrowing at all.
+ */
+export const buildLatestRecordsTransferNatures = ({
+  excludeTransfers,
+  excludeOutOfWallet,
+}: LatestRecordsExclusions): TRANSACTION_TRANSFER_NATURE[] | undefined => {
+  const excluded: TRANSACTION_TRANSFER_NATURE[] = [];
+
+  if (excludeTransfers) excluded.push(TRANSACTION_TRANSFER_NATURE.common_transfer);
+  if (excludeOutOfWallet) excluded.push(TRANSACTION_TRANSFER_NATURE.transfer_out_wallet);
+
+  if (!excluded.length) return undefined;
+
+  return Object.values(TRANSACTION_TRANSFER_NATURE).filter((nature) => !excluded.includes(nature));
+};

--- a/packages/frontend/src/components/widgets/latest-records.vue
+++ b/packages/frontend/src/components/widgets/latest-records.vue
@@ -8,21 +8,24 @@ import { useFormatCurrency } from '@/composable/formatters';
 import { buttonVariants } from '@/components/lib/ui/button';
 import UiButton from '@/components/lib/ui/button/Button.vue';
 import BrandLogo from '@/components/common/brand-logo.vue';
+import { DesktopOnlyTooltip } from '@/components/lib/ui/tooltip';
 import TransactionsList from '@/components/transactions-list/transactions-list.vue';
 import SubscriptionMarkPaidDialog from '@/pages/planned/subscriptions/components/subscription-mark-paid-dialog.vue';
 import { ROUTES_NAMES } from '@/routes/constants';
 import { useRootStore } from '@/stores';
 import { useQuery } from '@tanstack/vue-query';
 import { differenceInCalendarDays, format, parseISO } from 'date-fns';
-import { ListIcon } from '@lucide/vue';
+import { ArrowUpRightIcon, ListIcon } from '@lucide/vue';
 import { SUBSCRIPTION_PERIOD_STATUSES } from '@bt/shared/types';
 import { storeToRefs } from 'pinia';
 import type { Ref } from 'vue';
 import { computed, inject, ref } from 'vue';
 
 import EmptyState from './components/empty-state.vue';
+import LatestRecordsSettingsPopover from './components/latest-records-settings-popover.vue';
 import LoadingState from './components/loading-state.vue';
 import WidgetWrapper from './components/widget-wrapper.vue';
+import { buildLatestRecordsTransferNatures, readLatestRecordsExclusions } from './latest-records-config';
 
 // Days ahead threshold for "upcoming" payments shown in the widget.
 const UPCOMING_DAYS_WINDOW = 3;
@@ -45,10 +48,21 @@ const maxDisplay = computed(() => {
   return (config.rowSpan ?? 1) >= 2 ? 12 : 5;
 });
 
+const transferNatures = computed(() =>
+  buildLatestRecordsTransferNatures(readLatestRecordsExclusions({ widgetConfig: widgetConfigRef?.value })),
+);
+
 const { data: transactions, isFetching: isTxFetching } = useQuery({
-  queryKey: VUE_QUERY_CACHE_KEYS.widgetLatestRecords,
+  queryKey: [...VUE_QUERY_CACHE_KEYS.widgetLatestRecords, transferNatures],
   queryFn: () =>
-    apiLoadTransactions({ limit: 40, offset: 0, includeSplits: true, includeTags: true, includeGroups: true }), // Over-fetch to account for deduplication and grouping
+    apiLoadTransactions({
+      limit: 40, // Over-fetch to account for deduplication and grouping
+      offset: 0,
+      includeSplits: true,
+      includeTags: true,
+      includeGroups: true,
+      transferNatures: transferNatures.value,
+    }),
   staleTime: Infinity,
   placeholderData: [],
   enabled: isAppInitialized,
@@ -122,14 +136,22 @@ const isDataEmpty = computed(() => !isTxFetching.value && (transactions.value?.l
   <WidgetWrapper :is-fetching="isFetching">
     <template #title> {{ $t('dashboard.widgets.latestTransactions.title') }} </template>
     <template #action>
-      <template v-if="!isDataEmpty && !isInitialLoading">
-        <router-link
-          :class="buttonVariants({ variant: 'ghost', size: 'sm', class: 'text-muted-foreground' })"
-          :to="{ name: ROUTES_NAMES.transactions }"
-        >
-          {{ $t('dashboard.widgets.latestTransactions.showAll') }}
-        </router-link>
-      </template>
+      <DesktopOnlyTooltip
+        v-if="!isDataEmpty && !isInitialLoading"
+        :content="$t('dashboard.widgets.latestTransactions.showAll')"
+      >
+        <span class="inline-flex">
+          <router-link
+            :class="buttonVariants({ variant: 'ghost', size: 'icon-sm', class: 'text-muted-foreground' })"
+            :to="{ name: ROUTES_NAMES.transactions }"
+            :aria-label="$t('dashboard.widgets.latestTransactions.showAll')"
+          >
+            <ArrowUpRightIcon class="size-4" />
+          </router-link>
+        </span>
+      </DesktopOnlyTooltip>
+
+      <LatestRecordsSettingsPopover />
     </template>
 
     <template v-if="isInitialLoading">

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/dashboard.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/dashboard.json
@@ -190,6 +190,12 @@
           "off": "Off"
         }
       },
+      "settings": {
+        "excludeTitle": "Exclude transactions",
+        "excludeTransfersDescription": "Hide transfers between your own accounts",
+        "excludeOutOfWalletDescription": "Hide balance adjustments and other out-of-wallet transfers",
+        "nothingExcluded": "Nothing excluded"
+      },
       "overdueBadge": "Overdue",
       "scheduledBadge": "Scheduled",
       "payAction": "Mark paid"


### PR DESCRIPTION
Hides out-of-wallet transfers (incl. balance adjustments) by default, with per-widget toggles for out-of-wallet and between-accounts transfers