### PR TITLE
Always show balance-recalculation toggle in CSV import wizard

### DIFF
--- a/packages/frontend/src/composable/use-recalculate-balance-toggle.ts
+++ b/packages/frontend/src/composable/use-recalculate-balance-toggle.ts
@@ -5,8 +5,9 @@ import { captureException } from '@/lib/sentry';
 import { computed, ref } from 'vue';
 
 /**
- * Owns the "recalculate account balances" checkbox both import wizards render on
- * their review step. The checkbox follows the persisted
+ * Owns the "recalculate account balances" checkbox the import wizards render
+ * (CSV on its review step, Budget Bakers Wallet and MS Money on their resolve
+ * steps). The checkbox follows the persisted
  * `import.recalculateAccountBalance` user setting until the user toggles it, and
  * the chosen value is written back after a successful execute so the next import
  * remembers it.

--- a/packages/frontend/src/pages/import-export/components/recalculate-balance-toggle.vue
+++ b/packages/frontend/src/pages/import-export/components/recalculate-balance-toggle.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 /**
  * Import-wide "update account balances from imported transactions" checkbox,
- * shared by the CSV and Budget Bakers Wallet resolve steps. Purely presentational:
+ * shared by the CSV, Budget Bakers Wallet and MS Money wizards. Purely presentational:
  * the parent store owns the value (seeded from the persisted
  * `import.recalculateAccountBalance` user setting and written back on execute).
  */

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
@@ -6,7 +6,6 @@ import { Callout } from '@/components/lib/ui/callout';
 import { MappingTable, type MappingTableColumn } from '@/components/lib/ui/mapping-table';
 import { StatusIndicator } from '@/components/lib/ui/status-indicator';
 import { cn } from '@/lib/utils';
-import RecalculateBalanceToggle from '@/pages/import-export/components/recalculate-balance-toggle.vue';
 import { useCategoriesStore } from '@/stores/categories/categories';
 import { useImportExportStore } from '@/stores/import-export';
 import { useTagsStore } from '@/stores/tags';
@@ -428,13 +427,6 @@ async function handleNext() {
           </template>
         </MappingTable>
       </section>
-
-      <!-- ==================== BALANCE RECALCULATION ==================== -->
-      <RecalculateBalanceToggle
-        v-model="importStore.recalculateBalance"
-        :settings-loading="importStore.recalculateBalanceSettingLoading"
-        :settings-load-failed="importStore.recalculateBalanceSettingLoadFailed"
-      />
 
       <!-- Nav error -->
       <Callout v-if="navError" variant="destructive" role="alert">

--- a/packages/frontend/src/pages/import-export/components/review-duplicates-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/review-duplicates-step/index.vue
@@ -42,6 +42,12 @@
         </div>
       </div>
 
+      <RecalculateBalanceToggle
+        v-model="store.recalculateBalance"
+        :settings-loading="store.recalculateBalanceSettingLoading"
+        :settings-load-failed="store.recalculateBalanceSettingLoadFailed"
+      />
+
       <!-- Invalid rows table -->
       <section v-if="store.invalidRows.length > 0" aria-labelledby="invalid-rows-heading">
         <h3 id="invalid-rows-heading" class="text-destructive-text mb-3 text-sm font-semibold">
@@ -214,6 +220,7 @@ import { Callout } from '@/components/lib/ui/callout';
 import { MappingTable, type MappingTableColumn } from '@/components/lib/ui/mapping-table';
 import { StatCard } from '@/components/lib/ui/stat-card';
 import { StatusIndicator } from '@/components/lib/ui/status-indicator';
+import RecalculateBalanceToggle from '@/pages/import-export/components/recalculate-balance-toggle.vue';
 import { useImportExportStore } from '@/stores/import-export';
 import type { InvalidRow } from '@bt/shared/types';
 import { ChevronLeftIcon, ChevronRightIcon, LoaderCircleIcon } from '@lucide/vue';


### PR DESCRIPTION
The toggle lived on the Resolve Values step, which is skipped when the CSV has no account column, so users could never enable balance updates. Closes #495