### PR TITLE
Fall back to base currency when bank reports no currency (XXX)

### DIFF
--- a/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/connect-selected-accounts.ts
@@ -15,6 +15,7 @@ import AccountGroup from '@models/accounts-groups/account-groups.model';
 import Accounts from '@models/accounts.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
 import { NON_CURRENCY_CODES, getCurrency } from '@models/currencies.model';
+import { getBaseCurrency } from '@models/users-currencies.model';
 import { calculateRefAmount } from '@root/services/calculate-ref-amount.service';
 import { withTransaction } from '@root/services/common/with-transaction';
 import { addUserCurrencies } from '@services/currencies/add-user-currency';
@@ -124,10 +125,23 @@ const createAccountsForConnection = withTransaction(
         });
         createdAccounts.push(existingAccount);
       } else {
-        // Ensure user has the currency for this account. Reject both unknown codes
-        // and ISO 4217 non-currencies (XXX "no currency", precious metals, test
-        // codes): none have an exchange rate, so the calculateRefAmount call below
-        // would throw "Exchange rate not available" and surface as a 500 mid-sync.
+        // ISO "XXX" means the provider could not determine the currency.
+        // Fall back to the user's base currency instead of failing the connect,
+        // and record the substitution so the UI can explain it.
+        let currencyFallback: { providerCurrency: string; assignedCurrency: string } | undefined;
+        if (providerAccount.currency.toUpperCase() === 'XXX') {
+          const baseCurrency = await getBaseCurrency({ userId });
+          if (baseCurrency) {
+            currencyFallback = {
+              providerCurrency: providerAccount.currency,
+              assignedCurrency: baseCurrency.currencyCode,
+            };
+            providerAccount.currency = baseCurrency.currencyCode;
+          }
+        }
+
+        // Reject unknown codes and ISO 4217 non-currencies (metals, test codes):
+        // they have no exchange rate, so calculateRefAmount below would throw a 500.
         const currency = await getCurrency({ code: providerAccount.currency.toUpperCase() });
         if (!currency || NON_CURRENCY_CODES.includes(currency.code)) {
           throw new BadRequestError({
@@ -177,7 +191,7 @@ const createAccountsForConnection = withTransaction(
           creditLimit: creditLimitCents,
           refCreditLimit,
           externalId: providerAccount.externalId,
-          externalData: providerAccount.metadata || {},
+          externalData: { ...(providerAccount.metadata || {}), ...(currencyFallback && { currencyFallback }) },
           bankDataProviderConnectionId: connectionId,
         });
         createdAccounts.push(newAccount);

--- a/packages/backend/src/services/bank-data-providers/connection/get-connection-details.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/get-connection-details.ts
@@ -41,6 +41,9 @@ export interface ConnectionDetailsResponse {
     currentBalance: number;
     currencyCode: string;
     type: string;
+    // Present when the provider reported no currency (ISO "XXX") and the
+    // user's base currency was assigned instead.
+    currencyFallback: { providerCurrency: string; assignedCurrency: string } | null;
   }>;
   consent?: {
     validFrom: string | null;
@@ -66,7 +69,7 @@ export async function getConnectionDetails(params: GetConnectionDetailsParams): 
         {
           model: Accounts,
           as: 'accounts',
-          attributes: ['id', 'name', 'externalId', 'currentBalance', 'currencyCode', 'type'],
+          attributes: ['id', 'name', 'externalId', 'currentBalance', 'currencyCode', 'type', 'externalData'],
         },
       ],
     }),
@@ -111,6 +114,9 @@ export async function getConnectionDetails(params: GetConnectionDetailsParams): 
       currentBalance: account.currentBalance?.toNumber() ?? 0,
       currencyCode: account.currencyCode,
       type: account.type,
+      currencyFallback:
+        (account.externalData as { currencyFallback?: { providerCurrency: string; assignedCurrency: string } } | null)
+          ?.currencyFallback ?? null,
     })),
     consent: consentInfo,
     deactivationReason: metadata?.deactivationReason || null,

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
@@ -197,13 +197,11 @@ describe('Enable Banking Data Provider E2E', () => {
     });
   });
 
-  // Regression (Sentry MONEY-MATTER-BACKEND-82/83): a bank account whose currency
-  // is an ISO 4217 non-currency (e.g. "XXX" = no currency) has no exchange rate, so
-  // connecting it used to reach calculateRefAmount and throw "Exchange rate not
-  // available for XXX/EUR", surfacing as a 500 mid-sync. The connect must now reject
-  // with a clear 400 and create nothing.
+  // "XXX" (ISO no-currency) means the bank omitted the account currency: connect
+  // must fall back to the user's base currency. Other ISO non-currency codes
+  // still reject with 400.
   describe('unsupported account currency', () => {
-    it('rejects an account whose currency is an ISO non-currency (XXX) with a 400, creating nothing', async () => {
+    const connectWithMockedCurrency = async (currency: string) => {
       const connectResult = await helpers.bankDataProviders.connectProvider({
         providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
         credentials: helpers.enablebanking.mockCredentials(),
@@ -220,12 +218,12 @@ describe('Enable Banking Data Provider E2E', () => {
         },
       });
 
-      // Force every fetched account's currency to XXX while preserving its stable
-      // identification_hash, so the selected account routes an XXX currency into the
-      // connect path.
+      // Force every fetched account's currency while preserving its stable
+      // identification_hash, so the selected account routes that currency into
+      // the connect path.
       global.mswMockServer.use(
         http.get('https://api.enablebanking.com/accounts/:accountId/details', ({ params }) =>
-          HttpResponse.json({ ...getMockedAccountDetails(params.accountId as string), currency: 'XXX' }),
+          HttpResponse.json({ ...getMockedAccountDetails(params.accountId as string), currency }),
         ),
       );
 
@@ -233,11 +231,32 @@ describe('Enable Banking Data Provider E2E', () => {
         connectionId: connectResult.connectionId,
         accountExternalIds: [MOCK_IDENTIFICATION_HASH_1],
       });
+      return { connectionId: connectResult.connectionId, result };
+    };
+
+    it('falls back to the user base currency when the bank reports "XXX" (no currency)', async () => {
+      const { connectionId, result } = await connectWithMockedCurrency('XXX');
+      expect(result.status).toEqual(200);
+
+      const { connection } = await helpers.bankDataProviders.getConnectionDetails({
+        connectionId,
+        raw: true,
+      });
+      expect(connection.accounts.length).toBe(1);
+      expect(connection.accounts[0]!.currencyCode).toBe(global.BASE_CURRENCY.code);
+      expect(connection.accounts[0]!.currencyFallback).toEqual({
+        providerCurrency: 'XXX',
+        assignedCurrency: global.BASE_CURRENCY.code,
+      });
+    });
+
+    it('rejects an account whose currency is another ISO non-currency (XAU) with a 400, creating nothing', async () => {
+      const { connectionId, result } = await connectWithMockedCurrency('XAU');
       expect(result.status).toEqual(ERROR_CODES.BadRequest);
 
-      // The account-creation transaction must have rolled back — nothing linked.
+      // The account-creation transaction rolled back, so nothing is linked.
       const { connection } = await helpers.bankDataProviders.getConnectionDetails({
-        connectionId: connectResult.connectionId,
+        connectionId,
         raw: true,
       });
       expect(connection.accounts.length).toBe(0);

--- a/packages/frontend/src/api/bank-data-providers.ts
+++ b/packages/frontend/src/api/bank-data-providers.ts
@@ -64,6 +64,7 @@ interface BankConnectionDetails {
     currentBalance: number;
     currencyCode: string;
     type: string;
+    currencyFallback: { providerCurrency: string; assignedCurrency: string } | null;
   }>;
   consent?: {
     validFrom: string | null;

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/account-integrations.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/account-integrations.json
@@ -314,7 +314,8 @@
           "connectRemainingButton": "Connect Remaining Accounts",
           "empty": "No accounts connected yet.",
           "connectButton": "Connect Accounts",
-          "externalId": "External ID: {id}"
+          "externalId": "External ID: {id}",
+          "currencyFallback": "The bank didn't report a currency, so your base currency ({currency}) was used"
         },
         "actions": {
           "title": "Actions",

--- a/packages/frontend/src/pages/accounts/integrations/details.vue
+++ b/packages/frontend/src/pages/accounts/integrations/details.vue
@@ -374,11 +374,18 @@
                   :to="`/account/${account.id}`"
                   class="flex items-center justify-between gap-4 rounded-lg border p-4"
                 >
-                  <div class="flex-1 truncate">
-                    <p class="font-medium">{{ account.name }}</p>
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate font-medium">{{ account.name }}</p>
                     <p class="text-muted-foreground text-sm">{{ account.type }}</p>
                     <p class="text-muted-foreground truncate text-sm whitespace-nowrap">
                       {{ $t('pages.integrations.details.connectedAccounts.externalId', { id: account.externalId }) }}
+                    </p>
+                    <p v-if="account.currencyFallback" class="text-warning-text text-sm">
+                      {{
+                        $t('pages.integrations.details.connectedAccounts.currencyFallback', {
+                          currency: account.currencyFallback.assignedCurrency,
+                        })
+                      }}
                     </p>
                   </div>
                   <div class="text-right whitespace-nowrap">


### PR DESCRIPTION
Providers like Enable Banking send ISO "XXX" when the bank omits the account currency; connect now assigns the user's base currency instead of failing, and the integration page shows a note explaining the substitution. Closes #489