### PR TITLE
Harden data access

### DIFF
--- a/packages/backend/src/controllers/account-groups/get-accounts-in-group.ts
+++ b/packages/backend/src/controllers/account-groups/get-accounts-in-group.ts
@@ -7,9 +7,10 @@ export default createController(
   z.object({
     params: z.object({ groupId: recordId() }),
   }),
-  async ({ params }) => {
+  async ({ user, params }) => {
     const data = await accountGroupService.getAccountsInGroup({
       groupId: params.groupId,
+      userId: user.id,
     });
 
     return { data };

--- a/packages/backend/src/controllers/bank-data-providers/connections/get-sync-job-progress.ts
+++ b/packages/backend/src/controllers/bank-data-providers/connections/get-sync-job-progress.ts
@@ -12,8 +12,8 @@ export default createController(
       jobGroupId: z.string(),
     }),
   }),
-  async ({ query }) => {
-    const progress = await getJobGroupProgress(query.jobGroupId);
+  async ({ query, user }) => {
+    const progress = await getJobGroupProgress({ jobGroupId: query.jobGroupId, userId: user.id });
 
     return {
       data: progress,

--- a/packages/backend/src/controllers/demo.controller.ts
+++ b/packages/backend/src/controllers/demo.controller.ts
@@ -20,6 +20,11 @@ export const startDemo = async (req: Request, res: Response) => {
     logger.info(`Demo session requested from IP: ${req.ip}`);
     const startedAt = Date.now();
 
+    // Read per call, not at boot, so tests can toggle it.
+    if (process.env.SYSTEM_DEMO_DISABLED === 'true') {
+      throw new ForbiddenError({ message: 'Demo accounts are disabled by the administrator' });
+    }
+
     // createDemoUserFast inserts ba_user directly, bypassing better-auth's
     // user.create hook where the signup cap is enforced, so gate it here too.
     if (!(await areSignupsOpen())) {

--- a/packages/backend/src/controllers/demo.controller.ts
+++ b/packages/backend/src/controllers/demo.controller.ts
@@ -1,10 +1,12 @@
 import { API_RESPONSE_STATUS } from '@bt/shared/types';
 import { auth } from '@config/auth';
 import { errorHandler } from '@controllers/helpers';
+import { ForbiddenError } from '@js/errors';
 import { logger } from '@js/utils/logger';
 import { trackDemoSessionCreated } from '@js/utils/posthog';
 import { applyDemoTemplate } from '@services/demo/apply-demo-template.service';
 import { createDemoUserFast } from '@services/demo/create-demo-user.service';
+import { areSignupsOpen } from '@services/user/signups-open.service';
 import { Request, Response } from 'express';
 
 /**
@@ -17,6 +19,12 @@ export const startDemo = async (req: Request, res: Response) => {
   try {
     logger.info(`Demo session requested from IP: ${req.ip}`);
     const startedAt = Date.now();
+
+    // createDemoUserFast inserts ba_user directly, bypassing better-auth's
+    // user.create hook where the signup cap is enforced, so gate it here too.
+    if (!(await areSignupsOpen())) {
+      throw new ForbiddenError({ message: 'Signups are disabled by the administrator' });
+    }
 
     // 1. Create demo user records (auth + app user, no data seeding)
     const { user, email, password } = await createDemoUserFast();

--- a/packages/backend/src/controllers/user.controller.ts
+++ b/packages/backend/src/controllers/user.controller.ts
@@ -4,6 +4,7 @@ import { authPool } from '@config/auth';
 import { createController } from '@controllers/helpers/controller-factory';
 import { t } from '@i18n/index';
 import { ConflictError, ValidationError } from '@js/errors';
+import { isAdminUsername } from '@middlewares/admin-only';
 import { invalidateAppUserCache } from '@middlewares/better-auth';
 import { ExchangeRatePair } from '@models/user-exchange-rates.model';
 import * as userExchangeRates from '@services/user-exchange-rate';
@@ -19,8 +20,6 @@ import { z } from 'zod';
 export const getUser = createController(z.object({}), async ({ user }) => {
   const userData = await userService.getUser(user.id);
 
-  const isAdmin = (process.env.ADMIN_USERS || '').split(',').some((i) => i === user.username);
-
   // Fetch email from better-auth's ba_user table
   let email: string | null = null;
   if (userData?.authUserId) {
@@ -30,7 +29,7 @@ export const getUser = createController(z.object({}), async ({ user }) => {
     }
   }
 
-  return { data: { ...userData, email, isAdmin } };
+  return { data: { ...userData, email, isAdmin: isAdminUsername({ username: user.username }) } };
 });
 
 export const updateUser = createController(
@@ -57,6 +56,14 @@ export const updateUser = createController(
     }),
   }),
   async ({ user, body }) => {
+    // adminOnly gates its endpoints on username, so renaming into ADMIN_USERS would be
+    // privilege escalation. A no-op rename to the user's own current name is fine.
+    if (body.username && body.username !== user.username && isAdminUsername({ username: body.username })) {
+      throw new ValidationError({
+        message: 'This username is reserved and cannot be used.',
+      });
+    }
+
     try {
       const userData = await userService.updateUser({
         id: user.id,

--- a/packages/backend/src/middlewares/admin-only.ts
+++ b/packages/backend/src/middlewares/admin-only.ts
@@ -3,15 +3,26 @@ import { ERROR_CODES } from '@js/errors';
 import Users from '@models/users.model';
 import type { NextFunction, Request, Response } from 'express';
 
+const parseAdminUsers = (): string[] =>
+  (process.env.ADMIN_USERS || '')
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+
+/**
+ * Whether a username is an admin, per the ADMIN_USERS env list. Single source of truth: the
+ * middleware, the profile `isAdmin` flag, and the reserved-username guard all route through
+ * here so the parsing cannot drift and a mismatch cannot open an escalation.
+ */
+export const isAdminUsername = ({ username }: { username?: string | null }): boolean =>
+  Boolean(username) && parseAdminUsers().includes(username as string);
+
 /**
  * Middleware to ensure an endpoint is only accessible by admin users.
- * Checks if the authenticated user's email is in the ADMIN_USERS environment variable.
- * If not authorized, returns a 401 Unauthorized error.
+ * Returns a 401 Unauthorized error when the caller is not an admin.
  */
 export const adminOnly = (req: Request, res: Response, next: NextFunction) => {
-  const adminUsers = process.env.ADMIN_USERS?.split(',').map((username) => username.trim()) || [];
-
-  if (adminUsers.length === 0) {
+  if (parseAdminUsers().length === 0) {
     return res.status(ERROR_CODES.Unauthorized).json({
       status: API_RESPONSE_STATUS.error,
       response: {
@@ -34,7 +45,7 @@ export const adminOnly = (req: Request, res: Response, next: NextFunction) => {
     });
   }
 
-  if (!adminUsers.includes(username)) {
+  if (!isAdminUsername({ username })) {
     return res.status(ERROR_CODES.Unauthorized).json({
       status: API_RESPONSE_STATUS.error,
       response: {

--- a/packages/backend/src/models/categories.model.ts
+++ b/packages/backend/src/models/categories.model.ts
@@ -2,6 +2,7 @@ import { CATEGORY_TYPES, RecordId } from '@bt/shared/types';
 import { IdColumn } from '@common/types/id-column';
 import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
 import { ValidationError } from '@js/errors';
+import { Op } from 'sequelize';
 import { Table, Column, Model, ForeignKey, DataType, BelongsToMany } from 'sequelize-typescript';
 
 import MerchantCategoryCodes from './merchant-category-codes.model';
@@ -66,10 +67,20 @@ export const getCategories = async ({ userId }: { userId: number }) => {
   return categories;
 };
 
-export const getCategoriesForUsers = async ({ userIds }: { userIds: number[] }) => {
-  if (userIds.length === 0) return [];
+export const getAccessibleCategories = async ({
+  userIds,
+  categoryIds,
+}: {
+  userIds: number[];
+  categoryIds: RecordId[];
+}) => {
+  const conditions: Record<string, unknown>[] = [];
+  if (userIds.length) conditions.push({ userId: userIds });
+  if (categoryIds.length) conditions.push({ id: categoryIds });
+  if (conditions.length === 0) return [];
+
   const categories = await Categories.findAll({
-    where: { userId: userIds },
+    where: conditions.length === 1 ? conditions[0] : { [Op.or]: conditions },
     raw: true,
   });
 

--- a/packages/backend/src/routes/user.route.ts
+++ b/packages/backend/src/routes/user.route.ts
@@ -55,6 +55,7 @@ import {
   wipeUserData,
 } from '@controllers/user.controller';
 import { authenticateSession } from '@middlewares/better-auth';
+import { blockDemoUsers } from '@middlewares/block-demo-users';
 import { checkBaseCurrencyLock } from '@middlewares/check-base-currency-lock';
 import {
   aiCustomEndpointTestRateLimit,
@@ -339,6 +340,8 @@ router.get(
 router.post(
   '/ai/categorization/trigger',
   authenticateSession,
+  // Demo users would fall back to the operator's server-side AI key.
+  blockDemoUsers,
   validateEndpoint(triggerCategorizationController.schema),
   triggerCategorizationController.handler,
 );

--- a/packages/backend/src/services/account-groups/get-accounts-in-group.ts
+++ b/packages/backend/src/services/account-groups/get-accounts-in-group.ts
@@ -4,10 +4,10 @@ import AccountGroup from '@models/accounts-groups/account-groups.model';
 import { withTransaction } from '../common/with-transaction';
 
 export const getAccountsInGroup = withTransaction(
-  async ({ groupId }: { groupId: string }): Promise<AccountGrouping[]> => {
+  async ({ groupId, userId }: { groupId: string; userId: number }): Promise<AccountGrouping[]> => {
     return AccountGrouping.findAll({
       where: { groupId },
-      include: [{ model: AccountGroup, as: 'group' }],
+      include: [{ model: AccountGroup, as: 'group', required: true, where: { userId } }],
     });
   },
 );

--- a/packages/backend/src/services/account-groups/shared-account-group-scoping.e2e.ts
+++ b/packages/backend/src/services/account-groups/shared-account-group-scoping.e2e.ts
@@ -132,4 +132,33 @@ describe('Account group scoping with shared accounts', () => {
     expect(remaining).toHaveLength(1);
     expect(remaining[0]!.groupId).toBe(ownerGroup.id);
   });
+
+  it("stranger requesting the owner's groupId gets an empty result, never the owner's account ids", async () => {
+    const account = await helpers.createAccount({ raw: true });
+    const ownerGroup = await helpers.createAccountGroup({ name: 'owner-group', raw: true });
+    await helpers.addAccountToGroup({ accountId: account.id, groupId: ownerGroup.id });
+
+    const stranger = await provisionRecipient();
+
+    const res = await helpers.asUser({
+      cookies: stranger.cookies,
+      fn: () => helpers.getAccountsInGroup({ groupId: ownerGroup.id }),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.response).toEqual([]);
+    const accountIds = res.body.response.map((g) => g.accountId);
+    expect(accountIds).not.toContain(account.id);
+  });
+
+  it('owner can list the accounts in their own group', async () => {
+    const account = await helpers.createAccount({ raw: true });
+    const ownerGroup = await helpers.createAccountGroup({ name: 'owner-group', raw: true });
+    await helpers.addAccountToGroup({ accountId: account.id, groupId: ownerGroup.id });
+
+    const res = await helpers.getAccountsInGroup({ groupId: ownerGroup.id, raw: true });
+
+    expect(res).toHaveLength(1);
+    expect(res[0]!.accountId).toBe(account.id);
+  });
 });

--- a/packages/backend/src/services/bank-data-providers/connection/sync-job-progress-idor.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/connection/sync-job-progress-idor.e2e.ts
@@ -1,0 +1,89 @@
+import { BANK_PROVIDER_TYPE } from '@bt/shared/types';
+import { describe, expect, it } from '@jest/globals';
+import * as helpers from '@tests/helpers';
+import { VALID_MONOBANK_TOKEN, getMonobankTransactionsMock } from '@tests/mocks/monobank/mock-api';
+import { subDays } from 'date-fns';
+
+describe('Sync job progress authorization', () => {
+  it("scopes progress to the caller: user B cannot read user A's aggregate, owner still can", async () => {
+    // User A (primary test user): connect a provider, link an account and load a
+    // period so real batches land in the queue.
+    const { connectionId } = await helpers.bankDataProviders.connectProvider({
+      providerType: BANK_PROVIDER_TYPE.MONOBANK,
+      credentials: { apiToken: VALID_MONOBANK_TOKEN },
+      raw: true,
+    });
+
+    const { accounts: externalAccounts } = await helpers.bankDataProviders.listExternalAccounts({
+      connectionId,
+      raw: true,
+    });
+
+    const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+      connectionId,
+      accountExternalIds: [externalAccounts[0]!.externalId],
+      raw: true,
+    });
+
+    const accountId = syncedAccounts[0]!.id;
+
+    global.mswMockServer.use(getMonobankTransactionsMock({ response: helpers.monobank.mockedTransactionData(3) }));
+
+    const loadResult = await helpers.bankDataProviders.loadTransactionsForPeriod({
+      connectionId,
+      accountId,
+      from: subDays(new Date(), 60).toISOString(),
+      to: new Date().toISOString(),
+      raw: true,
+    });
+
+    expect(loadResult.totalBatches).toBeGreaterThan(0);
+
+    const { jobGroupId } = loadResult;
+
+    await helpers.bankDataProviders.waitForSyncJobsToComplete({ connectionId, jobGroupId, timeoutMs: 15000 });
+
+    // Owner reads their own aggregate — completed jobs are retained (removeOnComplete age/count).
+    const ownerProgress = await helpers.bankDataProviders.getSyncJobProgress({
+      connectionId,
+      jobGroupId,
+      raw: true,
+    });
+    expect(ownerProgress.totalBatches).toBe(loadResult.totalBatches);
+
+    // jobGroupId format is `${userId}-${accountId}-${timestamp}`, so the leading
+    // segment is user A's numeric id — the exploit input.
+    const userAId = jobGroupId.split('-')[0]!;
+
+    const userB = await helpers.provisionSecondUserWithBaseCurrency();
+
+    await helpers.asUser({
+      cookies: userB.cookies,
+      fn: async () => {
+        // ?jobGroupId=<user A's numeric id> used to leak user A's aggregate via a bare prefix match.
+        const foreignPrefix = await helpers.bankDataProviders.getSyncJobProgress({
+          connectionId,
+          jobGroupId: userAId,
+          raw: true,
+        });
+        expect(foreignPrefix.totalBatches).toBe(0);
+
+        // ?jobGroupId= (empty) used to leak a global aggregate across every user.
+        const emptyGroup = await helpers.bankDataProviders.getSyncJobProgress({
+          connectionId,
+          jobGroupId: '',
+          raw: true,
+        });
+        expect(emptyGroup.totalBatches).toBe(0);
+
+        // The full jobGroupId is still foreign to user B.
+        const fullGroup = await helpers.bankDataProviders.getSyncJobProgress({
+          connectionId,
+          jobGroupId,
+          raw: true,
+        });
+        expect(fullGroup.totalBatches).toBe(0);
+      },
+    });
+  });
+});

--- a/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
@@ -312,7 +312,7 @@ export class MonobankProvider extends BaseBankDataProvider {
   /**
    * Get progress of a queued transaction sync job
    */
-  async getTransactionSyncProgress(jobGroupId: string): Promise<{
+  async getTransactionSyncProgress({ jobGroupId, userId }: { jobGroupId: string; userId: number }): Promise<{
     totalBatches: number;
     completedBatches: number;
     failedBatches: number;
@@ -321,7 +321,7 @@ export class MonobankProvider extends BaseBankDataProvider {
     status: 'waiting' | 'active' | 'completed' | 'failed' | 'partial';
     progress?: unknown;
   }> {
-    return getJobGroupProgress(jobGroupId);
+    return getJobGroupProgress({ jobGroupId, userId });
   }
 
   // ============================================================================

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -788,7 +788,7 @@ export async function queueTransactionSync(params: {
  * known bundle and aggregate — cost scales with active-token count, which is
  * small (one entry per Monobank user with traffic since boot/recovery).
  */
-export async function getJobGroupProgress(jobGroupId: string): Promise<{
+export async function getJobGroupProgress({ jobGroupId, userId }: { jobGroupId: string; userId: number }): Promise<{
   totalBatches: number;
   completedBatches: number;
   failedBatches: number;
@@ -814,7 +814,11 @@ export async function getJobGroupProgress(jobGroupId: string): Promise<{
     }),
   );
 
-  const matches = (jobs: Job[]) => jobs.filter((job) => job.id?.startsWith(jobGroupId));
+  // Scope to the caller: an attacker-supplied jobGroupId (another user's id, or
+  // empty) must not match foreign jobs. `job.data.userId` is the authoritative
+  // owner; the `-` boundary stops a bare-id prefix widening ("5" matching "50-…").
+  const matches = (jobs: Job[]) =>
+    jobs.filter((job) => job.data.userId === userId && job.id?.startsWith(`${jobGroupId}-`));
   const waitingGroupJobs = perBundle.flatMap((b) => matches(b.waitingJobs));
   const activeGroupJobs = perBundle.flatMap((b) => matches(b.activeJobs));
   const completedGroupJobs = perBundle.flatMap((b) => matches(b.completedJobs));

--- a/packages/backend/src/services/categories.service.ts
+++ b/packages/backend/src/services/categories.service.ts
@@ -2,7 +2,7 @@ import { RESOURCE_TYPES, SHARE_PERMISSIONS } from '@bt/shared/types';
 import { NotFoundError, ValidationError } from '@js/errors';
 import * as Categories from '@models/categories.model';
 import { canUserAccessResource } from '@services/sharing/auth/can-user-access-resource.service';
-import { getAccessibleCategoryOwnerIds } from '@services/sharing/auth/get-accessible-category-owner-ids.service';
+import { getAccessibleCategoryCatalogScope } from '@services/sharing/auth/get-accessible-category-owner-ids.service';
 
 import { withTransaction } from './common/with-transaction';
 
@@ -27,11 +27,14 @@ export const bulkCreate = withTransaction(
  *  1. `accountId` is provided — return the *account owner's* category set so the
  *     recipient can categorize transactions on a shared account using the owner's tree
  *     (`family-sharing-categories.md`). Owned accounts behave like the no-arg path.
- *  2. `includeAccessible: true` — return the union of the caller's categories plus all
- *     categories belonging to owners of accounts the caller has read access to. Used by
- *     read-only display paths (transaction lists, dashboard widgets) so a single fetch
- *     populates the global lookup map for both own and shared-account txs. Without this,
- *     each shared-account tx would need a per-owner round-trip just to render its name.
+ *  2. `includeAccessible: true` — return the union of the caller's categories, every
+ *     category belonging to owners of accounts the caller has read access to, and the
+ *     specific categories referenced by transactions in budgets shared with (or by) the
+ *     caller. Budget shares contribute only their referenced categories — never the
+ *     counterparty's whole tree — so shared-budget tx names resolve without disclosing
+ *     unrelated category names. Used by read-only display paths (transaction lists,
+ *     dashboard widgets) so a single fetch populates the global lookup map for both own
+ *     and shared txs, sparing each shared tx a per-owner round-trip to render its name.
  *
  * Stranger `accountId` returns 404 to keep the param from leaking other users' resources.
  * `accountId` and `includeAccessible` are mutually exclusive — caller must pick one.
@@ -59,8 +62,8 @@ export const getCategories = withTransaction(
     }
 
     if (includeAccessible) {
-      const ownerUserIds = await getAccessibleCategoryOwnerIds({ userId });
-      return Categories.getCategoriesForUsers({ userIds: ownerUserIds });
+      const { ownerUserIds, budgetCategoryIds } = await getAccessibleCategoryCatalogScope({ userId });
+      return Categories.getAccessibleCategories({ userIds: ownerUserIds, categoryIds: budgetCategoryIds });
     }
 
     return Categories.getCategories({ userId });

--- a/packages/backend/src/services/demo/demo.e2e.ts
+++ b/packages/backend/src/services/demo/demo.e2e.ts
@@ -190,6 +190,26 @@ describe('Demo Mode', () => {
     }, 60000); // 60s timeout - demo user creation involves lots of data seeding
   });
 
+  describe('POST /demo - SYSTEM_DEMO_DISABLED gate', () => {
+    afterEach(() => {
+      delete process.env.SYSTEM_DEMO_DISABLED;
+    });
+
+    it('rejects demo creation when demo accounts are disabled', async () => {
+      global.APP_AUTH_COOKIES = null;
+      process.env.SYSTEM_DEMO_DISABLED = 'true';
+
+      const res = await makeAuthRequest({
+        method: 'post',
+        url: '/demo',
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.status).toBe(API_RESPONSE_STATUS.error);
+      expect(res.body.response.code).toBe(API_ERROR_CODES.forbidden);
+    }, 60000);
+  });
+
   describe('POST /demo - Signup cap gate', () => {
     afterEach(() => {
       delete process.env.SYSTEM_MAX_SIGNUPS_ALLOWED;

--- a/packages/backend/src/services/demo/demo.e2e.ts
+++ b/packages/backend/src/services/demo/demo.e2e.ts
@@ -190,6 +190,39 @@ describe('Demo Mode', () => {
     }, 60000); // 60s timeout - demo user creation involves lots of data seeding
   });
 
+  describe('POST /demo - Signup cap gate', () => {
+    afterEach(() => {
+      delete process.env.SYSTEM_MAX_SIGNUPS_ALLOWED;
+    });
+
+    it('rejects demo creation when signups are closed', async () => {
+      global.APP_AUTH_COOKIES = null;
+      process.env.SYSTEM_MAX_SIGNUPS_ALLOWED = '0';
+
+      const res = await makeAuthRequest({
+        method: 'post',
+        url: '/demo',
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.status).toBe(API_RESPONSE_STATUS.error);
+      expect(res.body.response.code).toBe(API_ERROR_CODES.forbidden);
+    }, 60000);
+
+    it('creates a demo user when signups are open', async () => {
+      global.APP_AUTH_COOKIES = null;
+      delete process.env.SYSTEM_MAX_SIGNUPS_ALLOWED;
+
+      const res = await makeAuthRequest({
+        method: 'post',
+        url: '/demo',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body.response.user.role).toBe(USER_ROLES.demo);
+    }, 60000);
+  });
+
   describe('Demo Data Seeding', () => {
     let demoSessionToken: string;
 
@@ -898,6 +931,20 @@ describe('Demo Mode', () => {
         payload: {
           newPassword: 'newpassword123',
         },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body.status).toBe(API_RESPONSE_STATUS.error);
+      expect(res.body.response.code).toBe(API_ERROR_CODES.forbidden);
+    });
+
+    it('blocks AI categorization trigger for demo users', async () => {
+      // Without a user AI key, this endpoint falls back to the operator's
+      // server-side key — demo users must not reach it.
+      const res = await makeRequest({
+        method: 'post',
+        url: '/user/ai/categorization/trigger',
+        payload: {},
       });
 
       expect(res.statusCode).toBe(403);

--- a/packages/backend/src/services/payees/payee-stats.e2e.ts
+++ b/packages/backend/src/services/payees/payee-stats.e2e.ts
@@ -1,4 +1,10 @@
-import { type RecordId, TRANSACTION_TRANSFER_NATURE, TRANSACTION_TYPES } from '@bt/shared/types';
+import {
+  type RecordId,
+  RESOURCE_TYPES,
+  SHARE_PERMISSIONS,
+  TRANSACTION_TRANSFER_NATURE,
+  TRANSACTION_TYPES,
+} from '@bt/shared/types';
 import { describe, expect, it } from '@jest/globals';
 import * as helpers from '@tests/helpers';
 
@@ -213,6 +219,89 @@ describe('Payee stats — rows that must not be counted', () => {
       expect(list.transactionCount).toBe(2);
       expect(list.netFlowRef).toBe(-200);
       expect(toMs(list.firstSeenAt)).toBe(toMs(firstVisible.time));
+    });
+  });
+
+  describe('shared-account scoping', () => {
+    // A single-account recipient must only ever see the owner's stats for the
+    // account shared with them. Aggregating across the owner's other (unshared)
+    // accounts would leak net flow, counts, and first/last-seen from private
+    // accounts the recipient was never granted.
+    const shareAccountReadOnly = async ({ accountId, recipientEmail }: { accountId: string; recipientEmail: string }) =>
+      helpers.createShareInvitation({
+        inviteeEmail: recipientEmail,
+        resourceType: RESOURCE_TYPES.account,
+        resourceId: accountId,
+        permission: SHARE_PERMISSIONS.read,
+        raw: true,
+      });
+
+    it("scopes a recipient's payee stats to the shared account only", async () => {
+      const sharedAccount = await helpers.createAccount({ raw: true });
+      const privateAccount = await helpers.createAccount({ raw: true });
+
+      // Active on BOTH accounts: shared side is 2 expenses of 100 (net -200,
+      // lastSeen 2024-05-02), plus one 500 expense on the private account.
+      const sharedScopePayee = await makePayee({ name: 'Shared Scope Co' });
+      await createExpense({
+        accountId: sharedAccount.id,
+        payeeId: sharedScopePayee.id,
+        amount: 100,
+        time: '2024-05-01T12:00:00.000Z',
+      });
+      const lastShared = await createExpense({
+        accountId: sharedAccount.id,
+        payeeId: sharedScopePayee.id,
+        amount: 100,
+        time: '2024-05-02T12:00:00.000Z',
+      });
+      await createExpense({
+        accountId: privateAccount.id,
+        payeeId: sharedScopePayee.id,
+        amount: 500,
+        time: '2024-05-10T12:00:00.000Z',
+      });
+
+      // Active ONLY on the private account — must not surface to the recipient.
+      const privateOnlyPayee = await makePayee({ name: 'Private Only Co' });
+      await createExpense({
+        accountId: privateAccount.id,
+        payeeId: privateOnlyPayee.id,
+        amount: 300,
+        time: '2024-05-03T12:00:00.000Z',
+      });
+
+      const recipient = await helpers.provisionSecondUserWithBaseCurrency();
+      const invitation = await shareAccountReadOnly({
+        accountId: sharedAccount.id,
+        recipientEmail: recipient.email,
+      });
+      await helpers.asUser({
+        cookies: recipient.cookies,
+        fn: () => helpers.acceptShareInvitation({ token: invitation.token, raw: true }),
+      });
+
+      const recipientList = await helpers.asUser({
+        cookies: recipient.cookies,
+        fn: () => helpers.listPayees({ accountId: sharedAccount.id, raw: true }),
+      });
+
+      const recipientShared = recipientList.find((row) => row.id === sharedScopePayee.id);
+      expect(recipientShared).toBeDefined();
+      expect(recipientShared!.stats).not.toBeNull();
+      expect(recipientShared!.stats!.transactionCount).toBe(2);
+      expect(recipientShared!.stats!.netFlowRef).toBe(-200);
+      expect(toMs(recipientShared!.stats!.lastSeenAt)).toBe(toMs(lastShared.time));
+
+      // The private-only payee is invisible to the recipient's shared-account view.
+      expect(recipientList.some((row) => row.id === privateOnlyPayee.id)).toBe(false);
+
+      // Owner's own list still aggregates across all their accounts.
+      const ownerList = await helpers.listPayees({ raw: true });
+      const ownerShared = ownerList.find((row) => row.id === sharedScopePayee.id);
+      expect(ownerShared!.stats!.transactionCount).toBe(3);
+      expect(ownerShared!.stats!.netFlowRef).toBe(-700);
+      expect(ownerList.some((row) => row.id === privateOnlyPayee.id)).toBe(true);
     });
   });
 

--- a/packages/backend/src/services/payees/payee-stats.e2e.ts
+++ b/packages/backend/src/services/payees/payee-stats.e2e.ts
@@ -293,8 +293,12 @@ describe('Payee stats — rows that must not be counted', () => {
       expect(recipientShared!.stats!.netFlowRef).toBe(-200);
       expect(toMs(recipientShared!.stats!.lastSeenAt)).toBe(toMs(lastShared.time));
 
-      // The private-only payee is invisible to the recipient's shared-account view.
-      expect(recipientList.some((row) => row.id === privateOnlyPayee.id)).toBe(false);
+      // The owner's full payee namespace stays visible so the recipient's picker can
+      // resolve it, but a payee with no shared-account activity carries no stats —
+      // none of the owner's private-account figures leak through.
+      const recipientPrivate = recipientList.find((row) => row.id === privateOnlyPayee.id);
+      expect(recipientPrivate).toBeDefined();
+      expect(recipientPrivate!.stats).toBeNull();
 
       // Owner's own list still aggregates across all their accounts.
       const ownerList = await helpers.listPayees({ raw: true });

--- a/packages/backend/src/services/payees/payee-stats.ts
+++ b/packages/backend/src/services/payees/payee-stats.ts
@@ -66,11 +66,19 @@ const countableScope = ({ userId }: { userId: number }): CountableScope => ({
  *
  * When `payeeIds` is empty, returns `[]` without hitting the DB.
  */
-async function getPayeeStats({ userId, payeeIds }: { userId: number; payeeIds: string[] }): Promise<PayeeStatsRow[]> {
+async function getPayeeStats({
+  userId,
+  payeeIds,
+  accountId,
+}: {
+  userId: number;
+  payeeIds: string[];
+  accountId?: string;
+}): Promise<PayeeStatsRow[]> {
   if (payeeIds.length === 0) return [];
 
   const scope = countableScope({ userId });
-  const payeeFilter = { payeeId: { [Op.in]: payeeIds } };
+  const payeeFilter = { payeeId: { [Op.in]: payeeIds }, ...(accountId !== undefined ? { accountId } : {}) };
 
   const [totals, categoryCounts] = (await Promise.all([
     findTransactions({
@@ -120,11 +128,13 @@ async function getPayeeStats({ userId, payeeIds }: { userId: number; payeeIds: s
 export async function getPayeeStatsMap({
   userId,
   payeeIds,
+  accountId,
 }: {
   userId: number;
   payeeIds: string[];
+  accountId?: string;
 }): Promise<Map<string, PayeeStatsRow>> {
-  const rows = await getPayeeStats({ userId, payeeIds });
+  const rows = await getPayeeStats({ userId, payeeIds, accountId });
   const map = new Map<string, PayeeStatsRow>();
   for (const row of rows) map.set(row.payeeId, row);
   return map;

--- a/packages/backend/src/services/payees/payees.service.ts
+++ b/packages/backend/src/services/payees/payees.service.ts
@@ -147,9 +147,10 @@ export const listPayees = withTransaction(
     accountId,
   }: ListPayeesParams): Promise<PayeeListRow[]> => {
     let scopedUserId = userId;
-    // Only set for a NON-owner recipient scoping to a shared account: their
-    // view must never reach the owner's other (unshared) accounts, so both the
-    // payee id selection and the stats aggregation are pinned to this account.
+    // Only set for a NON-owner recipient scoping to a shared account: their stats
+    // must never reach the owner's other (unshared) accounts, so the stats
+    // aggregation is pinned to this account. The payee namespace stays the owner's
+    // full set — the recipient's transaction-form picker needs to resolve it.
     let statsAccountId: string | undefined;
     if (accountId !== undefined) {
       const access = await canUserAccessResource({
@@ -183,16 +184,17 @@ export const listPayees = withTransaction(
     // when two rows share the same primary sort key.
     const orderBy = `${sortColumn} ${sortDirSql} NULLS LAST, p.id ASC`;
     const nameWhere = normalizedQuery !== null ? 'AND p."normalizedName" LIKE :nameLike' : '';
-    // Scoping to a shared account narrows the stats subquery to that account and
-    // switches the join to INNER, so only payees active on it surface.
+    // Scoping to a shared account narrows the stats subquery to that account, so the
+    // sort keys and shown stats reflect only shared-account activity. The join stays
+    // LEFT so the owner's full payee namespace still surfaces (payees unused on the
+    // shared account sort last with null stats), which the recipient's picker needs.
     const accountFilter = statsAccountId !== undefined ? 'AND t."accountId" = :statsAccountId' : '';
-    const statsJoin = statsAccountId !== undefined ? 'JOIN' : 'LEFT JOIN';
 
     const idRows: { id: string }[] = await connection.sequelize.query(
       `
       SELECT p.id
         FROM "Payees" p
-        ${statsJoin} (
+        LEFT JOIN (
           SELECT t."payeeId",
                  COUNT(*) AS "transactionCount",
                  SUM(

--- a/packages/backend/src/services/payees/payees.service.ts
+++ b/packages/backend/src/services/payees/payees.service.ts
@@ -97,8 +97,9 @@ interface ListPayeesParams {
   sortDir?: PayeeSortDir;
   /**
    * Scope to a single account's owner. On a shared account the recipient
-   * sees the owner's payee set; on an owned account it behaves like the
-   * no-arg path. Mirrors the categories `?accountId=` pattern so the
+   * sees the owner's payees active on that account, with stats scoped to it
+   * so the owner's other accounts never leak; on an owned account it behaves
+   * like the no-arg path. Mirrors the categories `?accountId=` pattern so the
    * recipient's transaction-form picker resolves to the same namespace
    * that backend write paths validate against. Stranger `accountId`
    * returns 404 to keep the param from leaking other users' resources.
@@ -146,6 +147,10 @@ export const listPayees = withTransaction(
     accountId,
   }: ListPayeesParams): Promise<PayeeListRow[]> => {
     let scopedUserId = userId;
+    // Only set for a NON-owner recipient scoping to a shared account: their
+    // view must never reach the owner's other (unshared) accounts, so both the
+    // payee id selection and the stats aggregation are pinned to this account.
+    let statsAccountId: string | undefined;
     if (accountId !== undefined) {
       const access = await canUserAccessResource({
         userId,
@@ -157,6 +162,9 @@ export const listPayees = withTransaction(
         throw new NotFoundError({ message: t({ key: 'accounts.accountNotFoundForTransaction' }) });
       }
       scopedUserId = access.isOwner ? userId : access.ownerUserId!;
+      if (!access.isOwner) {
+        statsAccountId = accountId;
+      }
     }
 
     let effectiveLimit = Math.min(Math.max(limit, 1), MAX_LIST_LIMIT);
@@ -175,12 +183,16 @@ export const listPayees = withTransaction(
     // when two rows share the same primary sort key.
     const orderBy = `${sortColumn} ${sortDirSql} NULLS LAST, p.id ASC`;
     const nameWhere = normalizedQuery !== null ? 'AND p."normalizedName" LIKE :nameLike' : '';
+    // Scoping to a shared account narrows the stats subquery to that account and
+    // switches the join to INNER, so only payees active on it surface.
+    const accountFilter = statsAccountId !== undefined ? 'AND t."accountId" = :statsAccountId' : '';
+    const statsJoin = statsAccountId !== undefined ? 'JOIN' : 'LEFT JOIN';
 
     const idRows: { id: string }[] = await connection.sequelize.query(
       `
       SELECT p.id
         FROM "Payees" p
-        LEFT JOIN (
+        ${statsJoin} (
           SELECT t."payeeId",
                  COUNT(*) AS "transactionCount",
                  SUM(
@@ -195,6 +207,7 @@ export const listPayees = withTransaction(
            WHERE t."userId" = :scopedUserId
              AND t."transferNature" = 'not_transfer'
              AND a."excludeFromStats" = false
+             ${accountFilter}
              AND (t."externalData" IS NULL OR NOT (t."externalData" @> '{"balanceAdjustment": true}'))
            GROUP BY t."payeeId"
         ) s ON s."payeeId" = p.id
@@ -207,6 +220,7 @@ export const listPayees = withTransaction(
         type: QueryTypes.SELECT,
         replacements: {
           scopedUserId,
+          statsAccountId: statsAccountId ?? null,
           nameLike: normalizedQuery !== null ? `%${normalizedQuery}%` : null,
           limit: effectiveLimit,
           offset,
@@ -226,7 +240,7 @@ export const listPayees = withTransaction(
           { model: Tags, as: 'defaultTags', attributes: ['id'], through: { attributes: [] } },
         ],
       }),
-      getPayeeStatsMap({ userId: scopedUserId, payeeIds: ids }),
+      getPayeeStatsMap({ userId: scopedUserId, payeeIds: ids, accountId: statsAccountId }),
     ]);
 
     const payeesById = new Map<string, Payees>(payees.map((p) => [p.id, p]));

--- a/packages/backend/src/services/sharing/auth/get-accessible-category-owner-ids.service.ts
+++ b/packages/backend/src/services/sharing/auth/get-accessible-category-owner-ids.service.ts
@@ -1,7 +1,9 @@
-import { RESOURCE_TYPES } from '@bt/shared/types';
+import { RESOURCE_TYPES, RecordId } from '@bt/shared/types';
 import Accounts from '@models/accounts.model';
+import BudgetTransactions from '@models/budget-transactions.model';
 import Budgets from '@models/budget.model';
 import ResourceShares from '@models/resource-shares.model';
+import { findTransactions } from '@models/transactions-query';
 import { Op } from 'sequelize';
 
 import { getAccessibleAccountIdsForUser } from './get-accessible-account-ids.service';
@@ -69,4 +71,61 @@ export const getAccessibleCategoryOwnerIds = async ({ userId }: { userId: number
   for (const row of ownedBudgetShareRecipientRows) ownerUserIds.add(row.sharedWithUserId);
 
   return Array.from(ownerUserIds);
+};
+
+/**
+ * Scope for the user-facing category catalog (`GET /categories?includeAccessible=true`),
+ * where the raw category names are handed straight to the caller.
+ *
+ * Account shares still expand to the owner's whole tree (`ownerUserIds`) — the recipient
+ * categorizes shared-account transactions against it. Budget shares expand only to the
+ * category ids actually referenced by that budget's transactions (`budgetCategoryIds`),
+ * in both directions, so a shared budget lets each side resolve the other's referenced
+ * category names without disclosing the counterparty's unrelated categories.
+ */
+export const getAccessibleCategoryCatalogScope = async ({
+  userId,
+}: {
+  userId: number;
+}): Promise<{ ownerUserIds: number[]; budgetCategoryIds: RecordId[] }> => {
+  const [accessibleAccountIds, accessibleBudgetIds] = await Promise.all([
+    getAccessibleAccountIdsForUser({ userId }),
+    getAccessibleBudgetIdsForUser({ userId }),
+  ]);
+
+  const ownerUserIds = new Set<number>([userId]);
+  if (accessibleAccountIds.length) {
+    const accountRows = await Accounts.findAll({
+      where: { id: accessibleAccountIds },
+      attributes: ['userId'],
+    });
+    for (const row of accountRows) ownerUserIds.add(row.userId);
+  }
+
+  const budgetCategoryIds = new Set<RecordId>();
+  if (accessibleBudgetIds.length) {
+    const junctionRows = (await BudgetTransactions.findAll({
+      where: { budgetId: { [Op.in]: accessibleBudgetIds } },
+      attributes: ['transactionId'],
+      raw: true,
+    })) as unknown as Array<{ transactionId: RecordId }>;
+    const transactionIds = junctionRows.map((row) => row.transactionId);
+
+    if (transactionIds.length) {
+      const txRows = (await findTransactions({
+        access: 'unscoped-internal',
+        planned: 'include',
+        balanceAdjustments: 'include',
+        completeness: 'all',
+        where: { id: { [Op.in]: transactionIds }, categoryId: { [Op.not]: null } },
+        attributes: ['categoryId'],
+        raw: true,
+      })) as unknown as Array<{ categoryId: RecordId | null }>;
+      for (const row of txRows) {
+        if (row.categoryId) budgetCategoryIds.add(row.categoryId);
+      }
+    }
+  }
+
+  return { ownerUserIds: Array.from(ownerUserIds), budgetCategoryIds: Array.from(budgetCategoryIds) };
 };

--- a/packages/backend/src/services/sharing/members/membership.service.e2e.ts
+++ b/packages/backend/src/services/sharing/members/membership.service.e2e.ts
@@ -206,6 +206,27 @@ describe('Share membership (S5)', () => {
       expect(res.statusCode).toBe(422);
     });
 
+    it('rejects self-escalation (manage recipient widening their own membership)', async () => {
+      const { account, recipient, recipientApp } = await setupAcceptedShare({
+        permission: SHARE_PERMISSIONS.manage,
+      });
+
+      const res = await helpers.asUser({
+        cookies: recipient.cookies,
+        fn: () =>
+          helpers.updateShareMember({
+            resourceType: RESOURCE_TYPES.account,
+            resourceId: account.id,
+            memberUserId: recipientApp.id,
+            policy: { transactionsWriteScope: TRANSACTIONS_WRITE_SCOPES.all },
+            raw: false,
+          }),
+      });
+      expect(res.statusCode).toBe(422);
+      const err = res.body.response as unknown as ErrorResponse;
+      expect(err.message).toMatch(/own membership/i);
+    });
+
     it('404s for a stranger', async () => {
       const { account, recipientApp } = await setupAcceptedShare();
       const stranger = await helpers.provisionSecondUserWithBaseCurrency();

--- a/packages/backend/src/services/sharing/members/update-member.service.ts
+++ b/packages/backend/src/services/sharing/members/update-member.service.ts
@@ -80,6 +80,12 @@ const updateMemberImpl = async (params: UpdateMemberParams): Promise<{ share: Re
     throw new ValidationError({ message: 'Cannot modify the owner of a shared resource.' });
   }
 
+  if (memberUserId === callerUserId) {
+    // A manage recipient editing their own row could widen their own permission/policy
+    // (self-escalation). Membership changes must come from someone else who holds manage.
+    throw new ValidationError({ message: 'Cannot modify your own membership on a shared resource.' });
+  }
+
   const resourceIdStr = String(resourceId);
   const share = await ResourceShares.findOne({
     where: {

--- a/packages/backend/src/services/sharing/shared-budget-visibility.service.e2e.ts
+++ b/packages/backend/src/services/sharing/shared-budget-visibility.service.e2e.ts
@@ -525,4 +525,63 @@ describe('Shared budget visibility', () => {
       expect((budgets as Array<{ id: string }>).find((b) => b.id === budget.id)).toBeUndefined();
     });
   });
+
+  describe('GET /categories?includeAccessible=true — budget-share scope', () => {
+    it("exposes only the shared budget's referenced categories, not the owner's whole tree", async () => {
+      const account = await helpers.createAccount({ raw: true });
+
+      const referencedCategory = await helpers.addCustomCategory({
+        name: 'budget-referenced-cat',
+        color: '#123456',
+        raw: true,
+      });
+      const unrelatedCategory = await helpers.addCustomCategory({
+        name: 'owner-unrelated-cat',
+        color: '#654321',
+        raw: true,
+      });
+
+      const [ownerTx] = await helpers.createTransaction({
+        payload: helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 100,
+          transactionType: TRANSACTION_TYPES.expense,
+          categoryId: referencedCategory.id,
+        }),
+        raw: true,
+      });
+
+      const budget = await helpers.createCustomBudget({
+        name: 'Shared category-scope budget',
+        autoInclude: false,
+        limitAmount: 1000,
+        raw: true,
+      });
+      await helpers.addTransactionToCustomBudget({
+        id: budget.id,
+        payload: { transactionIds: [ownerTx!.id] },
+        raw: false,
+      });
+
+      const recipient = await provisionRecipient();
+      await shareBudget({ budgetId: budget.id, recipient, permission: SHARE_PERMISSIONS.read });
+
+      const recipientOwnCategory = await helpers.asUser({
+        cookies: recipient.cookies,
+        fn: () => helpers.addCustomCategory({ name: 'recipient-own-cat', color: '#00FF00', raw: true }),
+      });
+
+      const list = await helpers.asUser({
+        cookies: recipient.cookies,
+        fn: () => helpers.getCategoriesList({ includeAccessible: true }),
+      });
+
+      // Referenced by the shared budget's tx — must resolve so the name renders.
+      expect(list.find((c) => c.id === referencedCategory.id)).toBeDefined();
+      // Recipient's own categories are always part of the union.
+      expect(list.find((c) => c.id === recipientOwnCategory.id)).toBeDefined();
+      // Owner category the shared budget never references must NOT leak.
+      expect(list.find((c) => c.id === unrelatedCategory.id)).toBeUndefined();
+    });
+  });
 });

--- a/packages/backend/src/services/stats/foreign-currency-balance-history.e2e.ts
+++ b/packages/backend/src/services/stats/foreign-currency-balance-history.e2e.ts
@@ -1,7 +1,7 @@
 import { type RecordId, TRANSACTION_TYPES } from '@bt/shared/types';
 import { afterEach, describe, expect, it } from '@jest/globals';
 import * as helpers from '@tests/helpers';
-import { eachDayOfInterval, format, startOfDay, subDays } from 'date-fns';
+import { addDays, eachDayOfInterval, format, startOfDay, subDays } from 'date-fns';
 
 /**
  * A day's stored balance for a non-base-currency account is the foreign units held
@@ -96,5 +96,46 @@ describe('Balance history for foreign-currency accounts', () => {
     expect(helpers.balanceCentsOn({ rows, date: LATER_DATE })).toEqualRefValue(
       HOLDINGS_INR_CENTS * helpers.INR_TO_AED_AFTER,
     );
+  });
+});
+
+describe('Balance history for a single account — cross-user access', () => {
+  // A window entirely after every stored balance forces the "no rows in range" fallback
+  // branch, which is where the missing user scope leaked another account's balance.
+  const FUTURE_FROM = format(addDays(TODAY, 365), 'yyyy-MM-dd');
+  const FUTURE_TO = format(addDays(TODAY, 366), 'yyyy-MM-dd');
+  const INITIAL_BALANCE = 1000;
+
+  it('does not leak a foreign account balance through the fallback branch', async () => {
+    const ownerAccount = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ initialBalance: INITIAL_BALANCE }),
+      raw: true,
+    });
+
+    const attacker = await helpers.provisionSecondUserWithBaseCurrency();
+
+    const leaked = await helpers.asUser({
+      cookies: attacker.cookies,
+      fn: () => helpers.getBalanceHistory({ accountId: ownerAccount.id, from: FUTURE_FROM, to: FUTURE_TO, raw: true }),
+    });
+
+    expect(leaked).toEqual([]);
+  });
+
+  it('still returns the owner their own balance through the same fallback window', async () => {
+    const ownerAccount = await helpers.createAccount({
+      payload: helpers.buildAccountPayload({ initialBalance: INITIAL_BALANCE }),
+      raw: true,
+    });
+
+    const rows = await helpers.getBalanceHistory({
+      accountId: ownerAccount.id,
+      from: FUTURE_FROM,
+      to: FUTURE_TO,
+      raw: true,
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.amount).toBe(INITIAL_BALANCE);
   });
 });

--- a/packages/backend/src/services/stats/get-balance-history-for-account.ts
+++ b/packages/backend/src/services/stats/get-balance-history-for-account.ts
@@ -35,6 +35,11 @@ export const getBalanceHistoryForAccount = async ({
   try {
     let data: Balances.default[] = [];
 
+    const account = await Accounts.default.findOne({ where: { id: accountId, userId } });
+    if (!account) {
+      return data;
+    }
+
     const dataAttributes = ['date', 'amount'];
     const balancesInRange = await Balances.default.findAll({
       where: getWhereConditionForTime({ from, to, columnName: 'date' }),

--- a/packages/backend/src/services/user/update-user.e2e.ts
+++ b/packages/backend/src/services/user/update-user.e2e.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from '@jest/globals';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
 import Users from '@models/users.model';
 import { makeRequest } from '@tests/helpers/common';
 
@@ -126,6 +126,64 @@ describe('PUT /user/update — username', () => {
 
       const stillTest1 = await Users.findOne({ where: { username: 'test1' }, raw: true });
       expect(stillTest1).not.toBeNull();
+    });
+  });
+
+  describe('reserved admin usernames', () => {
+    let originalAdminUsers: string | undefined;
+
+    beforeEach(() => {
+      originalAdminUsers = process.env.ADMIN_USERS;
+    });
+
+    afterEach(() => {
+      if (originalAdminUsers !== undefined) {
+        process.env.ADMIN_USERS = originalAdminUsers;
+      } else {
+        delete process.env.ADMIN_USERS;
+      }
+    });
+
+    it('rejects claiming a configured ADMIN_USERS name (privilege escalation)', async () => {
+      process.env.ADMIN_USERS = 'reserved-admin';
+
+      const res = await makeRequest({
+        method: 'put',
+        url: '/user/update',
+        payload: { username: 'reserved-admin' },
+      });
+
+      expect(res.statusCode).toEqual(422);
+
+      const stillTest1 = await Users.findOne({ where: { username: 'test1' }, raw: true });
+      expect(stillTest1).not.toBeNull();
+      const claimed = await Users.findOne({ where: { username: 'reserved-admin' }, raw: true });
+      expect(claimed).toBeNull();
+    });
+
+    it('normalizes ADMIN_USERS whitespace the same way adminOnly does', async () => {
+      process.env.ADMIN_USERS = '  reserved-admin  , other-admin';
+
+      const res = await makeRequest({
+        method: 'put',
+        url: '/user/update',
+        payload: { username: 'reserved-admin' },
+      });
+
+      expect(res.statusCode).toEqual(422);
+    });
+
+    it('still allows renaming to a non-admin username while ADMIN_USERS is set', async () => {
+      process.env.ADMIN_USERS = 'reserved-admin';
+
+      const res = await makeRequest({
+        method: 'put',
+        url: '/user/update',
+        payload: { username: 'harriet-vane' },
+      });
+
+      expect(res.statusCode).toEqual(200);
+      expect(res.body.response.username).toEqual('harriet-vane');
     });
   });
 });

--- a/packages/backend/src/tests/helpers/account-groups.ts
+++ b/packages/backend/src/tests/helpers/account-groups.ts
@@ -78,6 +78,19 @@ export async function removeAccountFromGroup<R extends boolean | undefined = und
   });
 }
 
+export async function getAccountsInGroup<R extends boolean | undefined = undefined>({
+  groupId,
+  raw,
+}: Omit<Parameters<typeof accountGroupService.getAccountsInGroup>[0], 'userId'> & {
+  raw?: R;
+}) {
+  return makeRequest<Awaited<ReturnType<typeof accountGroupService.getAccountsInGroup>>, R>({
+    method: 'get',
+    url: `/account-group/${groupId}/accounts`,
+    raw,
+  });
+}
+
 export async function addAccountToGroup<R extends boolean | undefined = undefined>({
   raw,
   accountId,

--- a/self-hosting/.env.example
+++ b/self-hosting/.env.example
@@ -93,6 +93,10 @@ APPLICATION_PORT=8081
 # Set the number of max allowed signups
 # SYSTEM_MAX_SIGNUPS_ALLOWED=1
 
+# Disables demo accounts completely. The compose stack defaults this to true;
+# set SYSTEM_DEMO_DISABLED=false to allow demo accounts.
+# SYSTEM_DEMO_DISABLED=true
+
 # --- Email (transactional / verification). Without RESEND_API_KEY email
 # verification is disabled and users can register with any address. ---
 # RESEND_API_KEY=

--- a/self-hosting/docker-compose.yml
+++ b/self-hosting/docker-compose.yml
@@ -52,6 +52,10 @@ services:
       # server on the operator's own network, and a restored backup backfills
       # historical prices for its securities.
       IS_SELF_HOST: 'true'
+      # Demo accounts are for the hosted instance's landing page; a self-hosted
+      # stack has no use for them, so they default to disabled. Set
+      # SYSTEM_DEMO_DISABLED=false in .env to allow them.
+      SYSTEM_DEMO_DISABLED: ${SYSTEM_DEMO_DISABLED:-true}
     healthcheck:
       # BusyBox wget ships in the node:alpine image. `--spider` returns non-zero
       # on any non-2xx status, so this flips healthy only once /health answers.

--- a/self-hosting/docs/environment-reference.md
+++ b/self-hosting/docs/environment-reference.md
@@ -57,6 +57,7 @@ Ignored unless you use the [Traefik overlay](traefik-overlay.md)
 | `ALLOWED_ORIGINS`                                                              | Extra CORS origins beyond `AUTH_ORIGIN`                                                                                                                                   |
 | `SENTRY_DSN`                                                                   | Backend error tracking                                                                                                                                                    |
 | `SYSTEM_MAX_SIGNUPS_ALLOWED`                                                   | Cap on user accounts: signups are rejected once the instance has this many users (`0` disables signups, `1` = "just me"). Deleting a user frees a slot. Unset = unlimited |
+| `SYSTEM_DEMO_DISABLED`                                                         | Blocks demo-account creation (`POST /demo`). Defaults to `true` in the self-host compose stack; set to `false` to allow demo accounts                                     |
 
 ## Frontend runtime (optional)
 


### PR DESCRIPTION
- scopes balance-history to the caller's own account
- blocks share member self-escalation via update-member
- blocks admin escalation via username rename
- scopes account-group accounts listing to the caller
- scopes shared-account payee stats to the shared account
- gates demo creation on signups and block demo AI usage
- limits shared-budget category exposure to referenced categories
- scope monobank sync-job progress to the caller
- new optional env variable to disable demo signups completely