### PR TITLE
Rebuild foreign-currency balance history at each day's rate

### DIFF
--- a/docs/specifications/foreign-currency-balance-history.md
+++ b/docs/specifications/foreign-currency-balance-history.md
@@ -1,0 +1,192 @@
+# Foreign-Currency Balance History
+
+How the app stores daily balance snapshots for accounts held in a currency other than the user's base currency.
+
+> **TL;DR**
+> For an account whose currency differs from the owner's **base currency** (their main display currency), each row in the `Balances` table equals _account balance at that day × that day's exchange rate_. A dedicated service, `revalueBalanceHistory`, recomputes an account's whole history from scratch. Every write path that can change account's balance schedules it, and a nightly cron re-runs it for every eligible account, so any missed write path or calculation shifts are healed.
+
+Terms used throughout: **`Balances`** table holds one row per account per day, amount in the owner's base currency. **`refAmount`** is a transaction's amount converted to the base currency at the rate of the transaction's own day. **Native units** are amounts in the account's own currency.
+
+## 1. The Problem This Solves
+
+Firstly, let's take a look how it was handled previously (in a wrong way).
+
+Daily `Balances` rows used to be built by summing each transaction's `refAmount` to calculate next days values. Each conversion held the rate of the transaction's own day, so calculated values kept the value of the latest calculated tx date.
+
+If at some point user had a big gap between two transactions in the account, the next transaction write calculated **`Balances`** row based on the new exchange rate, but the gap between two transactions (for example 1 year) wasn't fulfilled with exchange depreciation values. So if exchange rate depreciated a lot during 1 year, the new 5 euro transaction can cause a huge drop in account's "valuation".
+
+Example: An account with EUR as base currency holds a GBP fixed-deposit. A 50,000 GBP deposit from two years ago sits in storage at that day's value – 60,000 EUR – and carries forward unchanged while the pound loses 20% against the euro over the same stretch. Today's balance, computed as pounds held × today's rate, comes out to 48,000 EUR. The 12,000 EUR gap between the two lands on the chart as a one-day loss labeled "No significant transactions for this date" – no transaction records this "loss" and no rows in **`Balances`** table do it either – it just magically "dropped" in valuation for "no reason" from the user's perspective.
+
+The same setup produces a second symptom: an account holding **zero pounds**, all deposits withdrawn, shows a stored balance of **12,000 EUR**. That number is the deposit converted at the old rate minus the same amount converted at the new rate. The correct stored value is 0.
+
+### The new logic
+
+For every eligible account, the stored balance for day D equals the native units the account held on day D multiplied by the base-currency rate for day D. Currency movement spreads across the whole history as a slope, and stored history joins today's spot value continuously.
+
+Transaction `refAmount` values keep their per-day historical rates. Income and expense statistics report spend over a period, and converting each expense at the rate of its own day is the correct input for that. **The new logic** changes the fact that now eligible
+accounts are all getting daily snapshots, instead of relying on summing `refAmount`s
+after each write events. Each time transactions/accounts getting a write event – the
+`revalueBalanceHistory` gets scheduled to reevaluate **`Balances`** table based on the
+new values.
+
+## 2. Scope: Which Accounts Get Revalued at transaction change action
+
+`isRevaluedAccount({ account, baseCurrencyCode })` is the single predicate, exported so
+callers can select the incremental path without calling the rebuild first. It returns
+true when all three hold:
+
+- `account.type === 'system'` (a manual account the user types into).
+- The account category is not a dedicated-flow category (`loan`, `vehicle`), which own their balance rows through their own projection logic.
+- `account.currencyCode !== baseCurrencyCode`.
+
+Everything else keeps the incremental cascade that patches later days with the transaction's `refAmount`. Bank-synced accounts (`monobank`, `enable-banking`, `walutomat`) are excluded. Same-currency accounts are excluded because their rate is 1, so the stored conversion equals the live one on every day.
+
+## 3. Batching: One Rebuild Per Account
+
+A 1,000-row CSV or YNAB import touches one account a thousand times, and each touch
+schedules a rebuild. Batching collapses those into one full-history rebuild.
+
+`runWithBalanceRevalueBatch(fn)` opens an `AsyncLocalStorage` scope holding a `Set`
+of account IDs. Inside that scope, `scheduleBalanceRevalue({ accountId })` adds to
+the set and returns. The deduped rebuilds run once each after `fn` settles. They
+also run when `fn` throws, because the rows that already committed still need
+revaluing, and the original error is rethrown afterwards. A failed rebuild is
+logged under `BALANCE_REVALUE_BATCH_FAILED` and left to the nightly sweep, and
+the request still returns its result. Nested scopes merge into the outermost one.
+
+Outside a scope, `scheduleBalanceRevalue` runs the rebuild inline, joining the ambient CLS transaction so the rebuild commits together with the change that triggered it.
+
+Scopes are opened at entrypoints:
+
+- Every HTTP request, through `createController` in the controller factory.
+- Cron job bodies (`subscription-auto-record`).
+- Queue job bodies (import jobs, monobank transaction sync).
+
+## 4. The Rebuild: `revalueBalanceHistory`
+
+`revalueBalanceHistory({ accountId })` is the whole feature in one call. It returns
+`'rebuilt'` or `'skipped'`, and `'skipped'` means it decided not to touch a single row –
+the account is gone, has no base currency, fails `isRevaluedAccount`, or has no usable
+rate (section 5).
+
+Every run recomputes the account's **full** history, never a slice of it. That is what
+makes it idempotent: running it twice in a row produces the same rows, and a run always
+overwrites whatever an earlier run wrote. So a caller never has to reason about what
+already happened – it just schedules a rebuild and the account ends up correct.
+
+**Day buckets.** Every day is a UTC bucket. The SQL truncates transaction times at UTC,
+the day walk steps UTC midnights, and `Balances.date` is a `YYYY-MM-DD` string. No
+timezone drift creeps in between the three.
+
+**Grid bounds.** The grid starts at the earliest of: today, the day before the account's
+first transaction, and the account's oldest stored `Balances` row. The day before the
+first transaction is where `initialBalance` lives, so the series starts from the money
+the account actually opened with instead of from zero. The oldest stored row is included
+so that rows an earlier (wrong) run wrote are inside the range and get replaced rather
+than left behind. The grid ends at today, or at the last transaction's day when that one
+is later – a backdated-into-the-future transaction still gets valued.
+
+**The walk.** The rebuild loads per-day signed native deltas straight from
+`real_transactions` (income counts positive, everything else negative), seeds the running
+total with the account's `initialBalance`, then steps day by day: add that day's delta,
+look up that day's rate, and store `roundHalfToEven(native units × rate)`. Nothing here
+reads `refAmount` – the native amount is the source of truth and the rate is picked per
+day, which is exactly what the old cascade could not do.
+
+**Sparse output.** The read path forward-fills gaps, so a day whose value repeats the
+previous day carries no information and is dropped. Two days always survive that filter:
+the first day of the grid and today. Today's row is what makes the chart move with the
+exchange rate on days the user made no transactions at all.
+
+**Writes.** The rebuild deletes every row in its range and then inserts what it computed.
+The delete matters: a day the rebuild no longer emits must not survive, because the
+forward fill would read that leftover row as a real measurement and bend the chart around
+it. The insert still uses `ON CONFLICT ... DO UPDATE` on top of that, because the 18:00
+UTC remeasure can pin today's row in the window between the delete and the insert.
+
+**Concurrency.** The rebuild takes a per-account advisory lock
+(`pg_advisory_xact_lock`) held for its transaction. Two rebuilds of the same account
+would otherwise interleave their writes and leave a grid mixing rows from two different
+runs.
+
+## 5. Rate Resolution
+
+A flat user-defined rate wins for every day of the grid when one exists. `resolveCustomRate`
+hands one back only when the user turned `liveRateUpdate` **off** for that currency in
+`UsersCurrencies` **and** the target is their base currency – anything else returns `null`.
+With a flat rate in hand the rebuild skips the market lookup entirely, so the whole history
+gets re-priced at that single number.
+
+Otherwise `buildDailyPairRateResolver` builds a per-day lookup from the `ExchangeRates`
+table, which stores USD-pivot rows. The daily rate for a pair is derived by pivoting both
+currencies through USD: the exact day's row, else the most recent earlier row, else the
+earliest row known for that currency. That last fallback is what covers days older than
+the app's rate coverage – any rate beats no rate there. Rates are truncated to 5 decimals
+by `formatRate`, the same truncation `getExchangeRate` applies, so a rebuilt row matches
+what every other conversion in the app produces for that day. A rate that truncates to 0
+counts as missing, because multiplying by it would write a perfectly valid-looking history
+of zero balances.
+
+**Failure mode.** When the pair has no stored rate on either leg, or when some day inside
+the grid resolves to no rate, the rebuild logs a warning, returns `'skipped'`, and touches
+no row. The existing rows stay exactly as they are – a partially-valued history is worse
+than a stale one – and the nightly sweep retries the account once the rates arrive.
+
+## 6. Write Paths That Trigger a Rebuild
+
+| Path                                                                  | Where                                                                                                                                                                                                                                                                        |
+| --------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Transaction create, edit, delete                                      | `Balances.handleTransactionChange` (`models/balances.model.ts`). For a revalued account it calls `scheduleBalanceRevalue` in place of the incremental cascade and today's spot re-pin. A moved transaction schedules both the old and the new account.                       |
+| Account edit (opening balance, currency)                              | `updateAccount` in `services/accounts.service.ts`. Each stored day has to be re-priced at its own rate, so `handleAccountChange` and `setTodayRowToSpot` are bypassed and the rebuild owns the history.                                                                      |
+| Balance adjustment absorption                                         | `absorbBalanceAdjustment` in `services/accounts/absorb-balance-adjustment.ts`, same branch.                                                                                                                                                                                  |
+| User exchange-rate update or removal, and the `liveRateUpdate` toggle | `update-exchange-rates.service.ts`, `remove-exchange-rates.service.ts` and `user.service.ts`, all through `revalueAccountsInCurrencies`, which fans out to every eligible account of that user held in the affected currencies.                                              |
+| Base-currency change                                                  | `change-base-currency.service.ts` converts the other accounts row by row, but collects revalued account IDs and calls `revalueBalanceHistory` for them after its own transaction commits. Converting their rows one by one would only re-derive a blend of historical rates. |
+| MCP tool calls                                                        | `routes/mcp.route.ts` wraps `transport.handleRequest` in `runWithBalanceRevalueBatch`, so a tool's writes get their queued rebuilds after the tool finishes rather than inline from inside a model hook.                                                                     |
+
+## 7. Nightly Sweep
+
+The sweep (`crons/balance-revalue-sweep.ts`) runs at **18:45 UTC**, after the 18:00 UTC
+rate fetch has stored today's rates. Running it earlier would value today's row at
+yesterday's rate, which is precisely the bug this whole document is about.
+
+It selects **every** candidate account – category not in the dedicated-flow list, currency
+different from the owner's default currency – regardless of type, and then splits by type:
+
+- A `system` account gets the full `revalueBalanceHistory` rebuild.
+- A bank-synced account gets only **today's** row rewritten, via `writeBankBalanceWithHistory`,
+  as its last-known native balance × today's rate. The provider owns that account's history
+  and the sweep never rebuilds it.
+
+That second branch exists for the user's sake. A foreign-currency bank account that has not
+synced for a while would otherwise sit flat at the rate of its last sync, and then jump the
+whole accumulated currency move in one day when the next sync lands – the same cliff, just
+sourced from the provider instead of from a transaction.
+
+Accounts are processed **sequentially**. Rebuilding every foreign-currency account at once
+floods the database connection pool. The job holds a distributed lock with a 4-hour TTL,
+which comfortably exceeds a full sweep, so a second instance stays blocked instead of
+starting on top of a running one.
+
+A skipped account counts as a **failed** update in the job's report, with the reason
+recorded as missing exchange-rate coverage. A skip is not a success – it means an account
+still holds rows nobody has verified.
+
+No one-time data migration shipped with this feature, and none is needed. The rebuild
+covers full history and the sweep covers every candidate, so the first nightly run after
+deploy rewrites every stored row on its own. An account the user touches before that gets
+rewritten even sooner, by its write path.
+
+## 8. Where the Data Surfaces
+
+`GET /stats/combined-balance-history` reads the `Balances` rows, aggregates them across
+accounts, and forward-fills days without rows. It feeds the dashboard's Balance Trend and
+Net Worth widgets. The app has no per-account balance chart, so this aggregate is the only
+place these rows reach the UI.
+
+## 9. Deliberately Out of Scope
+
+- Per-transaction conversion amounts. `refAmount` stays at its historical rate.
+- Loan balance projection and vehicle depreciation, which own their own rows.
+- Demo-data seeding, which builds balances itself. The nightly sweep rewrites its foreign-currency history anyway, which is acceptable for demo accounts.
+- Bank-synced account **history**. Providers own it, and the sweep only re-pins today's row.
+- Labeling the currency-revaluation share of a day's change in the chart's spike panel. Considered and dropped.

--- a/packages/backend/src/background-jobs.ts
+++ b/packages/backend/src/background-jobs.ts
@@ -1,6 +1,7 @@
 import { logger } from '@js/utils/logger';
 import { shutdownPostHog } from '@js/utils/posthog';
 
+import { balanceRevalueSweepCron } from './crons/balance-revalue-sweep';
 import { cryptoPricesSyncCron } from './crons/crypto-prices-sync';
 import { demoCleanupCron } from './crons/demo-cleanup';
 import { demoTemplateRefreshCron } from './crons/demo-template-refresh';
@@ -41,6 +42,7 @@ export function initializeBackgroundJobs() {
       shareInvitationsExpireCron.startCron();
       shareResourceOrphanCleanupCron.startCron();
       purgeDeletedPortfoliosCron.startCron();
+      balanceRevalueSweepCron.startCron();
     }
   }
 }
@@ -57,6 +59,7 @@ export async function shutdownBackgroundJobs() {
   shareInvitationsExpireCron.stopCron();
   shareResourceOrphanCleanupCron.stopCron();
   purgeDeletedPortfoliosCron.stopCron();
+  balanceRevalueSweepCron.stopCron();
   loadCurrencyRatesJob.stop();
   // Flush remaining PostHog events before exit
   await shutdownPostHog();

--- a/packages/backend/src/controllers/helpers/controller-factory.ts
+++ b/packages/backend/src/controllers/helpers/controller-factory.ts
@@ -1,6 +1,7 @@
 import { API_RESPONSE_STATUS } from '@bt/shared/types';
 import { CustomRequest, CustomResponse } from '@common/types';
 import { errorHandler } from '@controllers/helpers';
+import { runWithBalanceRevalueBatch } from '@services/balances/revalue-balance-history.service';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 
@@ -31,14 +32,17 @@ export function createController<T extends z.ZodType>(schema: T, handler: Handle
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const validated = req.validated as any;
-        const result = await handler({
-          req: _req,
-          res: res,
-          user: req.user,
-          params: validated.params || {},
-          query: validated.query || {},
-          body: validated.body || {},
-        });
+        // One revalue scope per request, so the rebuilds finish before `res` is written.
+        const result = await runWithBalanceRevalueBatch(() =>
+          handler({
+            req: _req,
+            res: res,
+            user: req.user,
+            params: validated.params || {},
+            query: validated.query || {},
+            body: validated.body || {},
+          }),
+        );
 
         const statusCode = result?.statusCode || 200;
 

--- a/packages/backend/src/crons/balance-revalue-sweep.e2e.ts
+++ b/packages/backend/src/crons/balance-revalue-sweep.e2e.ts
@@ -1,0 +1,170 @@
+import { ACCOUNT_CATEGORIES, VEHICLE_CLASS, asDecimal } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import Accounts from '@models/accounts.model';
+import { connection } from '@models/connection';
+import { runBalanceRevalueSweep } from '@root/crons/balance-revalue-sweep';
+import * as helpers from '@tests/helpers';
+import { getLunchFlowBalanceMock, getLunchFlowTransactionsMock } from '@tests/mocks/lunchflow/mock-api';
+import { format, subDays, subYears } from 'date-fns';
+import { QueryTypes } from 'sequelize';
+import { v7 as uuidv7 } from 'uuid';
+
+/** The sweep has no HTTP surface, so this e2e invokes it directly. */
+
+const CORRUPTED_CENTS = 99_999_900;
+
+const dayKey = (date: Date) => format(date, 'yyyy-MM-dd');
+
+const writeBalanceRow = async ({ accountId, date, cents }: { accountId: string; date: Date; cents: number }) => {
+  await connection.sequelize.query(
+    `INSERT INTO "Balances" ("id", "accountId", "date", "amount", "createdAt", "updatedAt")
+     VALUES (:id, :accountId, :date, :amount, NOW(), NOW())
+     ON CONFLICT ("accountId", "date") DO UPDATE SET "amount" = EXCLUDED."amount"`,
+    { replacements: { id: uuidv7(), accountId, date: dayKey(date), amount: cents } },
+  );
+};
+
+const readBalanceRow = async ({ accountId, date }: { accountId: string; date: Date }): Promise<number | null> => {
+  const [row] = (await connection.sequelize.query(
+    `SELECT "amount"::bigint AS "cents" FROM "Balances" WHERE "accountId" = :accountId AND "date" = :date`,
+    { type: QueryTypes.SELECT, replacements: { accountId, date: dayKey(date) } },
+  )) as { cents: string }[];
+
+  return row ? Number(row.cents) : null;
+};
+
+const LUNCHFLOW_EXTERNAL_ACCOUNT_ID = 1001;
+const BANK_BALANCE = 1000.5;
+
+const connectBankAccount = async ({ currency }: { currency: string }): Promise<Accounts> => {
+  global.mswMockServer.use(
+    getLunchFlowTransactionsMock({ response: { transactions: [], total: 0 } }),
+    getLunchFlowBalanceMock({
+      accountId: LUNCHFLOW_EXTERNAL_ACCOUNT_ID,
+      response: { balance: { amount: asDecimal(BANK_BALANCE), currency } },
+    }),
+  );
+
+  const { connectionId } = await helpers.lunchflow.pair();
+  const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+    connectionId,
+    accountExternalIds: [String(LUNCHFLOW_EXTERNAL_ACCOUNT_ID)],
+    raw: true,
+  });
+
+  return (await Accounts.findByPk(syncedAccounts[0]!.id))!;
+};
+
+const setAccountCategory = async ({ accountId, category }: { accountId: string; category: ACCOUNT_CATEGORIES }) => {
+  await connection.sequelize.query(`UPDATE "Accounts" SET "accountCategory" = :category WHERE "id" = :accountId`, {
+    replacements: { accountId, category },
+  });
+};
+
+describe('Nightly balance revalue sweep', () => {
+  it('rebuilds a foreign-currency account, dropping a value it did not compute', async () => {
+    const { account } = await helpers.createAccountWithNewCurrency({ currency: 'UAH' });
+
+    await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: 1000,
+        time: subDays(new Date(), 10).toISOString(),
+      }),
+      raw: true,
+    });
+
+    const corruptedDay = subDays(new Date(), 5);
+    await writeBalanceRow({ accountId: account.id, date: corruptedDay, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(1);
+    expect(result.successfulUpdates).toBe(1);
+    expect(result.failedUpdates).toBe(0);
+
+    // The rebuild owns every day from the grid start on: the corrupted row is either
+    // rewritten with the day's real value or deleted as a day that carries no change.
+    expect(await readBalanceRow({ accountId: account.id, date: corruptedDay })).not.toBe(CORRUPTED_CENTS);
+  });
+
+  it('leaves accounts already in the base currency alone', async () => {
+    const account = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ currencyCode: global.BASE_CURRENCY.code }),
+      raw: true,
+    });
+
+    const untouchedDay = subDays(new Date(), 5);
+    await writeBalanceRow({ accountId: account.id, date: untouchedDay, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(0);
+    expect(await readBalanceRow({ accountId: account.id, date: untouchedDay })).toBe(CORRUPTED_CENTS);
+  });
+
+  it('re-values today for a foreign-currency bank account the provider did not sync', async () => {
+    const today = new Date();
+    await helpers.seedUsdExchangeRates({ date: today, ratesPerUsd: { AED: helpers.AED_PER_USD } });
+
+    const account = await connectBankAccount({ currency: 'USD' });
+    await writeBalanceRow({ accountId: account.id, date: today, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(1);
+    expect(result.successfulUpdates).toBe(1);
+    expect(await readBalanceRow({ accountId: account.id, date: today })).toBe(
+      account.currentBalance.toCents() * helpers.AED_PER_USD,
+    );
+  });
+
+  it('leaves a bank account in the base currency alone', async () => {
+    const today = new Date();
+    const account = await connectBankAccount({ currency: global.BASE_CURRENCY.code });
+
+    await writeBalanceRow({ accountId: account.id, date: today, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(0);
+    expect(await readBalanceRow({ accountId: account.id, date: today })).toBe(CORRUPTED_CENTS);
+  });
+
+  it('skips loan accounts, which own their balance history', async () => {
+    const { account } = await helpers.createAccountWithNewCurrency({ currency: 'UAH' });
+    await setAccountCategory({ accountId: account.id, category: ACCOUNT_CATEGORIES.loan });
+
+    const untouchedDay = subDays(new Date(), 5);
+    await writeBalanceRow({ accountId: account.id, date: untouchedDay, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(0);
+    expect(await readBalanceRow({ accountId: account.id, date: untouchedDay })).toBe(CORRUPTED_CENTS);
+  });
+
+  it('skips vehicle accounts, whose balance is a depreciation curve', async () => {
+    await helpers.addUserCurrencies({ currencyCodes: ['UAH'] });
+    const vehicle = await helpers.createVehicle({
+      name: 'Toyota Camry 2020',
+      currencyCode: 'UAH',
+      make: 'Toyota',
+      model: 'Camry',
+      year: 2020,
+      vehicleClass: VEHICLE_CLASS.sedan,
+      purchasePrice: 25000,
+      purchaseDate: format(subYears(new Date(), 3), 'yyyy-MM-dd'),
+      raw: true,
+    });
+
+    const accountId = vehicle.accountId;
+    const untouchedDay = subDays(new Date(), 5);
+    await writeBalanceRow({ accountId, date: untouchedDay, cents: CORRUPTED_CENTS });
+
+    const result = await runBalanceRevalueSweep();
+
+    expect(result.totalProcessed).toBe(0);
+    expect(await readBalanceRow({ accountId, date: untouchedDay })).toBe(CORRUPTED_CENTS);
+  });
+});

--- a/packages/backend/src/crons/balance-revalue-sweep.ts
+++ b/packages/backend/src/crons/balance-revalue-sweep.ts
@@ -1,0 +1,96 @@
+import { ACCOUNT_TYPES, DEDICATED_FLOW_ACCOUNT_CATEGORIES } from '@bt/shared/types';
+import { logger } from '@js/utils';
+import Accounts from '@models/accounts.model';
+import { connection } from '@models/connection';
+import { revalueBalanceHistory } from '@services/balances/revalue-balance-history.service';
+import { writeBankBalanceWithHistory } from '@services/bank-data-providers/utils/write-bank-balance-with-history';
+import { withLock } from '@services/common/lock';
+import { QueryTypes } from 'sequelize';
+
+import { createScheduledSync, type SyncResult } from './lib/create-scheduled-sync';
+
+const loadCandidateAccounts = async (): Promise<{ accountId: string; type: ACCOUNT_TYPES }[]> =>
+  (await connection.sequelize.query(
+    `SELECT a."id" AS "accountId", a."type" AS "type"
+       FROM "Accounts" a
+       JOIN "UsersCurrencies" uc ON uc."userId" = a."userId" AND uc."isDefaultCurrency" = true
+      WHERE a."accountCategory" NOT IN (:dedicatedFlowCategories)
+        AND a."currencyCode" <> uc."currencyCode"
+      ORDER BY a."id"`,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        dedicatedFlowCategories: [...DEDICATED_FLOW_ACCOUNT_CATEGORIES],
+      },
+    },
+  )) as { accountId: string; type: ACCOUNT_TYPES }[];
+
+/**
+ * Sequential on purpose: rebuilding every foreign-currency account at once floods the DB.
+ *
+ * Bank-synced accounts only get today's row re-valued from their last-known native
+ * balance — the provider owns their history, so it is never rebuilt from transactions.
+ */
+export const runBalanceRevalueSweep = async (): Promise<SyncResult> => {
+  const candidates = await loadCandidateAccounts();
+  const result: SyncResult = {
+    totalProcessed: candidates.length,
+    successfulUpdates: 0,
+    failedUpdates: 0,
+    errors: [],
+  };
+
+  for (const candidate of candidates) {
+    try {
+      if (candidate.type !== ACCOUNT_TYPES.system) {
+        const account = await Accounts.findByPk(candidate.accountId);
+
+        if (!account) {
+          throw new Error(`Account ${candidate.accountId} disappeared mid-sweep`);
+        }
+
+        await writeBankBalanceWithHistory({ account, balance: account.currentBalance });
+        result.successfulUpdates += 1;
+        continue;
+      }
+
+      const outcome = await revalueBalanceHistory({ accountId: candidate.accountId });
+
+      if (outcome === 'skipped') {
+        result.failedUpdates += 1;
+        result.errors.push(`Account ${candidate.accountId} skipped: no exchange rate coverage`);
+      } else {
+        result.successfulUpdates += 1;
+      }
+    } catch (error) {
+      result.failedUpdates += 1;
+      result.errors.push(error);
+      logger.error(
+        {
+          message: `Balance revalue sweep failed for account ${candidate.accountId}`,
+          error: error as Error,
+        },
+        { code: 'BALANCE_REVALUE_SWEEP_ACCOUNT_FAILED' },
+      );
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Nightly safety net: writes today's row at today's rate so foreign-currency charts
+ * move on days without transactions, and heals accounts a write path left stale.
+ *
+ * Must run after `loadCurrencyRatesJob` (18:00 UTC) has stored today's rates, or
+ * today's row gets valued at yesterday's rate.
+ */
+export const balanceRevalueSweepCron = createScheduledSync({
+  name: 'balance revalue',
+  cronExpression: '45 18 * * *',
+  timeZone: 'UTC',
+  scheduleDescription: 'runs daily at 18:45 UTC',
+  // A sweep over every foreign-currency account can outlive the default 30-minute
+  // lock TTL, which would let a second instance start on top of a running one.
+  run: withLock('lock:cron:balance-revalue-sweep', runBalanceRevalueSweep, { ttl: 60 * 60 * 4 }),
+});

--- a/packages/backend/src/crons/lib/create-scheduled-sync.ts
+++ b/packages/backend/src/crons/lib/create-scheduled-sync.ts
@@ -7,7 +7,7 @@ import { CronJob } from 'cron';
  * factory only needs the counts for logging; richer typing would couple this
  * module to securities-daily-sync internals.
  */
-interface SyncResult {
+export interface SyncResult {
   totalProcessed: number;
   successfulUpdates: number;
   failedUpdates: number;

--- a/packages/backend/src/crons/subscription-auto-record.ts
+++ b/packages/backend/src/crons/subscription-auto-record.ts
@@ -1,4 +1,5 @@
 import { logger } from '@js/utils';
+import { runWithBalanceRevalueBatch } from '@services/balances/revalue-balance-history.service';
 import { processAutoRecordPeriods } from '@services/subscriptions/process-auto-record';
 import { CronJob } from 'cron';
 
@@ -25,7 +26,7 @@ class SubscriptionAutoRecordCronService {
       async () => {
         try {
           logger.info('Starting subscription auto-record run');
-          const result = await processAutoRecordPeriods();
+          const result = await runWithBalanceRevalueBatch(() => processAutoRecordPeriods());
           logger.info('Subscription auto-record run completed', {
             booked: result.booked,
             failed: result.failed,

--- a/packages/backend/src/models/balances.model.ts
+++ b/packages/backend/src/models/balances.model.ts
@@ -139,6 +139,29 @@ export default class Balances extends Model {
           break;
         }
 
+        // Lazy import: the service reads accounts and rates, so a static import
+        // would close a model→service→model cycle at load time.
+        const { isRevaluedAccount, scheduleBalanceRevalue } =
+          await import('@services/balances/revalue-balance-history.service');
+
+        // A foreign-currency account can't be cascaded: every later day has to be
+        // re-valued at its own rate, so it is rebuilt wholesale instead.
+        const affectedAccounts = new Map<
+          string,
+          { account: Accounts; ownerBaseCode: string | undefined; isRevalued: boolean }
+        >();
+        for (const affectedAccountId of new Set([accountId, ...(prevData ? [prevData.accountId] : [])])) {
+          const account = await Accounts.findOne({ where: { id: affectedAccountId } });
+          if (!account) continue;
+
+          const ownerBaseCode = (await getBaseCurrency({ userId: account.userId }))?.currencyCode;
+          affectedAccounts.set(affectedAccountId, {
+            account,
+            ownerBaseCode,
+            isRevalued: !!ownerBaseCode && isRevaluedAccount({ account, baseCurrencyCode: ownerBaseCode }),
+          });
+        }
+
         if (isDelete) {
           amount = amount.negate(); // Reverse the amount if it's a deletion
         } else if (prevData) {
@@ -157,20 +180,24 @@ export default class Balances extends Model {
             !amount.isZero()
             // THEN remove the original transaction
           ) {
-            await this.updateBalanceIncremental({
-              accountId: prevData.accountId,
-              date: originalDate,
-              amount: originalAmount.negate(),
-            });
+            if (!affectedAccounts.get(prevData.accountId)?.isRevalued) {
+              await this.updateBalanceIncremental({
+                accountId: prevData.accountId,
+                date: originalDate,
+                amount: originalAmount.negate(),
+              });
+            }
           }
         }
 
         // Update the balance for the current account and date
-        await this.updateBalanceIncremental({
-          accountId,
-          date,
-          amount,
-        });
+        if (!affectedAccounts.get(accountId)?.isRevalued) {
+          await this.updateBalanceIncremental({
+            accountId,
+            date,
+            amount,
+          });
+        }
 
         // The incremental cascade folded this transaction's historical-rate
         // `refAmount` into today's row, but today's row is a STOCK: it must equal
@@ -178,13 +205,12 @@ export default class Balances extends Model {
         // each affected account to the spot value already written by the
         // account-balance hook. A moved transaction touches its old and new account,
         // so both are re-pinned.
-        const clampAccountIds = new Set<string>([accountId]);
-        if (prevData && prevData.accountId !== accountId) {
-          clampAccountIds.add(prevData.accountId);
-        }
-        for (const clampAccountId of clampAccountIds) {
-          const clampAccount = await Accounts.findOne({ where: { id: clampAccountId } });
-          if (!clampAccount) continue;
+        for (const [clampAccountId, { account: clampAccount, ownerBaseCode, isRevalued }] of affectedAccounts) {
+          // A revalued account gets its whole grid, today's row included, from the rebuild.
+          if (isRevalued) {
+            await scheduleBalanceRevalue({ accountId: clampAccountId });
+            continue;
+          }
 
           // Whether today's row still needs re-pinning. The one case that does NOT
           // is an identity-rate cascade in the OWNER's base currency: the account is
@@ -196,15 +222,10 @@ export default class Balances extends Model {
           // base, not the owner's. The skip therefore requires the account currency,
           // the row's ref currency, AND the owner's actual base to all agree. Loans
           // no-op inside `setTodayRowToSpot`.
-          let shouldPin = true;
-          if (clampAccount.currencyCode === data.refCurrencyCode) {
-            const ownerBaseCurrency = await getBaseCurrency({ userId: clampAccount.userId });
-            if (clampAccount.currencyCode === ownerBaseCurrency?.currencyCode) {
-              shouldPin = false;
-            }
-          }
+          const isOwnerBaseIdentityCascade =
+            clampAccount.currencyCode === data.refCurrencyCode && clampAccount.currencyCode === ownerBaseCode;
 
-          if (shouldPin) {
+          if (!isOwnerBaseIdentityCascade) {
             await this.setTodayRowToSpot({ account: clampAccount });
           }
         }

--- a/packages/backend/src/routes/mcp.route.ts
+++ b/packages/backend/src/routes/mcp.route.ts
@@ -1,6 +1,7 @@
 import { CustomError } from '@js/errors';
 import { logger } from '@js/utils/logger';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { runWithBalanceRevalueBatch } from '@services/balances/revalue-balance-history.service';
 import { McpAuthInfo, verifyMcpToken } from '@services/mcp/auth';
 import { createMcpServer } from '@services/mcp/server';
 import {
@@ -129,13 +130,15 @@ router.post('/', async (req: Request, res: Response) => {
 
   const sessionId = getSessionId({ req });
 
+  // Tool calls mutate data, so each request gets its own revalue scope: the queued
+  // rebuilds must run after the tool's writes, not inline from inside a model hook.
   try {
     // Reuse existing transport for established sessions
     if (sessionId) {
       const transport = resolveSessionTransport({ req, res });
       if (!transport) return;
 
-      await transport.handleRequest(req, res, req.body);
+      await runWithBalanceRevalueBatch(() => transport.handleRequest(req, res, req.body));
       return;
     }
 
@@ -158,7 +161,7 @@ router.post('/', async (req: Request, res: Response) => {
 
       const server = createMcpServer();
       await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      await runWithBalanceRevalueBatch(() => transport.handleRequest(req, res, req.body));
       return;
     }
 

--- a/packages/backend/src/services/accounts.service.ts
+++ b/packages/backend/src/services/accounts.service.ts
@@ -17,7 +17,9 @@ import * as Accounts from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import { countTransactions } from '@models/transactions-query';
+import { getBaseCurrency } from '@models/users-currencies.model';
 import Users from '@models/users.model';
+import { isRevaluedAccount, scheduleBalanceRevalue } from '@services/balances/revalue-balance-history.service';
 import { applyManualLogoPatch } from '@services/brand-logos';
 import { calculateRefAmount } from '@services/calculate-ref-amount.service';
 import { ensureUserCurrencyConnected } from '@services/sharing/auth/ensure-currency-connected.service';
@@ -376,10 +378,18 @@ export const updateAccount = withTransaction(
       throw new UnexpectedError({ message: t({ key: 'accounts.accountUpdateFailed' }) });
     }
 
-    await Balances.handleAccountChange({
-      account: result,
-      prevAccount: accountData,
-    });
+    // A foreign-currency opening balance can't be shifted through history as a flat
+    // `refInitialBalance` diff: every day has to be re-valued at its own rate.
+    const baseCurrency = await getBaseCurrency({ userId: accountData.userId });
+    const revalueOwnsHistory =
+      !!baseCurrency && isRevaluedAccount({ account: result, baseCurrencyCode: baseCurrency.currencyCode });
+
+    if (!revalueOwnsHistory) {
+      await Balances.handleAccountChange({
+        account: result,
+        prevAccount: accountData,
+      });
+    }
 
     let finalAccount = result;
     // The opening balance changed → its base-currency stamp must be re-derived at
@@ -404,8 +414,12 @@ export const updateAccount = withTransaction(
 
     // Today's net-worth row is a stock equal to the spot `refCurrentBalance`. Pin it
     // last, after the restamp's history cascade, so the spot value wins.
-    if (currentBalanceIsChanging) {
+    if (currentBalanceIsChanging && !revalueOwnsHistory) {
       await Balances.setTodayRowToSpot({ account: finalAccount });
+    }
+
+    if (revalueOwnsHistory) {
+      await scheduleBalanceRevalue({ accountId: finalAccount.id });
     }
 
     return finalAccount;

--- a/packages/backend/src/services/accounts/absorb-balance-adjustment.ts
+++ b/packages/backend/src/services/accounts/absorb-balance-adjustment.ts
@@ -5,7 +5,9 @@ import { logger } from '@js/utils/logger';
 import Accounts, * as AccountsModel from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import { namespace } from '@models/connection';
+import { getBaseCurrency } from '@models/users-currencies.model';
 import { assertNotDerivedBalanceAccount } from '@services/accounts/derived-balance-guard';
+import { isRevaluedAccount, scheduleBalanceRevalue } from '@services/balances/revalue-balance-history.service';
 
 import { withTransaction } from '../common/with-transaction';
 import { measureSpotRefBalance } from './measure-spot-ref-balance';
@@ -21,7 +23,8 @@ import { restampRefInitialBalance } from './restamp-ref-initial-balance';
  * rate, and `refInitialBalance` is restamped at the ledger-boundary rate (which
  * cascades the change into the Balances history). Summing a caller-supplied
  * `refAmountDelta` from historical per-row `refAmount`s instead would keep the
- * opening ref balance a blend of historical rates.
+ * opening ref balance a blend of historical rates. A system account held outside its
+ * owner's base currency skips the spot pin and is rebuilt at per-day rates instead.
  *
  * Deltas compose: the account row is read under SELECT ... FOR UPDATE, so
  * concurrent absorbs (two imports finalizing into one account, or an import racing
@@ -76,6 +79,10 @@ export const absorbBalanceAdjustment = withTransaction(
       throw new ValidationError({ message: `Account with ID ${accountId} could not be updated` });
     }
 
+    const baseCurrency = isSystem && !amountDelta.isZero() ? await getBaseCurrency({ userId }) : null;
+    const revalueOwnsHistory =
+      !!baseCurrency && isRevaluedAccount({ account: updated, baseCurrencyCode: baseCurrency.currencyCode });
+
     let result = updated;
     if (isSystem && !amountDelta.isZero()) {
       // The opening balance moved → re-derive its boundary-rate ref stamp; the
@@ -101,10 +108,14 @@ export const absorbBalanceAdjustment = withTransaction(
       }
     }
 
-    // Today's net-worth row is a stock equal to the spot `refCurrentBalance`. Pin
-    // it last — after the restamp cascade shifts today's row by the opening-balance
-    // diff — so the spot value survives.
-    await Balances.setTodayRowToSpot({ account: result });
+    // Today's net-worth row is a stock equal to the spot `refCurrentBalance`. Pin it
+    // last, after the restamp cascade shifts today's row by the opening-balance diff,
+    // so the spot value survives. A revalued account gets today's row from the rebuild.
+    if (revalueOwnsHistory) {
+      await scheduleBalanceRevalue({ accountId });
+    } else {
+      await Balances.setTodayRowToSpot({ account: result });
+    }
 
     return result;
   },

--- a/packages/backend/src/services/accounts/absorb-balance-adjustment.unit.ts
+++ b/packages/backend/src/services/accounts/absorb-balance-adjustment.unit.ts
@@ -35,6 +35,18 @@ jest.mock('@models/balances.model', () => ({
   default: { setTodayRowToSpot: jest.fn() },
 }));
 
+// The owner's base currency decides between the spot pin and a full history
+// rebuild. Every case here is same-currency (USD), so the pin path runs.
+jest.mock('@models/users-currencies.model', () => ({
+  __esModule: true,
+  getBaseCurrency: jest.fn(async () => ({ currencyCode: 'USD' })),
+}));
+jest.mock('@services/balances/revalue-balance-history.service', () => ({
+  __esModule: true,
+  isRevaluedAccount: jest.fn(() => false),
+  scheduleBalanceRevalue: jest.fn(),
+}));
+
 // `withTransaction` (imported by the service via ../common/with-transaction)
 // reads the ambient CLS transaction from this namespace and, finding none,
 // runs the body inside `connection.sequelize.transaction`. The stub runs the

--- a/packages/backend/src/services/accounts/foreign-account-initial-balance.e2e.ts
+++ b/packages/backend/src/services/accounts/foreign-account-initial-balance.e2e.ts
@@ -1,0 +1,61 @@
+import { TRANSACTION_TYPES } from '@bt/shared/types';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { startOfDay, subDays } from 'date-fns';
+
+const TODAY = startOfDay(new Date());
+const DEPOSIT_DATE = subDays(TODAY, 60);
+const MID_DATE = subDays(TODAY, 30);
+const SEEDED_DATES = [DEPOSIT_DATE, MID_DATE, TODAY];
+
+const DEPOSIT_INR = 100_000;
+const ADDED_OPENING_INR = 50_000;
+const HELD_AFTER_EDIT_CENTS = (DEPOSIT_INR + ADDED_OPENING_INR) * 100;
+
+const seedMarketRates = () => helpers.seedInrAedRates({ depositDate: DEPOSIT_DATE, laterDates: [MID_DATE, TODAY] });
+
+describe('Editing the opening balance of a foreign-currency account', () => {
+  afterEach(async () => {
+    await helpers.clearExchangeRatesForDates({ dates: SEEDED_DATES });
+  });
+
+  it('re-prices every stored day at that day’s rate, not by a flat diff', async () => {
+    await seedMarketRates();
+    await helpers.addUserCurrencies({ currencyCodes: ['INR'] });
+
+    const account = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ currencyCode: 'INR' }),
+      raw: true,
+    });
+
+    await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: DEPOSIT_INR,
+        transactionType: TRANSACTION_TYPES.income,
+        time: DEPOSIT_DATE.toISOString(),
+      }),
+      raw: true,
+    });
+
+    // No adjustment transaction: the diff is absorbed into the opening balance,
+    // so every day of the history now holds 50,000 more rupees.
+    await helpers.updateAccount({
+      id: account.id,
+      payload: { currentBalance: DEPOSIT_INR + ADDED_OPENING_INR },
+      raw: true,
+    });
+
+    const rows = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+
+    expect(helpers.balanceCentsOn({ rows, date: DEPOSIT_DATE })).toEqualRefValue(
+      HELD_AFTER_EDIT_CENTS * helpers.INR_TO_AED_AT_DEPOSIT,
+    );
+    expect(helpers.balanceCentsOn({ rows, date: MID_DATE })).toEqualRefValue(
+      HELD_AFTER_EDIT_CENTS * helpers.INR_TO_AED_AFTER,
+    );
+    expect(helpers.balanceCentsOn({ rows, date: TODAY })).toEqualRefValue(
+      HELD_AFTER_EDIT_CENTS * helpers.INR_TO_AED_AFTER,
+    );
+  });
+});

--- a/packages/backend/src/services/balances/revalue-balance-history.service.ts
+++ b/packages/backend/src/services/balances/revalue-balance-history.service.ts
@@ -1,0 +1,281 @@
+import { ACCOUNT_TYPES, isDedicatedFlowAccountCategory, TRANSACTION_TYPES } from '@bt/shared/types';
+import { roundHalfToEven } from '@common/utils/round-half-to-even';
+import { logger } from '@js/utils';
+import Accounts from '@models/accounts.model';
+import { connection } from '@models/connection';
+import UsersCurrencies, { getBaseCurrency } from '@models/users-currencies.model';
+import { withTransaction } from '@services/common/with-transaction';
+import {
+  buildDailyPairRateResolver,
+  type DailyPairRateResolver,
+  MS_PER_DAY,
+  toDayKey,
+} from '@services/exchange-rates/build-daily-pair-rate-resolver';
+import { resolveCustomRate } from '@services/user-exchange-rate/get-exchange-rate.service';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { QueryTypes } from 'sequelize';
+import { v7 as uuidv7 } from 'uuid';
+
+const dayKeyToDate = (dayKey: string): Date => new Date(`${dayKey}T00:00:00.000Z`);
+
+/** Every day in this file is a UTC bucket: the SQL truncates in UTC, the day walk
+ *  steps UTC midnights, and `Balances.date` is a `YYYY-MM-DD` string. */
+const utcDayStart = (date: Date): Date => dayKeyToDate(toDayKey(date));
+
+/** The same guard `revalueBalanceHistory` applies internally, exported so a caller can
+ *  pick the incremental path before a revalue would no-op. */
+export const isRevaluedAccount = ({
+  account,
+  baseCurrencyCode,
+}: {
+  account: Pick<Accounts, 'type' | 'accountCategory' | 'currencyCode'>;
+  baseCurrencyCode: string;
+}): boolean =>
+  account.type === ACCOUNT_TYPES.system &&
+  !isDedicatedFlowAccountCategory(account.accountCategory) &&
+  account.currencyCode !== baseCurrencyCode;
+
+const signedCentsSql = `SUM(CASE WHEN "transactionType" = '${TRANSACTION_TYPES.income}' THEN "amount" ELSE -"amount" END)`;
+
+const loadTransactionBounds = async ({
+  accountId,
+}: {
+  accountId: string;
+}): Promise<{ earliest: Date | null; latest: Date | null }> => {
+  const [row] = (await connection.sequelize.query(
+    `SELECT MIN("time") AS "earliest", MAX("time") AS "latest" FROM real_transactions WHERE "accountId" = :accountId`,
+    { type: QueryTypes.SELECT, replacements: { accountId } },
+  )) as { earliest: Date | null; latest: Date | null }[];
+
+  return {
+    earliest: row?.earliest ? new Date(row.earliest) : null,
+    latest: row?.latest ? new Date(row.latest) : null,
+  };
+};
+
+const loadOldestStoredDay = async ({ accountId }: { accountId: string }): Promise<string | null> => {
+  const [row] = (await connection.sequelize.query(
+    `SELECT to_char(MIN("date"), 'YYYY-MM-DD') AS "day" FROM "Balances" WHERE "accountId" = :accountId`,
+    { type: QueryTypes.SELECT, replacements: { accountId } },
+  )) as { day: string | null }[];
+
+  return row?.day ?? null;
+};
+
+const loadDailyNativeDeltas = async ({
+  accountId,
+  from,
+  toExclusive,
+}: {
+  accountId: string;
+  from: Date;
+  toExclusive: Date;
+}): Promise<Map<string, number>> => {
+  const rows = (await connection.sequelize.query(
+    `SELECT to_char(date_trunc('day', "time" AT TIME ZONE 'UTC'), 'YYYY-MM-DD') AS "day",
+            ${signedCentsSql}::bigint AS "cents"
+       FROM real_transactions
+      WHERE "accountId" = :accountId AND "time" >= :from AND "time" < :toExclusive
+      GROUP BY 1`,
+    { type: QueryTypes.SELECT, replacements: { accountId, from, toExclusive } },
+  )) as { day: string; cents: string | number }[];
+
+  return new Map(rows.map((row) => [row.day, Number(row.cents)]));
+};
+
+/** Delete before insert: a day the rebuild no longer emits must not survive and be
+ *  read as a real measurement by the chart's forward fill. `ON CONFLICT` still guards
+ *  the insert, because the 18:00 remeasure can pin today's row between the two. */
+const writeBalanceRows = async ({
+  accountId,
+  fromDay,
+  rows,
+}: {
+  accountId: string;
+  fromDay: string;
+  rows: { date: string; amount: number }[];
+}): Promise<void> => {
+  if (!rows.length) return;
+
+  await connection.sequelize.query(`DELETE FROM "Balances" WHERE "accountId" = :accountId AND "date" >= :fromDay`, {
+    replacements: { accountId, fromDay },
+  });
+
+  const replacements: Record<string, unknown> = { accountId };
+  const values = rows.map((row, index) => {
+    replacements[`id${index}`] = uuidv7();
+    replacements[`date${index}`] = row.date;
+    replacements[`amount${index}`] = row.amount;
+    return `(:id${index}, :accountId, :date${index}, :amount${index}, NOW(), NOW())`;
+  });
+
+  await connection.sequelize.query(
+    `INSERT INTO "Balances" ("id", "accountId", "date", "amount", "createdAt", "updatedAt")
+     VALUES ${values.join(', ')}
+     ON CONFLICT ("accountId", "date") DO UPDATE
+     SET "amount" = EXCLUDED."amount", "updatedAt" = NOW()`,
+    { replacements },
+  );
+};
+
+/**
+ * Rewrite an account's daily `Balances` rows as "native units held that day × that
+ * day's rate to the owner's base currency", from the day before its first transaction
+ * (or its oldest stored row) through today (or its last transaction).
+ *
+ * The output is sparse: a row only where the value moves, plus the first day and
+ * today. Every other row in the range is deleted, so the chart's forward fill reads
+ * exactly what the rebuild computed.
+ */
+const revalueBalanceHistoryImpl = async ({ accountId }: { accountId: string }): Promise<'rebuilt' | 'skipped'> => {
+  const account = await Accounts.findByPk(accountId);
+  if (!account) return 'skipped';
+
+  const baseCurrency = await getBaseCurrency({ userId: account.userId });
+  if (!baseCurrency || !isRevaluedAccount({ account, baseCurrencyCode: baseCurrency.currencyCode })) return 'skipped';
+
+  // Two rebuilds of the same account would otherwise interleave their writes and
+  // leave the grid mixing rows from different runs.
+  await connection.sequelize.query(`SELECT pg_advisory_xact_lock(hashtext(:accountId))`, {
+    type: QueryTypes.SELECT,
+    replacements: { accountId },
+  });
+
+  const today = utcDayStart(new Date());
+  const { earliest, latest } = await loadTransactionBounds({ accountId });
+  const oldestStoredDay = await loadOldestStoredDay({ accountId });
+
+  // The day before the first transaction carries the account's opening balance, so
+  // the chart starts from the account's own money rather than from zero.
+  const gridStart = new Date(
+    Math.min(
+      +today,
+      earliest ? +utcDayStart(earliest) - MS_PER_DAY : Infinity,
+      oldestStoredDay ? +dayKeyToDate(oldestStoredDay) : Infinity,
+    ),
+  );
+  const gridEnd = new Date(Math.max(+today, latest ? +utcDayStart(latest) : +today));
+
+  const userCurrency = (await UsersCurrencies.findOne({
+    where: { userId: account.userId, currencyCode: account.currencyCode },
+    attributes: ['liveRateUpdate'],
+    raw: true,
+  })) as { liveRateUpdate: boolean | null } | null;
+
+  // A flat manual rate wins every day of the grid, so the market resolver is built
+  // only when there is no manual rate. Only that resolver can abort the rebuild.
+  const flatCustomRate =
+    (
+      await resolveCustomRate({
+        userId: account.userId,
+        pair: { baseCode: account.currencyCode, quoteCode: baseCurrency.currencyCode },
+        liveRateUpdate: userCurrency?.liveRateUpdate ?? null,
+      })
+    )?.rate ?? null;
+
+  let resolveRate: DailyPairRateResolver | null = null;
+  if (flatCustomRate === null) {
+    resolveRate = await buildDailyPairRateResolver({
+      baseCode: account.currencyCode,
+      quoteCode: baseCurrency.currencyCode,
+      from: gridStart,
+      to: gridEnd,
+    });
+
+    if (!resolveRate) {
+      logger.warn('No stored exchange rate for pair; account left untouched', {
+        accountId,
+        pair: `${account.currencyCode}/${baseCurrency.currencyCode}`,
+      });
+      return 'skipped';
+    }
+  }
+
+  const dailyDeltas = await loadDailyNativeDeltas({
+    accountId,
+    from: gridStart,
+    toExclusive: new Date(+gridEnd + MS_PER_DAY),
+  });
+
+  const startKey = toDayKey(gridStart);
+  const todayKey = toDayKey(today);
+
+  let nativeCents: number = account.initialBalance.toCents();
+  let lastEmitted: number | null = null;
+  const rows: { date: string; amount: number }[] = [];
+
+  for (let time = +gridStart; time <= +gridEnd; time += MS_PER_DAY) {
+    const dayKey = toDayKey(new Date(time));
+    nativeCents += dailyDeltas.get(dayKey) ?? 0;
+
+    const rate = flatCustomRate ?? resolveRate?.(dayKey) ?? null;
+    if (rate == null) {
+      logger.warn('No exchange rate for day; account left untouched', {
+        accountId,
+        pair: `${account.currencyCode}/${baseCurrency.currencyCode}`,
+        day: dayKey,
+      });
+      return 'skipped';
+    }
+
+    const cents = roundHalfToEven(nativeCents * rate);
+    // The chart forward-fills, so a day repeating the previous value carries no
+    // information. Today always gets a row so the series tracks the daily rate.
+    if (cents === lastEmitted && dayKey !== startKey && dayKey !== todayKey) continue;
+
+    lastEmitted = cents;
+    rows.push({ date: dayKey, amount: cents });
+  }
+
+  await writeBalanceRows({ accountId, fromDay: startKey, rows });
+
+  return 'rebuilt';
+};
+
+export const revalueBalanceHistory = withTransaction(revalueBalanceHistoryImpl);
+
+const revalueBatchStorage = new AsyncLocalStorage<Set<string>>();
+
+/**
+ * Collapse every revalue scheduled inside `fn` into one rebuild per account, run after
+ * `fn` settles. Opened at entrypoints (HTTP controllers, cron and queue job bodies).
+ *
+ * Rebuilds run even when `fn` throws, since rows that did commit still need healing,
+ * and the original error is rethrown. Nested scopes merge into the outermost one.
+ */
+export const runWithBalanceRevalueBatch = async <R>(fn: () => Promise<R>): Promise<R> => {
+  if (revalueBatchStorage.getStore()) return fn();
+
+  const queue = new Set<string>();
+  try {
+    return await revalueBatchStorage.run(queue, fn);
+  } finally {
+    for (const accountId of queue) {
+      try {
+        await revalueBalanceHistory({ accountId });
+      } catch (error) {
+        // The data is already committed; a failed rebuild leaves stale rows for
+        // the nightly revalue job to correct rather than killing the process.
+        logger.error(
+          { message: 'Balance revalue failed after batch', error: error as Error },
+          { code: 'BALANCE_REVALUE_BATCH_FAILED', accountId },
+        );
+      }
+    }
+  }
+};
+
+/**
+ * Defer the rebuild to the end of the surrounding batch scope, or run it inline when
+ * there is none. Inline under an ambient CLS transaction it joins that transaction, so
+ * the rebuild commits together with the change that triggered it.
+ */
+export const scheduleBalanceRevalue = async ({ accountId }: { accountId: string }): Promise<void> => {
+  const queue = revalueBatchStorage.getStore();
+  if (queue) {
+    queue.add(accountId);
+    return;
+  }
+
+  await revalueBalanceHistory({ accountId });
+};

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -18,6 +18,7 @@ import * as UserMerchantCategoryCodes from '@models/user-merchant-category-codes
 import * as Users from '@models/users.model';
 import { redisClient } from '@root/redis-client';
 import { runPendingLinkAbsorb } from '@services/accounts/absorb-link-residual';
+import { runWithBalanceRevalueBatch } from '@services/balances/revalue-balance-history.service';
 import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import * as transactionsService from '@services/transactions';
 import { accountHasPlannedRows } from '@services/transactions/planned-matching';
@@ -341,17 +342,22 @@ function createBundle(tokenHash: string): QueueBundle {
     }
   });
 
-  const worker = new Worker<TransactionSyncJobData>(queueName, buildJobProcessor(queueName), {
-    connection,
-    concurrency: 1, // Process one job at a time per worker (one token's rate-limit lane)
-    // Only enable rate limiter in production (not in tests)
-    ...(process.env.NODE_ENV !== 'test' && {
-      limiter: {
-        max: 1, // Max jobs per duration
-        duration: 60000, // 60 seconds - Monobank per-token rate limit
-      },
-    }),
-  });
+  const processJob = buildJobProcessor(queueName);
+  const worker = new Worker<TransactionSyncJobData>(
+    queueName,
+    (job) => runWithBalanceRevalueBatch(() => processJob(job)),
+    {
+      connection,
+      concurrency: 1, // Process one job at a time per worker (one token's rate-limit lane)
+      // Only enable rate limiter in production (not in tests)
+      ...(process.env.NODE_ENV !== 'test' && {
+        limiter: {
+          max: 1, // Max jobs per duration
+          duration: 60000, // 60 seconds - Monobank per-token rate limit
+        },
+      }),
+    },
+  );
 
   worker.on('completed', (job) => handleCompletedBatch(job));
 

--- a/packages/backend/src/services/currencies/change-base-currency.service.ts
+++ b/packages/backend/src/services/currencies/change-base-currency.service.ts
@@ -25,7 +25,9 @@ import ResourceShares from '@models/resource-shares.model';
 import { findTransactions } from '@models/transactions-query';
 import Transactions from '@models/transactions.model';
 import { getBaseCurrency, updateCurrencies } from '@models/users-currencies.model';
+import { isRevaluedAccount, revalueBalanceHistory } from '@services/balances/revalue-balance-history.service';
 import { calculateRefAmountFromParams } from '@services/calculate-ref-amount.service';
+import { buildDailyPairRateResolver, toDayKey } from '@services/exchange-rates/build-daily-pair-rate-resolver';
 import * as userExchangeRateService from '@services/user-exchange-rate';
 import { Op, QueryTypes, Transaction as SequelizeTransaction } from 'sequelize';
 
@@ -177,6 +179,9 @@ export async function validateBaseCurrencyChange({ userId, newCurrencyCode }: Ch
  * (in-job re-check), then sweeps the eight tables in order, invoking `onProgress`
  * before each so the running job reports its current step.
  *
+ * Foreign-currency accounts' balance history is rebuilt after that transaction
+ * commits: a rebuild inside it would still read the old base currency.
+ *
  * Runs in the base-currency-change worker with the lock already held — it does NOT
  * acquire one itself. Progress reporting is best-effort and must never throw here,
  * or a Redis hiccup would roll back the whole recalculation.
@@ -221,7 +226,7 @@ export async function changeBaseCurrencyImpl({
     });
 
     await onProgress?.({ step: 'balances' });
-    const balancesRebuilt = await rebuildBalances({
+    const { totalBalancesRecalculated: balancesRebuilt, revaluedAccountIds } = await rebuildBalances({
       userId,
       oldCurrencyCode: oldBaseCurrency.currencyCode,
       newCurrencyCode,
@@ -295,10 +300,14 @@ export async function changeBaseCurrencyImpl({
       portfolioTransfersUpdated,
       holdingsUpdated,
       portfolioBalancesUpdated,
+      revaluedAccountIds,
     };
   });
 
-  return result;
+  const { revaluedAccountIds, ...counts } = result;
+  await revalueForeignAccountHistories({ accountIds: revaluedAccountIds });
+
+  return counts;
 }
 
 const localCalculateRefAmount = async ({
@@ -526,22 +535,52 @@ async function recalculateLoanDetails(params: {
   return loans.length;
 }
 
+const ROWS_PER_UPDATE = 500;
+
+async function writeBalanceAmounts({
+  rows,
+  transaction,
+}: {
+  rows: { id: string; amountCents: number }[];
+  transaction: SequelizeTransaction;
+}): Promise<void> {
+  for (let offset = 0; offset < rows.length; offset += ROWS_PER_UPDATE) {
+    const chunk = rows.slice(offset, offset + ROWS_PER_UPDATE);
+    const replacements: Record<string, unknown> = {};
+    const values = chunk.map((row, index) => {
+      replacements[`id${index}`] = row.id;
+      replacements[`amount${index}`] = row.amountCents;
+      return `(:id${index}::uuid, :amount${index}::bigint)`;
+    });
+
+    await Transactions.sequelize!.query(
+      `UPDATE "Balances" AS b
+          SET "amount" = v.amount, "updatedAt" = NOW()
+         FROM (VALUES ${values.join(', ')}) AS v(id, amount)
+        WHERE b."id" = v.id`,
+      { replacements, transaction },
+    );
+  }
+}
+
 /**
- * Recalculates all balance amounts by converting from old base currency to new base currency.
- * Much simpler than rebuilding from scratch - just recalculates the amounts using exchange rates.
+ * Re-values every stored `Balances` row into the new base currency.
  *
- * Key insight: Balances.amount is ALWAYS stored in the base currency.
- * So we convert from OLD base → NEW base for each balance record.
+ * A row is always denominated in the owner's base currency, so an account whose
+ * currency will EQUAL the new base converts row by row at each row's own date.
+ *
+ * An account whose currency DIFFERS from the new base is returned to the caller
+ * instead, to be rebuilt with `revalueBalanceHistory` once this transaction commits.
+ * Converting its rows one by one would re-derive a blend of historical rates.
  */
 async function rebuildBalances(params: {
   userId: number;
   oldCurrencyCode: string;
   newCurrencyCode: string;
   transaction: SequelizeTransaction;
-}): Promise<number> {
+}): Promise<{ totalBalancesRecalculated: number; revaluedAccountIds: string[] }> {
   const { userId, oldCurrencyCode, newCurrencyCode, transaction } = params;
 
-  // Get all user accounts with their balances
   const accounts = await Accounts.findAll({
     where: { userId },
     transaction,
@@ -549,34 +588,79 @@ async function rebuildBalances(params: {
 
   logger.info(`Recalculating balances for ${accounts.length} accounts for user ${userId}`);
 
+  const convertedAccounts: Accounts[] = [];
+  const revaluedAccountIds: string[] = [];
   let totalBalancesRecalculated = 0;
 
   for (const account of accounts) {
-    const balances = await Balances.findAll({
-      where: { accountId: account.id },
-      transaction,
-    });
-
-    // For each existing balance record, recalculate the amount
-    // Balance amounts are in OLD base currency, convert to NEW base currency
-    for (const balance of balances) {
-      // Convert: OLD base currency → NEW base currency
-      const newAmount = await localCalculateRefAmount({
-        amount: balance.amount, // This is in OLD base currency
-        userId,
-        baseCode: oldCurrencyCode,
-        quoteCode: newCurrencyCode,
-        date: balance.date,
-      });
-
-      balance.amount = newAmount;
-      await balance.save({ transaction, hooks: false });
-
-      totalBalancesRecalculated++;
+    if (isRevaluedAccount({ account, baseCurrencyCode: newCurrencyCode })) {
+      revaluedAccountIds.push(account.id);
+      continue;
     }
+
+    convertedAccounts.push(account);
   }
 
-  return totalBalancesRecalculated;
+  if (!convertedAccounts.length) return { totalBalancesRecalculated, revaluedAccountIds };
+
+  const balances: Balances[] = [];
+  for (const account of convertedAccounts) {
+    balances.push(...(await Balances.findAll({ where: { accountId: account.id }, transaction })));
+  }
+
+  const times = balances.map((balance) => +new Date(balance.date));
+  if (!times.length) return { totalBalancesRecalculated, revaluedAccountIds };
+
+  // A user's manual rate can't apply to this pair: it only fires when the quote is the
+  // user's CURRENT base, and the flip to `newCurrencyCode` happens after this sweep.
+  const resolveRate = await buildDailyPairRateResolver({
+    baseCode: oldCurrencyCode,
+    quoteCode: newCurrencyCode,
+    from: new Date(Math.min(...times)),
+    to: new Date(Math.max(...times)),
+    transaction,
+  });
+
+  const updates: { id: string; amountCents: number }[] = [];
+
+  for (const balance of balances) {
+    const rate = resolveRate?.(toDayKey(balance.date)) ?? null;
+    const newAmount =
+      rate === null
+        ? await localCalculateRefAmount({
+            amount: balance.amount,
+            userId,
+            baseCode: oldCurrencyCode,
+            quoteCode: newCurrencyCode,
+            date: balance.date,
+          })
+        : calculateRefAmountFromParams({ amount: balance.amount, rate });
+
+    updates.push({ id: balance.id, amountCents: newAmount.toCents() });
+    totalBalancesRecalculated++;
+  }
+
+  await writeBalanceAmounts({ rows: updates, transaction });
+
+  return { totalBalancesRecalculated, revaluedAccountIds };
+}
+
+/** One account failing must not abandon the rest: the nightly sweep rebuilds whatever
+ *  is left stale. */
+async function revalueForeignAccountHistories({ accountIds }: { accountIds: string[] }): Promise<void> {
+  for (const accountId of accountIds) {
+    try {
+      await revalueBalanceHistory({ accountId });
+    } catch (error) {
+      logger.error(
+        {
+          message: `Balance history rebuild failed after base currency change for account ${accountId}`,
+          error: error as Error,
+        },
+        { code: 'BASE_CURRENCY_CHANGE_REVALUE_FAILED', accountId },
+      );
+    }
+  }
 }
 
 /**

--- a/packages/backend/src/services/exchange-rates/build-daily-pair-rate-resolver.ts
+++ b/packages/backend/src/services/exchange-rates/build-daily-pair-rate-resolver.ts
@@ -1,0 +1,90 @@
+import { connection } from '@models/connection';
+import { buildUsdRateLookup } from '@services/stats/build-usd-rate-lookup';
+import { createFindLatestUsdRate } from '@services/stats/get-combined-balance-history/exchange-rate-lookup';
+import { QueryTypes, Transaction as SequelizeTransaction } from 'sequelize';
+
+import { API_LAYER_BASE_CURRENCY_CODE } from './constants';
+
+export const MS_PER_DAY = 86_400_000;
+
+/** Same 5-decimal truncation `getExchangeRate` applies, so a resolved rate matches
+ *  what every other conversion in the app produces for that day. */
+export const formatRate = (rate: number) => Math.trunc(rate * 100000) / 100000;
+
+/** UTC calendar day of a timestamp, or the day part of a `DATEONLY` string. */
+export const toDayKey = (date: Date | string): string =>
+  typeof date === 'string' ? date.slice(0, 10) : date.toISOString().slice(0, 10);
+
+export type DailyPairRateResolver = (dayKey: string) => number | null;
+
+/**
+ * Per-day `baseCode → quoteCode` rate from the USD-pivot rows: exact day, else the
+ * most recent earlier day, else the earliest day known for that currency.
+ *
+ * Returns `null` when either leg has no stored rate at all, and the resolver returns
+ * `null` for a day neither leg covers.
+ */
+export const buildDailyPairRateResolver = async ({
+  baseCode,
+  quoteCode,
+  from,
+  to,
+  transaction,
+}: {
+  baseCode: string;
+  quoteCode: string;
+  from: Date;
+  to: Date;
+  transaction?: SequelizeTransaction;
+}): Promise<DailyPairRateResolver | null> => {
+  const quoteCodes = [baseCode, quoteCode];
+
+  const systemRates = (await connection.sequelize.query(
+    `SELECT "quoteCode", "date", "rate"
+       FROM "ExchangeRates"
+      WHERE "baseCode" = :pivotCode AND "quoteCode" IN (:quoteCodes) AND "date" >= :from AND "date" < :toExclusive
+      ORDER BY "quoteCode", "date" ASC`,
+    {
+      type: QueryTypes.SELECT,
+      replacements: {
+        pivotCode: API_LAYER_BASE_CURRENCY_CODE,
+        quoteCodes,
+        from,
+        toExclusive: new Date(+to + MS_PER_DAY),
+      },
+      transaction,
+    },
+  )) as { quoteCode: string; date: Date; rate: number }[];
+
+  const { usdRatesMap, usdRateDatesByQuote } = await buildUsdRateLookup({
+    systemRates,
+    quoteCodes,
+    windowStart: toDayKey(from),
+  });
+  const findLatestUsdRate = createFindLatestUsdRate({ usdRatesMap, usdRateDatesByQuote });
+
+  const hasAnyRate = (code: string) =>
+    code === API_LAYER_BASE_CURRENCY_CODE || (usdRateDatesByQuote.get(code)?.length ?? 0) > 0;
+
+  if (!hasAnyRate(baseCode) || !hasAnyRate(quoteCode)) return null;
+
+  const findUsdRate = (code: string, dayKey: string): number | null => {
+    const latest = findLatestUsdRate(code, dayKey);
+    if (latest !== null) return latest;
+
+    // Days before the first stored rate borrow it: any rate beats no rate.
+    const earliest = usdRateDatesByQuote.get(code)?.[0];
+    return earliest ? (usdRatesMap.get(`${code}_${earliest}`) ?? null) : null;
+  };
+
+  return (dayKey: string) => {
+    const usdToBase = findUsdRate(baseCode, dayKey);
+    const usdToQuote = findUsdRate(quoteCode, dayKey);
+    if (usdToBase == null || usdToQuote == null || usdToBase === 0) return null;
+
+    // Truncation to 5 decimals collapses a sub-0.00001 rate to 0, and a zero rate
+    // would be written as a valid history of zero balances.
+    const rate = formatRate(usdToQuote / usdToBase);
+    return rate > 0 ? rate : null;
+  };
+};

--- a/packages/backend/src/services/import-export/core/queue/create-import-job-queue.ts
+++ b/packages/backend/src/services/import-export/core/queue/create-import-job-queue.ts
@@ -2,6 +2,7 @@ import { SSEEventPayload, SSEEventType } from '@bt/shared/types';
 import { t } from '@i18n/index';
 import { logger } from '@js/utils/logger';
 import { SentryTraceData, withQueueProcessSpan, withQueuePublishSpan } from '@js/utils/sentry';
+import { runWithBalanceRevalueBatch } from '@services/balances/revalue-balance-history.service';
 import { sseManager } from '@services/common/sse';
 import { isBaseCurrencyChangeLocked } from '@services/currencies/base-currency-lock';
 import { Job, Queue, Worker } from 'bullmq';
@@ -239,33 +240,35 @@ export function createImportJobQueue<
 
           let lastEmittedAt = 0;
           let lastTotal = 0;
-          const summary = await processJob({
-            job,
-            onProgress: async (processedCount, totalCount) => {
-              lastTotal = totalCount;
-              // Progress reporting is best-effort: a committed row must not be
-              // failed and the job must not abort because persisting progress or
-              // pushing the SSE update threw (Redis hiccup, dropped SSE channel).
-              // Swallow and log so the import keeps writing rows.
-              try {
-                // Persist progress on the job itself so /status polling works even
-                // with no SSE listener (e.g. user closed the tab).
-                await job.updateProgress({ processedCount, totalCount });
-                if (processedCount - lastEmittedAt >= PROGRESS_SSE_THROTTLE || processedCount === totalCount) {
-                  lastEmittedAt = processedCount;
-                  sendProgress({
-                    userId,
-                    payload: buildRunningPayload({ jobId: job.id!, processedCount, totalCount }),
+          const summary = await runWithBalanceRevalueBatch(() =>
+            processJob({
+              job,
+              onProgress: async (processedCount, totalCount) => {
+                lastTotal = totalCount;
+                // Progress reporting is best-effort: a committed row must not be
+                // failed and the job must not abort because persisting progress or
+                // pushing the SSE update threw (Redis hiccup, dropped SSE channel).
+                // Swallow and log so the import keeps writing rows.
+                try {
+                  // Persist progress on the job itself so /status polling works even
+                  // with no SSE listener (e.g. user closed the tab).
+                  await job.updateProgress({ processedCount, totalCount });
+                  if (processedCount - lastEmittedAt >= PROGRESS_SSE_THROTTLE || processedCount === totalCount) {
+                    lastEmittedAt = processedCount;
+                    sendProgress({
+                      userId,
+                      payload: buildRunningPayload({ jobId: job.id!, processedCount, totalCount }),
+                    });
+                  }
+                } catch (err) {
+                  logger.error({
+                    message: `[${logLabel} Worker] Progress update failed for job ${job.id}`,
+                    error: err instanceof Error ? err : new Error(String(err)),
                   });
                 }
-              } catch (err) {
-                logger.error({
-                  message: `[${logLabel} Worker] Progress update failed for job ${job.id}`,
-                  error: err instanceof Error ? err : new Error(String(err)),
-                });
-              }
-            },
-          });
+              },
+            }),
+          );
 
           return { summary, totalCount: lastTotal };
         },

--- a/packages/backend/src/services/import-export/csv-import/execute-import/index.ts
+++ b/packages/backend/src/services/import-export/csv-import/execute-import/index.ts
@@ -78,7 +78,7 @@ interface ExecuteImportParams {
  * account, category, and tag creation each wrap themselves in `withTransaction`
  * further down the call stack, so they commit independently of the row loop too.
  */
-async function executeImportImpl({
+export async function executeImport({
   userId,
   validRows,
   accountMapping,
@@ -433,5 +433,3 @@ async function executeImportImpl({
     accountBalanceChanges,
   };
 }
-
-export const executeImport = executeImportImpl;

--- a/packages/backend/src/services/import-export/ms-money-import/ms-money-execute-import.e2e.ts
+++ b/packages/backend/src/services/import-export/ms-money-import/ms-money-execute-import.e2e.ts
@@ -335,7 +335,7 @@ describeWithFixture('Microsoft Money import execution', () => {
 
       const transactions = await helpers.getTransactions({ limit: 500, raw: true });
       expect(transactions.filter((tx) => Number(tx.amount) === 0)).toHaveLength(0);
-    });
+    }, 30000);
 
     it('imports them at zero with the Void tag when opted in', async () => {
       const upload = await helpers.uploadMsMoneyFixture({ file: FIXTURE, password: FIXTURE_PASSWORD });
@@ -372,7 +372,7 @@ describeWithFixture('Microsoft Money import execution', () => {
       // only place it can live once the row itself is zeroed.
       const withOriginalAmount = zeroRows.filter((tx) => /\(voided: \d+\.\d{2}\)/.test(tx.note ?? ''));
       expect(withOriginalAmount.length).toBeGreaterThan(0);
-    });
+    }, 30000);
   });
 
   /**

--- a/packages/backend/src/services/import-export/ynab-import/execute-import.e2e.ts
+++ b/packages/backend/src/services/import-export/ynab-import/execute-import.e2e.ts
@@ -160,7 +160,7 @@ describe('Execute YNAB import endpoint', () => {
     const mainPln = accountsAfter.find((a) => a.name === 'Main PLN (PLN) – 8437')!;
     expect(mainPln.currencyCode).toBe('PLN');
     expect(Number(mainPln.initialBalance)).toBe(2050.95);
-  });
+  }, 30000);
 
   it('returns 404 for an unknown job id', async () => {
     const response = await helpers.getYnabImportStatus({ jobId: 'no-such-job' });

--- a/packages/backend/src/services/loans/loan-balance-history.e2e.ts
+++ b/packages/backend/src/services/loans/loan-balance-history.e2e.ts
@@ -183,6 +183,34 @@ describe('Loan Balances history rebuild', () => {
     const history = await getLoanHistory({ loanId: loan.id });
     expect(history).toEqual([{ date: TODAY, amount: -9_200 }]);
   });
+
+  it('keeps a foreign-currency loan on its own event-shaped history while the FX source account is revalued', async () => {
+    // USD under the AED test base: both accounts are foreign-currency, but only the
+    // non-loan one becomes a per-day revaluation grid. The loan owns its own rows.
+    const { account: sourceAccount } = await helpers.createAccountWithNewCurrency({ currency: 'USD' });
+    const loan = await helpers.createLoan({
+      payload: helpers.buildCreateLoanPayload({
+        currencyCode: 'USD',
+        initialBalance: 10_000,
+        originalPrincipal: 10_000,
+      }),
+      raw: true,
+    });
+
+    await reAnchorLoan({ loanId: loan.id, balance: 10_000, asOf: DAY_30_AGO });
+    await payLoan({
+      loanId: loan.id,
+      sourceAccountId: sourceAccount.id as RecordId,
+      amount: 2_000,
+      time: subDays(new Date(), 20).toISOString(),
+    });
+
+    const loanHistory = await getLoanHistory({ loanId: loan.id });
+    expect(loanHistory.map((row) => row.date)).toEqual([DAY_30_AGO, DAY_20_AGO]);
+
+    const sourceHistory = await helpers.getBalanceHistory({ accountId: sourceAccount.id, raw: true });
+    expect(sourceHistory.length).toBeGreaterThan(loanHistory.length);
+  });
 });
 
 /** Runs `fn` authenticated as the user owning `cookies`, restoring the default test user afterwards. */

--- a/packages/backend/src/services/stats/foreign-currency-balance-history.e2e.ts
+++ b/packages/backend/src/services/stats/foreign-currency-balance-history.e2e.ts
@@ -1,0 +1,100 @@
+import { type RecordId, TRANSACTION_TYPES } from '@bt/shared/types';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { eachDayOfInterval, format, startOfDay, subDays } from 'date-fns';
+
+/**
+ * A day's stored balance for a non-base-currency account is the foreign units held
+ * that day valued at THAT day's rate, never a running sum of per-transaction rates.
+ */
+
+const TODAY = startOfDay(new Date());
+const YESTERDAY = subDays(TODAY, 1);
+const DEPOSIT_DATE = subDays(TODAY, 90);
+const LATER_DATE = subDays(TODAY, 45);
+const SEEDED_DATES = [DEPOSIT_DATE, LATER_DATE, YESTERDAY, TODAY];
+
+const HOLDINGS_INR = 100_000;
+const HOLDINGS_INR_CENTS = HOLDINGS_INR * 100;
+
+const seedRates = () =>
+  helpers.seedInrAedRates({ depositDate: DEPOSIT_DATE, laterDates: [LATER_DATE, YESTERDAY, TODAY] });
+
+const createInrAccount = async () => {
+  await helpers.addUserCurrencies({ currencyCodes: ['INR'] });
+  return helpers.createAccount({
+    payload: helpers.buildAccountPayload({ currencyCode: 'INR' }),
+    raw: true,
+  });
+};
+
+const depositHoldings = ({ accountId }: { accountId: RecordId }) =>
+  helpers.createTransaction({
+    payload: helpers.buildTransactionPayload({
+      accountId,
+      amount: HOLDINGS_INR,
+      transactionType: TRANSACTION_TYPES.income,
+      time: DEPOSIT_DATE.toISOString(),
+    }),
+    raw: true,
+  });
+
+describe('Balance history for foreign-currency accounts', () => {
+  afterEach(async () => {
+    await helpers.clearExchangeRatesForDates({ dates: SEEDED_DATES });
+  });
+
+  it('shows zero on every day after the account is drained of foreign units', async () => {
+    await seedRates();
+    const account = await createInrAccount();
+
+    await depositHoldings({ accountId: account.id });
+    await helpers.createTransaction({
+      payload: helpers.buildTransactionPayload({
+        accountId: account.id,
+        amount: HOLDINGS_INR,
+        transactionType: TRANSACTION_TYPES.expense,
+        time: LATER_DATE.toISOString(),
+      }),
+      raw: true,
+    });
+
+    const rows = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+
+    const nonZeroDays = eachDayOfInterval({ start: LATER_DATE, end: TODAY })
+      .filter((date) => helpers.balanceCentsOn({ rows, date }) !== 0)
+      .map((date) => format(date, 'yyyy-MM-dd'));
+
+    expect(nonZeroDays).toEqual([]);
+  });
+
+  it('has no cliff between yesterday and today when the rate is unchanged', async () => {
+    await seedRates();
+    const account = await createInrAccount();
+
+    await depositHoldings({ accountId: account.id });
+
+    const rows = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+
+    expect(helpers.balanceCentsOn({ rows, date: TODAY })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AFTER,
+    );
+    expect(helpers.balanceCentsOn({ rows, date: YESTERDAY })).toBe(helpers.balanceCentsOn({ rows, date: TODAY }));
+  });
+
+  it('values each historical day at that day’s rate', async () => {
+    await seedRates();
+    const account = await createInrAccount();
+
+    await depositHoldings({ accountId: account.id });
+
+    const rows = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+
+    expect(helpers.balanceCentsOn({ rows, date: DEPOSIT_DATE })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AT_DEPOSIT,
+    );
+    expect(helpers.balanceCentsOn({ rows, date: LATER_DATE })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AFTER,
+    );
+  });
+});

--- a/packages/backend/src/services/user-exchange-rate/custom-rate-balance-history.e2e.ts
+++ b/packages/backend/src/services/user-exchange-rate/custom-rate-balance-history.e2e.ts
@@ -1,0 +1,103 @@
+import { TRANSACTION_TYPES } from '@bt/shared/types';
+import { afterEach, describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { startOfDay, subDays } from 'date-fns';
+
+/** A manual `INR → AED` rate prices every stored day of an INR account, not only the
+ *  spot balance on the account card. */
+
+const TODAY = startOfDay(new Date());
+const DEPOSIT_DATE = subDays(TODAY, 60);
+const SEEDED_DATES = [DEPOSIT_DATE, TODAY];
+
+const CUSTOM_INR_TO_AED = 0.5;
+const EDITED_INR_TO_AED = 0.25;
+
+const HOLDINGS_INR = 100_000;
+const HOLDINGS_INR_CENTS = HOLDINGS_INR * 100;
+
+const seedMarketRates = () => helpers.seedInrAedRates({ depositDate: DEPOSIT_DATE, laterDates: [TODAY] });
+
+const setCustomRate = ({ inrToAed }: { inrToAed: number }) =>
+  helpers.editCurrencyExchangeRate({
+    pairs: [
+      { baseCode: 'INR', quoteCode: 'AED', rate: inrToAed },
+      { baseCode: 'AED', quoteCode: 'INR', rate: 1 / inrToAed },
+    ],
+    raw: true,
+  });
+
+const createInrAccountWithHoldings = async () => {
+  await helpers.addUserCurrencies({ currencyCodes: ['INR'] });
+  const account = await helpers.createAccount({
+    payload: helpers.buildAccountPayload({ currencyCode: 'INR' }),
+    raw: true,
+  });
+
+  await helpers.createTransaction({
+    payload: helpers.buildTransactionPayload({
+      accountId: account.id,
+      amount: HOLDINGS_INR,
+      transactionType: TRANSACTION_TYPES.income,
+      time: DEPOSIT_DATE.toISOString(),
+    }),
+    raw: true,
+  });
+
+  return account;
+};
+
+describe('Custom exchange rate and foreign-currency balance history', () => {
+  afterEach(async () => {
+    await helpers.clearExchangeRatesForDates({ dates: SEEDED_DATES });
+  });
+
+  it('re-prices the whole stored history when the manual rate is edited', async () => {
+    await seedMarketRates();
+    const account = await createInrAccountWithHoldings();
+
+    await setCustomRate({ inrToAed: CUSTOM_INR_TO_AED });
+
+    const afterSet = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+    expect(helpers.balanceCentsOn({ rows: afterSet, date: DEPOSIT_DATE })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * CUSTOM_INR_TO_AED,
+    );
+    expect(helpers.balanceCentsOn({ rows: afterSet, date: TODAY })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * CUSTOM_INR_TO_AED,
+    );
+
+    await setCustomRate({ inrToAed: EDITED_INR_TO_AED });
+
+    const afterEdit = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+    expect(helpers.balanceCentsOn({ rows: afterEdit, date: DEPOSIT_DATE })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * EDITED_INR_TO_AED,
+    );
+    expect(helpers.balanceCentsOn({ rows: afterEdit, date: TODAY })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * EDITED_INR_TO_AED,
+    );
+  });
+
+  it('falls back to per-day market rates when the manual rate is removed', async () => {
+    await seedMarketRates();
+    const account = await createInrAccountWithHoldings();
+
+    await setCustomRate({ inrToAed: CUSTOM_INR_TO_AED });
+
+    await helpers.removeCurrencyExchangeRate({
+      pairs: [
+        { baseCode: 'INR', quoteCode: 'AED' },
+        { baseCode: 'AED', quoteCode: 'INR' },
+      ],
+      raw: true,
+    });
+
+    const rows = await helpers.getBalanceHistory({ accountId: account.id, raw: true });
+
+    expect(helpers.balanceCentsOn({ rows, date: DEPOSIT_DATE })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AT_DEPOSIT,
+    );
+    expect(helpers.balanceCentsOn({ rows, date: TODAY })).toEqualRefValue(
+      HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AFTER,
+    );
+  });
+});

--- a/packages/backend/src/services/user-exchange-rate/get-exchange-rate.service.ts
+++ b/packages/backend/src/services/user-exchange-rate/get-exchange-rate.service.ts
@@ -7,11 +7,9 @@ import { CacheClient } from '@js/utils/cache';
 import * as Currencies from '@models/currencies.model';
 import * as UserExchangeRates from '@models/user-exchange-rates.model';
 import UsersCurrencies, { getBaseCurrency } from '@models/users-currencies.model';
+import { formatRate } from '@services/exchange-rates/build-daily-pair-rate-resolver';
 import { API_LAYER_BASE_CURRENCY_CODE } from '@services/exchange-rates/constants';
 import { type RateLookup, resolveUsdRates } from '@services/exchange-rates/resolve-usd-rates';
-
-// Round to 5 precision
-const formatRate = (rate: number) => Math.trunc(rate * 100000) / 100000;
 
 /**
  * Global cache for computed cross-rates.
@@ -131,7 +129,7 @@ async function resolveUserConnection({
  * custom rate and the caller falls through to the market cross-rate. Never
  * cached globally – it belongs to one user.
  */
-async function resolveCustomRate({
+export async function resolveCustomRate({
   userId,
   pair,
   liveRateUpdate,

--- a/packages/backend/src/services/user-exchange-rate/remove-exchange-rates.service.ts
+++ b/packages/backend/src/services/user-exchange-rate/remove-exchange-rates.service.ts
@@ -2,6 +2,7 @@ import * as UserExchangeRates from '@models/user-exchange-rates.model';
 import { remeasureRefBalances } from '@services/accounts/remeasure-ref-balances';
 
 import { withTransaction } from '../common/with-transaction';
+import { revalueAccountsInCurrencies } from './revalue-accounts-in-currencies';
 
 export const removeUserExchangeRates = withTransaction(
   async ({ userId, pairs }: { userId: number; pairs: UserExchangeRates.ExchangeRatePair[] }) => {
@@ -16,6 +17,8 @@ export const removeUserExchangeRates = withTransaction(
     // rolling back the removal, which committed correctly. Return the counts so the
     // caller can warn the user; the daily sync re-anchors the lagging ones later.
     const remeasure = await remeasureRefBalances({ userId });
+
+    await revalueAccountsInCurrencies({ userId, pairs });
 
     return { remeasure };
   },

--- a/packages/backend/src/services/user-exchange-rate/revalue-accounts-in-currencies.ts
+++ b/packages/backend/src/services/user-exchange-rate/revalue-accounts-in-currencies.ts
@@ -1,0 +1,30 @@
+import Accounts from '@models/accounts.model';
+import { getBaseCurrency } from '@models/users-currencies.model';
+import { isRevaluedAccount, scheduleBalanceRevalue } from '@services/balances/revalue-balance-history.service';
+
+/**
+ * A manual rate for `X → base` prices every past day of an account held in X, so a
+ * rate edit or removal moves the whole stored history, not only the spot balances
+ * `remeasureRefBalances` re-anchors.
+ */
+export const revalueAccountsInCurrencies = async ({
+  userId,
+  pairs,
+}: {
+  userId: number;
+  pairs: { baseCode: string; quoteCode: string }[];
+}): Promise<void> => {
+  const currencyCodes = [...new Set(pairs.flatMap((pair) => [pair.baseCode, pair.quoteCode]))];
+  if (!currencyCodes.length) return;
+
+  const baseCurrency = await getBaseCurrency({ userId });
+  if (!baseCurrency) return;
+
+  const accounts = await Accounts.findAll({ where: { userId, currencyCode: currencyCodes } });
+
+  for (const account of accounts) {
+    if (!isRevaluedAccount({ account, baseCurrencyCode: baseCurrency.currencyCode })) continue;
+
+    await scheduleBalanceRevalue({ accountId: account.id });
+  }
+};

--- a/packages/backend/src/services/user-exchange-rate/update-exchange-rates.service.ts
+++ b/packages/backend/src/services/user-exchange-rate/update-exchange-rates.service.ts
@@ -2,6 +2,7 @@ import * as UserExchangeRates from '@models/user-exchange-rates.model';
 import { remeasureRefBalances } from '@services/accounts/remeasure-ref-balances';
 
 import { withTransaction } from '../common/with-transaction';
+import { revalueAccountsInCurrencies } from './revalue-accounts-in-currencies';
 
 export const editUserExchangeRates = withTransaction(
   async ({ userId, pairs }: { userId: number; pairs: UserExchangeRates.UpdateExchangeRatePair[] }) => {
@@ -16,6 +17,8 @@ export const editUserExchangeRates = withTransaction(
     // committed and throwing would roll it back. Return the counts so the caller can
     // warn the user; the daily sync re-anchors the lagging ones later.
     const remeasure = await remeasureRefBalances({ userId });
+
+    await revalueAccountsInCurrencies({ userId, pairs });
 
     return { rates, remeasure };
   },

--- a/packages/backend/src/services/user.service.ts
+++ b/packages/backend/src/services/user.service.ts
@@ -12,6 +12,7 @@ import * as Users from '@models/users.model';
 
 import { withTransaction } from './common/with-transaction';
 import { addUserCurrencies } from './currencies/add-user-currency';
+import { revalueAccountsInCurrencies } from './user-exchange-rate/revalue-accounts-in-currencies';
 
 export const getUser = async (id: number) => {
   const user = await Users.default.findOne({
@@ -166,6 +167,12 @@ export const editUserCurrency = withTransaction(
       exchangeRate,
       liveRateUpdate,
     });
+
+    // `liveRateUpdate` picks between a flat manual rate and per-day market rates for
+    // every stored balance row in this currency, so the whole history must be rebuilt.
+    if (liveRateUpdate !== undefined && liveRateUpdate !== passedCurrency.liveRateUpdate) {
+      await revalueAccountsInCurrencies({ userId, pairs: [{ baseCode: currencyCode, quoteCode: currencyCode }] });
+    }
 
     return result;
   },

--- a/packages/backend/src/tests/helpers/exchange-rates.ts
+++ b/packages/backend/src/tests/helpers/exchange-rates.ts
@@ -1,6 +1,8 @@
-import { type endpointsTypes } from '@bt/shared/types';
+import { EXCHANGE_RATE_PROVIDER_TYPE, type endpointsTypes } from '@bt/shared/types';
+import { connection } from '@models/index';
 import { getExchangeRatesForDate } from '@root/services/exchange-rates';
 import { editUserExchangeRates, removeUserExchangeRates } from '@root/services/user-exchange-rate';
+import { format, startOfDay } from 'date-fns';
 
 import { makeRequest } from './common';
 
@@ -84,4 +86,49 @@ export async function syncExchangeRates() {
     url: '/tests/exchange-rates/sync',
     method: 'get',
   });
+}
+
+/**
+ * `ExchangeRates` survives the between-test truncation and the global cleanup only
+ * drops today and later, so past dates a test seeded must be cleared by the test.
+ */
+export async function clearExchangeRatesForDates({ dates }: { dates: Date[] }) {
+  await connection.sequelize.query(`DELETE FROM "ExchangeRates" WHERE "date"::date = ANY(ARRAY[:days]::date[])`, {
+    replacements: { days: dates.map((date) => format(date, 'yyyy-MM-dd')) },
+  });
+}
+
+/**
+ * Pin the market rates a test's date needs. Rate resolution reads USD-based rows
+ * only, so quotes are given per USD; the `api-layer` source also marks the date
+ * fully fetched, which keeps the providers out of the test.
+ */
+export async function seedUsdExchangeRates({ date, ratesPerUsd }: { date: Date; ratesPerUsd: Record<string, number> }) {
+  const day = startOfDay(date);
+  await clearExchangeRatesForDates({ dates: [day] });
+
+  for (const [quoteCode, rate] of Object.entries(ratesPerUsd)) {
+    await connection.sequelize.query(
+      `INSERT INTO "ExchangeRates" ("baseCode", "quoteCode", "date", "rate", "source")
+       VALUES ('USD', :quoteCode, :date, :rate, :source)`,
+      { replacements: { quoteCode, date: day, rate, source: EXCHANGE_RATE_PROVIDER_TYPE.API_LAYER } },
+    );
+  }
+}
+
+// Powers of two so every cross-rate and every converted amount is exact.
+export const AED_PER_USD = 4;
+export const INR_PER_USD_AT_DEPOSIT = 64;
+export const INR_PER_USD_AFTER = 128;
+export const INR_TO_AED_AT_DEPOSIT = AED_PER_USD / INR_PER_USD_AT_DEPOSIT;
+export const INR_TO_AED_AFTER = AED_PER_USD / INR_PER_USD_AFTER;
+
+/** The INR/AED grid the foreign-currency history tests share: the rupee is worth
+ *  half as much from the day after `depositDate` on. */
+export async function seedInrAedRates({ depositDate, laterDates }: { depositDate: Date; laterDates: Date[] }) {
+  await seedUsdExchangeRates({ date: depositDate, ratesPerUsd: { AED: AED_PER_USD, INR: INR_PER_USD_AT_DEPOSIT } });
+
+  for (const date of laterDates) {
+    await seedUsdExchangeRates({ date, ratesPerUsd: { AED: AED_PER_USD, INR: INR_PER_USD_AFTER } });
+  }
 }

--- a/packages/backend/src/tests/helpers/stats.ts
+++ b/packages/backend/src/tests/helpers/stats.ts
@@ -4,6 +4,7 @@ import {
   getEarliestTransactionDate as _getEarliestTransactionDate,
 } from '@root/services/stats';
 import * as helpers from '@tests/helpers';
+import { format } from 'date-fns';
 
 export async function getBalanceHistory<R extends boolean | undefined = undefined>({
   from,
@@ -29,6 +30,19 @@ export async function getBalanceHistory<R extends boolean | undefined = undefine
 
   return result;
 }
+
+const dateKey = (date: string | Date) => (typeof date === 'string' ? date.slice(0, 10) : format(date, 'yyyy-MM-dd'));
+
+/** What the chart reads on `date`: the latest row dated on or before it, in cents. */
+export const balanceCentsOn = ({ rows, date }: { rows: { date: string | Date; amount: unknown }[]; date: Date }) => {
+  const key = format(date, 'yyyy-MM-dd');
+  const latest = rows
+    .filter((row) => dateKey(row.date) <= key)
+    .toSorted((a, b) => dateKey(a.date).localeCompare(dateKey(b.date)))
+    .at(-1);
+
+  return latest ? Math.round(Number(latest.amount) * 100) : 0;
+};
 
 export const getSpendingsByCategories = async ({
   raw = false,

--- a/packages/shared/src/types/enums.ts
+++ b/packages/shared/src/types/enums.ts
@@ -106,8 +106,12 @@ export enum ACCOUNT_CATEGORIES {
  * so the create service rejects them and the create-account UI hides them.
  * Each is created only via its own endpoint, which writes the account and its
  * sidecar in one transaction.
+ *
+ * Their balance history belongs to the same dedicated flow (loan projection,
+ * depreciation curve) rather than to `initialBalance + Σtransactions`, so the
+ * balance-revalue paths skip them too.
  */
-const DEDICATED_FLOW_ACCOUNT_CATEGORIES = [ACCOUNT_CATEGORIES.loan, ACCOUNT_CATEGORIES.vehicle] as const;
+export const DEDICATED_FLOW_ACCOUNT_CATEGORIES = [ACCOUNT_CATEGORIES.loan, ACCOUNT_CATEGORIES.vehicle] as const;
 
 type DedicatedFlowAccountCategory = (typeof DEDICATED_FLOW_ACCOUNT_CATEGORIES)[number];
 


### PR DESCRIPTION
Daily balance snapshots for non-base-currency accounts were running sums of per-transaction conversions at stale rates, so currency depreciation piled up and appeared as a fake one-day loss; history is now recomputed as native units held × that day's rate, with a nightly sweep as safety net