### PR TITLE
Parse YNAB Register.csv with any currency and date format

### DIFF
--- a/packages/backend/src/services/import-export/ynab-import/parse-amount.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-amount.ts
@@ -1,22 +1,123 @@
+/** The decimal mark a whole Register.csv is written with. */
+type YnabDecimalSeparator = '.' | ',';
+
+/** Spacing marks used as thousands separators: plain, non-breaking and thin spaces, and the Swiss apostrophe. */
+const GROUPING_WHITESPACE = /[\s   ']/g;
+
 /**
- * Parse a YNAB amount cell ("$1234.56", "$0.00", "", "$1,234.56").
+ * Strips currency decoration and returns the bare digits-and-separators run
+ * plus its sign, or null when the cell holds no usable number.
  *
- * YNAB uniformly prefixes every amount with `$` regardless of the account's
- * actual currency (the currency lives in the account name, not the amount
- * column). Strip the `$`, strip any thousands separators, then parse.
+ * A sign is only honoured when it sits before the first digit, so both
+ * `-$5.00` and `$-5.00` read as negative.
+ */
+function extractNumericToken({ raw }: { raw: string }): { token: string; negative: boolean } | null {
+  const compact = raw.replace(GROUPING_WHITESPACE, '');
+
+  const firstDigit = compact.search(/\d/);
+  if (firstDigit === -1) return null;
+  const lastDigit = compact.replace(/\D+$/, '').length - 1;
+
+  let start = firstDigit;
+  while (start > 0 && (compact[start - 1] === '.' || compact[start - 1] === ',')) start -= 1;
+
+  const token = compact.slice(start, lastDigit + 1);
+  if (!/^[\d.,]+$/.test(token)) return null;
+
+  return { token, negative: compact.slice(0, firstDigit).includes('-') };
+}
+
+/**
+ * Resolves which mark is the decimal point across a whole Register.csv.
+ *
+ * One YNAB budget has one currency format, so the answer is file-wide. YNAB
+ * pads decimals on every row (`0.00` / `0,00`), which is what makes a decisive
+ * signal near-certain; zero-decimal currencies like JPY leave no signal at all
+ * and fall back to a dot, under which their lone comma reads as grouping.
+ */
+export function detectYnabDecimalSeparator({
+  values,
+}: {
+  values: (string | null | undefined)[];
+}): YnabDecimalSeparator {
+  let dotVotes = 0;
+  let commaVotes = 0;
+
+  for (const value of values) {
+    if (value === null || value === undefined) continue;
+    const extracted = extractNumericToken({ raw: value });
+    if (!extracted) continue;
+
+    const { token } = extracted;
+    const lastDot = token.lastIndexOf('.');
+    const lastComma = token.lastIndexOf(',');
+
+    if (lastDot >= 0 && lastComma >= 0) {
+      if (lastDot > lastComma) dotVotes += 1;
+      else commaVotes += 1;
+      continue;
+    }
+    if (lastDot < 0 && lastComma < 0) continue;
+
+    const separator = lastDot >= 0 ? '.' : ',';
+    const separatorIndex = lastDot >= 0 ? lastDot : lastComma;
+    const occurrences = token.split(separator).length - 1;
+
+    if (occurrences > 1) {
+      // Repeated marks can only be grouping, which makes the other mark decimal.
+      if (separator === '.') commaVotes += 1;
+      else dotVotes += 1;
+      continue;
+    }
+
+    const digitsAfter = token.length - separatorIndex - 1;
+    if (digitsAfter === 1 || digitsAfter === 2) {
+      if (separator === '.') dotVotes += 1;
+      else commaVotes += 1;
+    }
+  }
+
+  return commaVotes > dotVotes ? ',' : '.';
+}
+
+/**
+ * Parse a YNAB amount cell ("$1234.56", "₹0.00", "", "€1.234,56", "1 234,56 kr").
+ *
+ * YNAB writes amounts in the budget's currency format: the symbol may lead or
+ * trail, the decimal mark is a dot or a comma, and grouping is not always in
+ * threes (Indian lakh writes `1,23,456.78`). `decimalSeparator` comes from
+ * `detectYnabDecimalSeparator` over the whole file, so grouping marks can be
+ * dropped without re-guessing per cell.
  *
  * Returns null when the input cannot be parsed into a finite number — caller
  * decides whether that becomes a warning or a hard failure.
  */
-export function parseYnabAmount(raw: string | null | undefined): number | null {
+export function parseYnabAmount({
+  raw,
+  decimalSeparator,
+}: {
+  raw: string | null | undefined;
+  decimalSeparator: YnabDecimalSeparator;
+}): number | null {
   if (raw === null || raw === undefined) return null;
-  const trimmed = raw.trim();
-  if (trimmed === '') return null;
+  const extracted = extractNumericToken({ raw: raw.trim() });
+  if (!extracted) return null;
 
-  const stripped = trimmed.replace(/[$\s,]/g, '');
-  if (stripped === '' || stripped === '-' || stripped === '+') return null;
+  const groupingSeparator = decimalSeparator === '.' ? ',' : '.';
+  let body = extracted.token;
 
-  const n = Number(stripped);
-  if (!Number.isFinite(n)) return null;
-  return n;
+  const decimalIndex = body.lastIndexOf(decimalSeparator);
+  const groupingIndex = body.lastIndexOf(groupingSeparator);
+  if (decimalIndex >= 0 && groupingIndex > decimalIndex) return null;
+  body = body.split(groupingSeparator).join('');
+
+  if (body.split(decimalSeparator).length - 1 > 1) return null;
+
+  const normalized = body.replace(decimalSeparator, '.');
+  if (!/^\d*\.?\d+$/.test(normalized)) return null;
+
+  const amount = Number(normalized);
+  if (!Number.isFinite(amount)) return null;
+
+  return extracted.negative && amount !== 0 ? -amount : amount;
 }

--- a/packages/backend/src/services/import-export/ynab-import/parse-amount.unit.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-amount.unit.ts
@@ -1,46 +1,126 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { parseYnabAmount } from './parse-amount';
+import { detectYnabDecimalSeparator, parseYnabAmount } from './parse-amount';
+
+describe('detectYnabDecimalSeparator', () => {
+  it('detects a dot regime from a cell carrying both marks', () => {
+    expect(detectYnabDecimalSeparator({ values: ['$1,234.56'] })).toBe('.');
+  });
+
+  it('detects a comma regime from a cell carrying both marks', () => {
+    expect(detectYnabDecimalSeparator({ values: ['€1.234,56'] })).toBe(',');
+  });
+
+  it('detects a dot regime from YNAB padded decimals alone', () => {
+    expect(detectYnabDecimalSeparator({ values: ['₹0.00', '₹369.00'] })).toBe('.');
+  });
+
+  it('detects a comma regime from padded decimals alone', () => {
+    expect(detectYnabDecimalSeparator({ values: ['0,00 kr', '1 234,56 kr'] })).toBe(',');
+  });
+
+  it('treats a repeated separator as grouping and reads the other mark as decimal', () => {
+    expect(detectYnabDecimalSeparator({ values: ['€1.234.567'] })).toBe(',');
+    expect(detectYnabDecimalSeparator({ values: ['$1,234,567'] })).toBe('.');
+  });
+
+  it('defaults to dot when a zero-decimal currency gives no signal', () => {
+    expect(detectYnabDecimalSeparator({ values: ['¥1,234', '¥0'] })).toBe('.');
+  });
+
+  it('defaults to dot for an empty column', () => {
+    expect(detectYnabDecimalSeparator({ values: [] })).toBe('.');
+    expect(detectYnabDecimalSeparator({ values: ['', '   ', null, undefined] })).toBe('.');
+  });
+
+  it('ignores unparseable cells', () => {
+    expect(detectYnabDecimalSeparator({ values: ['not-money', '€1.234,56'] })).toBe(',');
+  });
+});
 
 describe('parseYnabAmount', () => {
+  const dot = { decimalSeparator: '.' } as const;
+  const comma = { decimalSeparator: ',' } as const;
+
   it('parses a standard YNAB amount with $ prefix and two decimals', () => {
-    expect(parseYnabAmount('$1234.56')).toBe(1234.56);
+    expect(parseYnabAmount({ raw: '$1234.56', ...dot })).toBe(1234.56);
   });
 
   it('parses zero', () => {
-    expect(parseYnabAmount('$0.00')).toBe(0);
+    expect(parseYnabAmount({ raw: '$0.00', ...dot })).toBe(0);
   });
 
-  it('parses without the $ prefix', () => {
-    expect(parseYnabAmount('1234.56')).toBe(1234.56);
+  it('parses without any currency symbol', () => {
+    expect(parseYnabAmount({ raw: '369.00', ...dot })).toBe(369);
   });
 
   it('strips thousands separators', () => {
-    expect(parseYnabAmount('$1,234,567.89')).toBe(1234567.89);
+    expect(parseYnabAmount({ raw: '$1,234,567.89', ...dot })).toBe(1234567.89);
   });
 
   it('handles whitespace around the value', () => {
-    expect(parseYnabAmount('  $42.50  ')).toBe(42.5);
+    expect(parseYnabAmount({ raw: '  $42.50  ', ...dot })).toBe(42.5);
   });
 
   it('parses negative values (defensive — YNAB does not emit these but should not crash)', () => {
-    expect(parseYnabAmount('-$5.00')).toBe(-5);
-    expect(parseYnabAmount('$-5.00')).toBe(-5);
+    expect(parseYnabAmount({ raw: '-$5.00', ...dot })).toBe(-5);
+    expect(parseYnabAmount({ raw: '$-5.00', ...dot })).toBe(-5);
+  });
+
+  it('parses a non-dollar leading symbol', () => {
+    expect(parseYnabAmount({ raw: '₹1,234.56', ...dot })).toBe(1234.56);
+    expect(parseYnabAmount({ raw: '₹0.00', ...dot })).toBe(0);
+    expect(parseYnabAmount({ raw: '£12.30', ...dot })).toBe(12.3);
+    expect(parseYnabAmount({ raw: 'R$12.30', ...dot })).toBe(12.3);
+  });
+
+  it('parses a comma-decimal regime with dot grouping', () => {
+    expect(parseYnabAmount({ raw: '€1.234,56', ...comma })).toBe(1234.56);
+    expect(parseYnabAmount({ raw: '€0,00', ...comma })).toBe(0);
+  });
+
+  it('parses a trailing symbol with space grouping', () => {
+    expect(parseYnabAmount({ raw: '1 234,56 kr', ...comma })).toBe(1234.56);
+    expect(parseYnabAmount({ raw: '1 234,56 kr', ...comma })).toBe(1234.56);
+    expect(parseYnabAmount({ raw: "1'234.56 Fr.", ...dot })).toBe(1234.56);
+  });
+
+  it('treats a lone comma as grouping for a zero-decimal currency under a dot regime', () => {
+    expect(parseYnabAmount({ raw: '¥1,234', ...dot })).toBe(1234);
+    expect(parseYnabAmount({ raw: '¥0', ...dot })).toBe(0);
+  });
+
+  it('parses Indian lakh grouping (groups of two before the final group of three)', () => {
+    expect(parseYnabAmount({ raw: '₹1,23,456.78', ...dot })).toBe(123456.78);
+    expect(parseYnabAmount({ raw: '₹12,34,567', ...dot })).toBe(1234567);
   });
 
   it('returns null for empty input', () => {
-    expect(parseYnabAmount('')).toBeNull();
-    expect(parseYnabAmount('   ')).toBeNull();
+    expect(parseYnabAmount({ raw: '', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: '   ', ...dot })).toBeNull();
   });
 
   it('returns null for nullish input', () => {
-    expect(parseYnabAmount(null)).toBeNull();
-    expect(parseYnabAmount(undefined)).toBeNull();
+    expect(parseYnabAmount({ raw: null, ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: undefined, ...dot })).toBeNull();
   });
 
   it('returns null for unparseable input', () => {
-    expect(parseYnabAmount('abc')).toBeNull();
-    expect(parseYnabAmount('$')).toBeNull();
-    expect(parseYnabAmount('-')).toBeNull();
+    expect(parseYnabAmount({ raw: 'abc', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: '$', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: '-', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: 'not-money', ...dot })).toBeNull();
+  });
+
+  it('returns null when separators contradict the known regime', () => {
+    expect(parseYnabAmount({ raw: '12,34.56.78', ...dot })).toBeNull();
+    // Grouping mark after the decimal mark is impossible in either regime.
+    expect(parseYnabAmount({ raw: '1.23,456', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: '1,23.456', ...comma })).toBeNull();
+  });
+
+  it('returns null when digits are interrupted by junk', () => {
+    expect(parseYnabAmount({ raw: '12a34.56', ...dot })).toBeNull();
+    expect(parseYnabAmount({ raw: '12-34', ...dot })).toBeNull();
   });
 });

--- a/packages/backend/src/services/import-export/ynab-import/parse-date.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-date.ts
@@ -1,35 +1,60 @@
+import { type DateFieldOrder } from '@bt/shared/types';
+import { parseImportDate } from '@services/import-export/core/parse/date-engine';
+
+/** Year-last date with two 1-2 digit lead fields — the only shape whose
+ *  day/month order is not intrinsic. Mirrors the date engine's family. */
+const AMBIGUOUS_FIELD_ORDER_RE = /^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$/;
+
 /**
  * Parse a YNAB Register.csv date cell into an ISO `YYYY-MM-DD` string.
  *
- * YNAB exports dates as US-style `MM/DD/YYYY` regardless of the user's
- * locale. Treating it as ambiguous (e.g. swapping for DD/MM/YYYY) would
- * silently shift every transaction in the European user's import.
+ * YNAB writes dates in the budget's Date Format setting — MM/DD/YYYY,
+ * DD/MM/YYYY, YYYY-MM-DD, DD.MM.YYYY and friends all occur. `fieldOrder` is
+ * resolved once for the whole column so a d/d/yyyy file never flips reading
+ * mid-import.
  *
  * Returns null on any unparseable input.
  */
-export function parseYnabDate(raw: string | null | undefined): string | null {
+export function parseYnabDate({
+  raw,
+  fieldOrder,
+}: {
+  raw: string | null | undefined;
+  fieldOrder: DateFieldOrder;
+}): string | null {
   if (raw === null || raw === undefined) return null;
   const trimmed = raw.trim();
   if (trimmed === '') return null;
 
-  const match = trimmed.match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
-  if (!match) return null;
+  const parsed = parseImportDate({ value: trimmed, format: { fieldOrder } });
+  if (!parsed) return null;
 
-  const month = Number(match[1]);
-  const day = Number(match[2]);
-  const year = Number(match[3]);
+  const { year, month, day } =
+    parsed.kind === 'instant'
+      ? {
+          year: parsed.instant.getUTCFullYear(),
+          month: parsed.instant.getUTCMonth() + 1,
+          day: parsed.instant.getUTCDate(),
+        }
+      : parsed;
 
-  if (month < 1 || month > 12) return null;
-  if (day < 1 || day > 31) return null;
+  return `${String(year).padStart(4, '0')}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
 
-  // Verify by round-tripping through Date so we reject invalid combos like
-  // 02/30/2026 — Date constructor would silently roll into March.
-  const date = new Date(Date.UTC(year, month - 1, day));
-  if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
-    return null;
+/**
+ * True when the column contains d/d/yyyy values and not one of them settles the
+ * day/month order — the case where the parser has to fall back to a convention
+ * and should say so.
+ */
+export function hasAmbiguousDateFieldOrder({ values }: { values: string[] }): boolean {
+  let sawAmbiguousFamily = false;
+
+  for (const value of values) {
+    const match = value.trim().match(AMBIGUOUS_FIELD_ORDER_RE);
+    if (!match) continue;
+    if (Number(match[1]) > 12 || Number(match[2]) > 12) return false;
+    sawAmbiguousFamily = true;
   }
 
-  const mm = String(month).padStart(2, '0');
-  const dd = String(day).padStart(2, '0');
-  return `${year}-${mm}-${dd}`;
+  return sawAmbiguousFamily;
 }

--- a/packages/backend/src/services/import-export/ynab-import/parse-date.unit.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-date.unit.ts
@@ -1,50 +1,86 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { parseYnabDate } from './parse-date';
+import { hasAmbiguousDateFieldOrder, parseYnabDate } from './parse-date';
 
 describe('parseYnabDate', () => {
+  const monthFirst = { fieldOrder: 'month-first' } as const;
+  const dayFirst = { fieldOrder: 'day-first' } as const;
+
   it('parses a standard MM/DD/YYYY date', () => {
-    expect(parseYnabDate('06/11/2026')).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '06/11/2026', ...monthFirst })).toBe('2026-06-11');
+  });
+
+  it('parses the same value day-first when the budget uses DD/MM/YYYY', () => {
+    expect(parseYnabDate({ raw: '06/11/2026', ...dayFirst })).toBe('2026-11-06');
+    expect(parseYnabDate({ raw: '25/12/2026', ...dayFirst })).toBe('2026-12-25');
+  });
+
+  it('does not transpose day and month in a day-first file when the day is <= 12', () => {
+    expect(parseYnabDate({ raw: '05/03/2026', ...dayFirst })).toBe('2026-03-05');
+    expect(parseYnabDate({ raw: '05/03/2026', ...monthFirst })).toBe('2026-05-03');
   });
 
   it('parses single-digit month and day with leading zeros stripped', () => {
-    expect(parseYnabDate('1/5/2026')).toBe('2026-01-05');
+    expect(parseYnabDate({ raw: '1/5/2026', ...monthFirst })).toBe('2026-01-05');
   });
 
   it('trims surrounding whitespace', () => {
-    expect(parseYnabDate('  06/11/2026  ')).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '  06/11/2026  ', ...monthFirst })).toBe('2026-06-11');
+  });
+
+  it('parses year-first dates regardless of the resolved field order', () => {
+    expect(parseYnabDate({ raw: '2026-06-11', ...monthFirst })).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '2026-06-11', ...dayFirst })).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '2026/06/11', ...dayFirst })).toBe('2026-06-11');
+  });
+
+  it('parses dot- and dash-separated day-first dates', () => {
+    expect(parseYnabDate({ raw: '11.06.2026', ...dayFirst })).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '11-06-2026', ...dayFirst })).toBe('2026-06-11');
+    expect(parseYnabDate({ raw: '06.11.2026', ...monthFirst })).toBe('2026-06-11');
   });
 
   it('returns null on a date that does not exist (Feb 30)', () => {
-    expect(parseYnabDate('02/30/2026')).toBeNull();
+    expect(parseYnabDate({ raw: '02/30/2026', ...monthFirst })).toBeNull();
   });
 
   it('returns null on an out-of-range month', () => {
-    expect(parseYnabDate('13/01/2026')).toBeNull();
+    expect(parseYnabDate({ raw: '13/01/2026', ...monthFirst })).toBeNull();
   });
 
   it('returns null on an out-of-range day', () => {
-    expect(parseYnabDate('01/32/2026')).toBeNull();
+    expect(parseYnabDate({ raw: '01/32/2026', ...monthFirst })).toBeNull();
   });
 
-  it('returns null on the European DD/MM/YYYY when it would be ambiguous', () => {
-    // 31/06 has no month 31, must reject — even though some EU users assume this format.
-    expect(parseYnabDate('31/06/2026')).toBeNull();
-  });
-
-  it('returns null on ISO format (YNAB never emits this — reject so caller catches the surprise)', () => {
-    expect(parseYnabDate('2026-06-11')).toBeNull();
+  it('returns null when the day-first reading lands on a nonexistent day', () => {
+    expect(parseYnabDate({ raw: '31/06/2026', ...dayFirst })).toBeNull();
   });
 
   it('returns null on empty / nullish input', () => {
-    expect(parseYnabDate('')).toBeNull();
-    expect(parseYnabDate('   ')).toBeNull();
-    expect(parseYnabDate(null)).toBeNull();
-    expect(parseYnabDate(undefined)).toBeNull();
+    expect(parseYnabDate({ raw: '', ...monthFirst })).toBeNull();
+    expect(parseYnabDate({ raw: '   ', ...monthFirst })).toBeNull();
+    expect(parseYnabDate({ raw: null, ...monthFirst })).toBeNull();
+    expect(parseYnabDate({ raw: undefined, ...monthFirst })).toBeNull();
   });
 
   it('returns null on garbage', () => {
-    expect(parseYnabDate('hello')).toBeNull();
-    expect(parseYnabDate('06-11-2026')).toBeNull();
+    expect(parseYnabDate({ raw: 'hello', ...monthFirst })).toBeNull();
+    expect(parseYnabDate({ raw: '11/2026', ...monthFirst })).toBeNull();
+  });
+});
+
+describe('hasAmbiguousDateFieldOrder', () => {
+  it('is true when every d/d/yyyy value fits both readings', () => {
+    expect(hasAmbiguousDateFieldOrder({ values: ['06/11/2026', '01/05/2026'] })).toBe(true);
+  });
+
+  it('is false when at least one value disambiguates', () => {
+    expect(hasAmbiguousDateFieldOrder({ values: ['25/12/2026', '01/05/2026'] })).toBe(false);
+    expect(hasAmbiguousDateFieldOrder({ values: ['12/25/2026', '01/05/2026'] })).toBe(false);
+  });
+
+  it('is false when no value belongs to the ambiguous family', () => {
+    expect(hasAmbiguousDateFieldOrder({ values: ['2026-06-11', '20260611'] })).toBe(false);
+    expect(hasAmbiguousDateFieldOrder({ values: [] })).toBe(false);
   });
 });

--- a/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
@@ -15,11 +15,12 @@ import {
   type YnabParseWarning,
 } from '@bt/shared/types';
 import { ValidationError } from '@js/errors';
+import { detectDateColumnFormat } from '@services/import-export/core/parse/date-engine';
 import { roundCurrency } from '@services/import-export/core/round-currency';
 import { parse } from 'csv-parse/sync';
 
-import { parseYnabAmount } from './parse-amount';
-import { parseYnabDate } from './parse-date';
+import { detectYnabDecimalSeparator, parseYnabAmount } from './parse-amount';
+import { hasAmbiguousDateFieldOrder, parseYnabDate } from './parse-date';
 
 /** Headers we require to exist (case-sensitive — YNAB's are stable). */
 const REQUIRED_HEADERS = [
@@ -105,6 +106,30 @@ export function parseYnabRegister({ fileContent }: { fileContent: string }): Yna
   const warnings: YnabParseWarning[] = [];
   const classifiedRows: ClassifiedRow[] = [];
 
+  // One budget = one date format and one currency format, so both are resolved
+  // over the whole file before any row is read.
+  const dateValues = records.map((record) => (record['Date'] ?? '').trim());
+  const detectedDateFormat = detectDateColumnFormat({ values: dateValues, locale: 'en' });
+  if (!detectedDateFormat.ok) {
+    throw new ValidationError({
+      message:
+        'The Date column in YNAB Register.csv mixes contradictory day/month orders — some rows only make sense as DD/MM/YYYY and others only as MM/DD/YYYY. Re-export the budget with a single date format.',
+    });
+  }
+  const { fieldOrder } = detectedDateFormat.format;
+
+  if (hasAmbiguousDateFieldOrder({ values: dateValues })) {
+    warnings.push({
+      code: 'ambiguous-date-order',
+      message:
+        'No row in the Date column settles whether it is day-first or month-first; dates were interpreted as MM/DD/YYYY. Check a few transactions after import.',
+    });
+  }
+
+  const decimalSeparator = detectYnabDecimalSeparator({
+    values: records.flatMap((record) => [record['Outflow'], record['Inflow']]),
+  });
+
   records.forEach((record, idx) => {
     // CSV row index that maps to the file's line number (header = line 1).
     const rowIndex = idx + 2;
@@ -115,7 +140,7 @@ export function parseYnabRegister({ fileContent }: { fileContent: string }): Yna
       return;
     }
 
-    const date = parseYnabDate(record['Date']);
+    const date = parseYnabDate({ raw: record['Date'], fieldOrder });
     if (!date) {
       warnings.push({
         rowIndex,
@@ -125,8 +150,8 @@ export function parseYnabRegister({ fileContent }: { fileContent: string }): Yna
       return;
     }
 
-    const outflowParsed = parseYnabAmount(record['Outflow']);
-    const inflowParsed = parseYnabAmount(record['Inflow']);
+    const outflowParsed = parseYnabAmount({ raw: record['Outflow'], decimalSeparator });
+    const inflowParsed = parseYnabAmount({ raw: record['Inflow'], decimalSeparator });
     const outflowUnparseable = !!record['Outflow'] && outflowParsed === null;
     const inflowUnparseable = !!record['Inflow'] && inflowParsed === null;
     if (outflowUnparseable) {
@@ -190,8 +215,11 @@ export function parseYnabRegister({ fileContent }: { fileContent: string }): Yna
   });
 
   if (classifiedRows.length === 0) {
+    const firstProblem = warnings.find((w) => w.rowIndex !== undefined);
     throw new ValidationError({
-      message: 'No usable rows found in YNAB Register.csv (all rows were skipped or unparseable).',
+      message:
+        'No usable rows found in YNAB Register.csv (all rows were skipped or unparseable).' +
+        (firstProblem ? ` First problem: ${firstProblem.message}` : ''),
     });
   }
 

--- a/packages/backend/src/services/import-export/ynab-import/parse-ynab.unit.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-ynab.unit.ts
@@ -157,5 +157,122 @@ describe('parseYnabRegister', () => {
       expect(cafeTx).toBeDefined();
       expect(cafeTx!.flag).toBeNull();
     });
+
+    it('explains the first row-level problem when every row is skipped', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Checking (USD) – 1234","","not-a-date","Cafe","Wants: Dining","Wants","Dining","Coffee",$3.50,$0.00,"Cleared"`,
+        '',
+      ].join('\n');
+      expect(() => parseYnabRegister({ fileContent })).toThrow(/No usable rows found/i);
+      expect(() => parseYnabRegister({ fileContent })).toThrow(/First problem: Could not parse date "not-a-date"/);
+    });
+  });
+
+  describe('non-US budget formats', () => {
+    it('parses an INR budget: rupee symbol, lakh grouping and DD/MM/YYYY dates', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"HDFC (INR) – 1234","","01/06/2026","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","","₹0.00","₹1,00,000.00","Cleared"`,
+        `"HDFC (INR) – 1234","","25/06/2026","Big Bazaar","Needs: Groceries","Needs","Groceries","Weekly shop","₹369.00","₹0.00","Cleared"`,
+        `"HDFC (INR) – 1234","","03/07/2026","Employer","Inflow: Ready to Assign","Inflow","Ready to Assign","Salary","₹0.00","₹1,23,456.78","Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+
+      expect(result.warnings.map((w) => w.code)).not.toContain('unparseable-amount');
+      expect(result.warnings.map((w) => w.code)).not.toContain('unparseable-date');
+      expect(result.accounts[0]!.startingBalance).toBe(100000);
+
+      const groceries = result.transactions.find((t) => t.payeeName === 'Big Bazaar')!;
+      expect(groceries.amount).toBe(-369);
+      // 25/06 can only be day-first, so the whole column reads DD/MM/YYYY.
+      expect(groceries.date).toBe('2026-06-25');
+
+      const salary = result.transactions.find((t) => t.payeeName === 'Employer')!;
+      expect(salary.amount).toBe(123456.78);
+      expect(salary.date).toBe('2026-07-03');
+
+      expect(result.dateRange).toEqual({ from: '2026-06-01', to: '2026-07-03' });
+    });
+
+    it('parses a EUR budget written with comma decimals and dot grouping', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Konto (EUR) – 1","","01/06/2026","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","","€0,00","€1.234,56","Cleared"`,
+        `"Konto (EUR) – 1","","25/06/2026","Rewe","Needs: Groceries","Needs","Groceries","Shop","€1.234,56","€0,00","Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+
+      expect(result.accounts[0]!.startingBalance).toBe(1234.56);
+      expect(result.transactions.find((t) => t.payeeName === 'Rewe')!.amount).toBe(-1234.56);
+    });
+
+    it('parses a zero-decimal JPY budget where the only separator is grouping', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Bank (JPY) – 1","","2026-01-06","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","","¥0","¥1,234","Cleared"`,
+        `"Bank (JPY) – 1","","2026-01-07","Konbini","Needs: Groceries","Needs","Groceries","Snack","¥1,234","¥0","Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+
+      expect(result.accounts[0]!.startingBalance).toBe(1234);
+      const konbini = result.transactions.find((t) => t.payeeName === 'Konbini')!;
+      expect(konbini.amount).toBe(-1234);
+      expect(konbini.date).toBe('2026-01-07');
+      expect(result.warnings.map((w) => w.code)).not.toContain('ambiguous-date-order');
+    });
+
+    it('parses YYYY-MM-DD dates', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Checking (USD) – 1234","","2026-06-01","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","",$0.00,$100.00,"Cleared"`,
+        `"Checking (USD) – 1234","","2026-06-25","Cafe","Wants: Dining","Wants","Dining","Coffee",$3.50,$0.00,"Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+      expect(result.transactions.find((t) => t.payeeName === 'Cafe')!.date).toBe('2026-06-25');
+    });
+
+    it('parses DD.MM.YYYY dates', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Konto (EUR) – 1","","01.06.2026","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","","€0,00","€100,00","Cleared"`,
+        `"Konto (EUR) – 1","","25.06.2026","Rewe","Needs: Groceries","Needs","Groceries","Shop","€3,50","€0,00","Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+      const rewe = result.transactions.find((t) => t.payeeName === 'Rewe')!;
+      expect(rewe.date).toBe('2026-06-25');
+      expect(rewe.amount).toBe(-3.5);
+    });
+
+    it('falls back to MM/DD/YYYY and warns once when no row disambiguates the date order', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Checking (USD) – 1234","","06/01/2026","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","",$0.00,$100.00,"Cleared"`,
+        `"Checking (USD) – 1234","","05/02/2026","Cafe","Wants: Dining","Wants","Dining","Coffee",$3.50,$0.00,"Cleared"`,
+        '',
+      ].join('\n');
+      const result = parseYnabRegister({ fileContent });
+
+      expect(result.transactions.find((t) => t.payeeName === 'Cafe')!.date).toBe('2026-05-02');
+      const ambiguous = result.warnings.filter((w) => w.code === 'ambiguous-date-order');
+      expect(ambiguous).toHaveLength(1);
+      expect(ambiguous[0]!.rowIndex).toBeUndefined();
+      expect(ambiguous[0]!.message).toMatch(/MM\/DD\/YYYY/);
+    });
+
+    it('throws when the Date column mixes contradictory day/month orders', () => {
+      const fileContent = [
+        YNAB_HEADERS,
+        `"Checking (USD) – 1234","","25/06/2026","Starting Balance","Inflow: Ready to Assign","Inflow","Ready to Assign","",$0.00,$100.00,"Cleared"`,
+        `"Checking (USD) – 1234","","06/25/2026","Cafe","Wants: Dining","Wants","Dining","Coffee",$3.50,$0.00,"Cleared"`,
+        '',
+      ].join('\n');
+      expect(() => parseYnabRegister({ fileContent })).toThrow(/Date column/i);
+    });
   });
 });

--- a/packages/frontend/src/components/dialogs/manage-transaction/helpers.ts
+++ b/packages/frontend/src/components/dialogs/manage-transaction/helpers.ts
@@ -107,7 +107,7 @@ export const isTxEditableAsManual = ({
 export const resolveFormIsPlanned = ({ form }: { form: UI_FORM_STRUCT }): boolean =>
   form.type !== FORM_TYPES.transfer && !!form.isPlanned;
 
-export type OriginalCurrencyPairResolution =
+type OriginalCurrencyPairResolution =
   | { state: 'untouched' }
   | { state: 'clear' }
   | { state: 'pair'; originalAmount: number; originalCurrencyCode: string };

--- a/packages/frontend/src/pages/analytics/subpages/net-worth-drivers/composables/net-worth-drivers-derivations.ts
+++ b/packages/frontend/src/pages/analytics/subpages/net-worth-drivers/composables/net-worth-drivers-derivations.ts
@@ -215,7 +215,7 @@ export interface BreakdownBar {
   segments: (BreakdownLegendEntry & { growth: number })[];
 }
 
-export interface BreakdownModel {
+interface BreakdownModel {
   legend: BreakdownLegendEntry[];
   bars: BreakdownBar[];
 }

--- a/packages/shared/src/types/ynab-import.ts
+++ b/packages/shared/src/types/ynab-import.ts
@@ -116,6 +116,7 @@ export interface YnabParseWarning {
     | 'transfer-counterpart-missing'
     | 'unparseable-amount'
     | 'unparseable-date'
+    | 'ambiguous-date-order'
     | 'unknown-flag'
     | 'row-skipped';
   message: string;


### PR DESCRIPTION
Non-US budgets (e.g. INR) failed with "No usable rows found" because amounts assumed a $ prefix and dates assumed MM/DD/YYYY; both formats are now inferred from the whole file