### PR TITLE
Dedup Enable Banking re-imports after account unlink → reconnect

### DIFF
--- a/packages/backend/src/services/bank-data-providers/docs/architecture.md
+++ b/packages/backend/src/services/bank-data-providers/docs/architecture.md
@@ -395,8 +395,8 @@ This is the per-account unlink/relink flow (distinct from full provider disconne
    Two-tier deduplication prevents duplicates (LunchFlow, SimpleFIN, Walutomat):
      Primary: check by originalId (fast path)
      Secondary: check externalData.originalSource.originalId (covers unlink→relink)
-     Enable Banking has no originalSource check — its four-tier matcher
-     re-anchors originalId from entry_reference / IBAN evidence instead
+     Enable Banking folds the originalSource check into tier 2 of its
+     four-tier matcher (see Flow 3)
        ↓
    Date-based filtering (all providers):
      Find latest existing transaction date → skip older API transactions
@@ -494,7 +494,7 @@ Each provider generates a unique `externalId` for transactions:
 
 If secondary dedup finds a match, it restores `originalId` so future syncs use the fast primary path.
 
-**Enable Banking implements no `originalSource` check.** It relies on its own four-tier matcher instead (entry_reference → originalId hash → IBAN fingerprint → pending upgrade, see Flow 3). It exists because some ASPSPs populate `entry_reference` only on later syncs, shift the date that feeds the hash, and re-issue a `PDNG` card purchase as a `BOOK` row with a fresh reference and different remittance text — each of which would otherwise produce a duplicate.
+**Enable Banking folds the `originalSource` check into its own four-tier matcher** (entry_reference → originalId hash / pendingHash / originalSource → IBAN fingerprint → pending upgrade, see Flow 3). The matcher exists because some ASPSPs populate `entry_reference` only on later syncs, shift the date that feeds the hash, and re-issue a `PDNG` card purchase as a `BOOK` row with a fresh reference and different remittance text — each of which would otherwise produce a duplicate. The `originalSource` branch covers unlink→relink for rows with no `entry_reference` and no counterparty IBAN, which no other tier can match; the sync loop's re-anchor step then restores `originalId`.
 
 **Reconciliation of pre-existing duplicates:** `POST /connections/:id/reconcile-duplicates` runs `reconcileDuplicateTransactionsForAccount`, which buckets an account's transactions by (amount, currency, transactionType) and makes two passes:
 

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-dedup.e2e.ts
@@ -1520,4 +1520,73 @@ describe('Enable Banking dedup improvements (E2E)', () => {
       expect(requested!.dateFrom! <= requested!.dateTo!).toBe(true);
     });
   });
+
+  // ==========================================================================
+  // #8 — account unlink → reconnect
+  // ==========================================================================
+  describe('#8 unlink → reconnect dedup', () => {
+    it('does not duplicate reference-less transactions after account unlink → reconnect', async () => {
+      // Unlink nulls originalId on every row (preserving it only in
+      // externalData.originalSource.originalId). A reference-less, IBAN-less row
+      // — the "Prel" card-purchase shape — then has no surviving match key
+      // except that snapshot.
+      helpers.enablebanking.setFixedTransactions([
+        {
+          amount: '43.00',
+          currency: 'EUR',
+          isExpense: true,
+          bookingDate: '2024-03-15',
+          counterpartyIban: null,
+          remittanceInformation: ['Prel card purchase'],
+        },
+        {
+          amount: '250.00',
+          currency: 'EUR',
+          isExpense: false,
+          bookingDate: '2024-03-15',
+          counterpartyIban: null,
+          entryReference: 'ref_reconnect_control',
+        },
+      ]);
+      const { accountId } = await setupConnectionWithAccount();
+
+      const txsBefore = await listTransactions({ accountId });
+      expect(txsBefore.length).toBe(2);
+
+      await helpers.unlinkAccountFromBankConnection({ id: String(accountId), raw: true });
+
+      // Reconnect through a brand-new connection, same bank account.
+      const reconnectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+        credentials: helpers.enablebanking.mockCredentials(),
+        raw: true,
+      });
+      const state = await helpers.enablebanking.getConnectionState(reconnectResult.connectionId);
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/bank-data-providers/enablebanking/oauth-callback',
+        payload: {
+          connectionId: reconnectResult.connectionId,
+          code: helpers.enablebanking.mockAuthCode,
+          state,
+        },
+      });
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: reconnectResult.connectionId,
+        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
+        raw: true,
+      });
+
+      // The disconnected account row is re-linked, not recreated
+      expect(syncedAccounts[0]!.id).toBe(accountId);
+
+      const txsAfter = await listTransactions({ accountId });
+      expect(txsAfter.length).toBe(2);
+
+      // Matched rows get originalId restored so future syncs use the fast path
+      for (const tx of txsAfter) {
+        expect(tx.originalId).not.toBeNull();
+      }
+    });
+  });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -1588,6 +1588,9 @@ export class EnableBankingProvider extends BaseBankDataProvider {
     // consistently returns the same fields (or no entry_reference at all).
     // `pendingHash` is the hash a row carried while it was pending, kept so a
     // pending entry the ASPSP re-sends after booking still lands on the same row.
+    // `originalSource.originalId` is the snapshot account-unlink takes before
+    // nulling originalId; matching it dedups the unlink → reconnect flow, and the
+    // caller's re-anchor restores originalId for future syncs.
     const byOriginalId = await findOneTransaction({
       planned: 'exclude',
       access: 'unscoped-internal',
@@ -1597,6 +1600,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
         [Op.or]: [
           { originalId: tx.externalId },
           Sequelize.where(Sequelize.literal(`"externalData"->>'pendingHash'`), tx.externalId),
+          Sequelize.where(Sequelize.literal(`"externalData"#>>'{originalSource,originalId}'`), tx.externalId),
         ],
       },
     });


### PR DESCRIPTION
Unlink nulls originalId, so rows with no entry_reference and no counterparty IBAN had no surviving match key and re-imported as duplicates on reconnect