### PR TITLE
Performance optimizations

### DIFF
--- a/.claude/skills/add-mcp-tool/SKILL.md
+++ b/.claude/skills/add-mcp-tool/SKILL.md
@@ -50,15 +50,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  someId: z.number().describe('...'),
+  optionalFilter: z.string().optional().describe('...'),
+};
+
 export function registerMyNewTool(server: McpServer) {
   server.registerTool(
     'my_new_tool',
     {
       description: 'What it returns and when an agent should call it. One sentence plus a hint on key fields.',
-      inputSchema: {
-        someId: z.number().describe('...'),
-        optionalFilter: z.string().optional().describe('...'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });
@@ -75,7 +77,7 @@ Rules:
 
 - Tool name is **snake_case** (matches MCP convention) and must exactly equal the string in `server-card.json`.
 - Register function is `register<PascalCase>`. File is `<kebab-case>.ts`.
-- `inputSchema` is a **plain object of Zod schemas** (no outer `z.object(...)`).
+- `inputSchema` is a **plain object of Zod schemas** (no outer `z.object(...)`), declared as a **module-scope `const`**, never inline inside `registerTool()`. Every MCP session builds its own `McpServer`, so an inline shape is rebuilt per session (zod v4 schemas are ~30 KB each).
 - For tools with no inputs: omit `inputSchema` and drop the `args` parameter — handler becomes `async (extra) => {...}`.
 - Always call `getUserId({ extra })` first — it enforces auth and returns `userId`.
 - Always call `trackMcpToolUsed({ userId, tool, clientId: extra.authInfo?.clientId })` immediately after.

--- a/packages/backend/src/common/lib/cls/logging.ts
+++ b/packages/backend/src/common/lib/cls/logging.ts
@@ -6,7 +6,7 @@ export const loggerNamespace = cls.createNamespace(NAMESPACE_NAME);
 
 const getNamespace = () => cls.getNamespace(NAMESPACE_NAME);
 
-const getFromNamespace = <T>(key: 'req' | 'requestId'): T | null => {
+const getFromNamespace = <T>(key: 'requestId'): T | null => {
   const namespace = getNamespace();
   return namespace ? namespace.get(key) : null;
 };

--- a/packages/backend/src/common/lib/cls/session-id.ts
+++ b/packages/backend/src/common/lib/cls/session-id.ts
@@ -7,7 +7,7 @@ export const sessionIdNamespace = cls.createNamespace(NAMESPACE_NAME);
 
 const getNamespace = () => cls.getNamespace(NAMESPACE_NAME);
 
-const getFromNamespace = <T>(key: 'req' | typeof SESSION_ID_KEY_NAME): T | null => {
+const getFromNamespace = <T>(key: typeof SESSION_ID_KEY_NAME): T | null => {
   const namespace = getNamespace();
   return namespace ? namespace.get(key) : null;
 };

--- a/packages/backend/src/config/auth.ts
+++ b/packages/backend/src/config/auth.ts
@@ -7,6 +7,7 @@ import { shouldUseSecureCookies } from '@config/should-use-secure-cookies';
 import { logger } from '@js/utils/logger';
 import { identifyUser, trackSignup } from '@js/utils/posthog';
 import { captureException } from '@js/utils/sentry';
+import { redisClient } from '@root/redis-client';
 import { sendEmail } from '@services/email/send-email';
 import { createAppUserWithUniqueUsername, seedUserDefaults } from '@services/user/create-user-with-defaults.service';
 import { areSignupsOpen } from '@services/user/signups-open.service';
@@ -41,6 +42,10 @@ const pool = new Pool({
 // In dev mode, trust the common localhost variants of the frontend port so a
 // self-host setup with a misconfigured ALLOWED_ORIGINS still completes auth.
 // Mirrors the localhost allow-list in setup-middleware.ts's CORS check.
+// Longest better-auth rate-limit window (core + plugins) is 60s; the limiter
+// resets from `lastRequest` itself, so a longer TTL only affects storage.
+const AUTH_RATE_LIMIT_TTL_SECONDS = 120;
+
 const DEV_TRUSTED_ORIGINS =
   process.env.NODE_ENV === 'development'
     ? ['http://localhost:8100', 'https://localhost:8100', 'http://127.0.0.1:8100', 'https://127.0.0.1:8100']
@@ -221,6 +226,17 @@ export const auth = betterAuth({
   // environments to avoid flaky Playwright tests and local dev friction.
   rateLimit: {
     enabled: process.env.NODE_ENV === 'production' && process.env.DISABLE_AUTH_RATE_LIMIT !== 'true',
+    // The default in-memory store only evicts a key when that same key is read
+    // again after expiry, so entries for IPs that never return are kept forever.
+    customStorage: {
+      get: async (key) => {
+        const raw = await redisClient.get(`auth-rate-limit:${key}`);
+        return raw ? JSON.parse(raw) : null;
+      },
+      set: async (key, value) => {
+        await redisClient.set(`auth-rate-limit:${key}`, JSON.stringify(value), 'EX', AUTH_RATE_LIMIT_TTL_SECONDS);
+      },
+    },
   },
 
   // Advanced options

--- a/packages/backend/src/middlewares/request-id.ts
+++ b/packages/backend/src/middlewares/request-id.ts
@@ -9,7 +9,6 @@ export const requestIdMiddleware = (req, res, next) => {
 
   loggerNamespace.run(() => {
     loggerNamespace.set('requestId', requestId);
-    loggerNamespace.set('req', req);
     next();
   });
 };

--- a/packages/backend/src/middlewares/session-id.ts
+++ b/packages/backend/src/middlewares/session-id.ts
@@ -42,7 +42,6 @@ export const sessionMiddleware = async (req: Request, res: Response, next: NextF
 
       sessionIdNamespace.run(() => {
         sessionIdNamespace.set(SESSION_ID_KEY_NAME, sessionId);
-        sessionIdNamespace.set('req', req);
 
         req[SESSION_ID_KEY_NAME] = sessionId;
         next();

--- a/packages/backend/src/routes/sse.route.ts
+++ b/packages/backend/src/routes/sse.route.ts
@@ -42,34 +42,29 @@ router.get('/events', authenticateSession, async (req, res) => {
   // Register client with SSE manager
   sseManager.addClient({ userId, res, connectionId });
 
+  const keepaliveInterval = setInterval(() => {
+    if (!res.writableEnded) res.write(': keepalive\n\n');
+  }, KEEPALIVE_INTERVAL_MS);
+
+  // Registered before the first await: 'close' is one-shot, so a client that
+  // drops during the sync-status lookup would otherwise never be removed.
+  res.on('close', () => {
+    clearInterval(keepaliveInterval);
+    sseManager.removeClient({ userId, res, connectionId });
+  });
+
   // Send initial sync status if there's an active sync
   try {
     const syncStatus = await getUserAccountsSyncStatus(userId);
     const hasActiveSync = syncStatus.summary.syncing > 0 || syncStatus.summary.queued > 0;
 
-    if (hasActiveSync) {
+    if (hasActiveSync && !res.writableEnded) {
       res.write(`event: ${SSE_EVENT_TYPES.SYNC_STATUS_CHANGED}\n`);
       res.write(`data: ${JSON.stringify(syncStatus)}\n\n`);
     }
   } catch (err) {
     logger.error({ message: '[SSE] Failed to send initial sync status', error: err as Error });
   }
-
-  // Set up keepalive interval for this specific connection
-  const keepaliveInterval = setInterval(() => {
-    try {
-      res.write(': keepalive\n\n');
-    } catch {
-      // Connection failed - cleanup will happen in 'close' handler
-      clearInterval(keepaliveInterval);
-    }
-  }, KEEPALIVE_INTERVAL_MS);
-
-  // Handle client disconnect
-  req.on('close', () => {
-    clearInterval(keepaliveInterval);
-    sseManager.removeClient({ userId, res, connectionId });
-  });
 });
 
 export default router;

--- a/packages/backend/src/services/data-export/writers/xlsx-writer.ts
+++ b/packages/backend/src/services/data-export/writers/xlsx-writer.ts
@@ -1,4 +1,5 @@
 import ExcelJS from 'exceljs';
+import { PassThrough } from 'stream';
 
 import { columnsFor } from '../registry';
 import { totalRowCount } from '../transformers/utils';
@@ -9,9 +10,19 @@ import type { ExportWriter, ExportWriterInput } from './types';
 const XLSX_MAX_SHEET_NAME = 31;
 
 async function writeXlsx({ tables }: { tables: ExportTable[] }): Promise<BuiltFile> {
-  const workbook = new ExcelJS.Workbook();
-  // Pin timestamps to the epoch so the same input produces the same bytes;
-  // SHA-256 round-trip tests assert that.
+  const chunks: Buffer[] = [];
+  const stream = new PassThrough();
+  stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+  const streamDone = new Promise<void>((resolve, reject) => {
+    stream.on('end', resolve);
+    stream.on('error', reject);
+  });
+
+  // The streaming writer serializes each row on commit() and drops it, instead
+  // of holding a cell object per value (~4 KB/row) plus the whole sheet XML
+  // until writeBuffer(). Timestamps are pinned to the epoch so the same input
+  // produces the same bytes; SHA-256 round-trip tests assert that.
+  const workbook = new ExcelJS.stream.xlsx.WorkbookWriter({ stream, useStyles: true });
   workbook.created = new Date(0);
   workbook.modified = new Date(0);
 
@@ -29,8 +40,7 @@ async function writeXlsx({ tables }: { tables: ExportTable[] }): Promise<BuiltFi
     sheetNames.add(sheetName);
     const sheet = workbook.addWorksheet(sheetName);
 
-    sheet.addRow(columns.map((c) => c.header));
-    const header = sheet.getRow(1);
+    const header = sheet.addRow(columns.map((c) => c.header));
     header.font = { bold: true };
     header.commit();
 
@@ -42,14 +52,17 @@ async function writeXlsx({ tables }: { tables: ExportTable[] }): Promise<BuiltFi
     });
 
     for (const row of table.rows as unknown as Record<string, unknown>[]) {
-      sheet.addRow(rowToValues({ columns, row }));
+      sheet.addRow(rowToValues({ columns, row })).commit();
     }
+    sheet.commit();
   }
 
-  const arrayBuffer = await workbook.xlsx.writeBuffer();
+  await workbook.commit();
+  await streamDone;
+
   return {
     filename: 'data-export.xlsx',
-    buffer: Buffer.from(arrayBuffer as ArrayBuffer),
+    buffer: Buffer.concat(chunks),
     rowCount: totalRowCount({ tables }),
   };
 }

--- a/packages/backend/src/services/mcp/tools/add-transactions-to-budget.ts
+++ b/packages/backend/src/services/mcp/tools/add-transactions-to-budget.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to link transactions to'),
+  transactionIds: z.array(recordId()).describe('IDs of the transactions to add to the budget'),
+};
+
 export function registerAddTransactionsToBudget(server: McpServer) {
   server.registerTool(
     'add_transactions_to_budget',
     {
       description:
         'Manually link one or more transactions to a manual-type budget. Category-type budgets do not support manual linking. Returns a success message on completion.',
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to link transactions to'),
-        transactionIds: z.array(recordId()).describe('IDs of the transactions to add to the budget'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/add-transactions-to-group.ts
+++ b/packages/backend/src/services/mcp/tools/add-transactions-to-group.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  groupId: recordId().describe('ID of the transaction group to add transactions to'),
+  transactionIds: z.array(recordId()).describe('IDs of transactions to add to the group'),
+};
+
 export function registerAddTransactionsToGroup(server: McpServer) {
   server.registerTool(
     'add_transactions_to_group',
     {
       description:
         'Add one or more transactions to an existing transaction group. Transfer pairs are auto-included. Returns the updated group with all its transactions. Requires finance:write scope.',
-      inputSchema: {
-        groupId: recordId().describe('ID of the transaction group to add transactions to'),
-        transactionIds: z.array(recordId()).describe('IDs of transactions to add to the group'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/adjust-account-balance.ts
+++ b/packages/backend/src/services/mcp/tools/adjust-account-balance.ts
@@ -7,19 +7,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  accountId: recordId().describe('ID of the account to adjust.'),
+  newBalance: z
+    .number()
+    .describe('Target balance as a decimal (e.g. 1500.00). An adjustment transaction is created for the diff.'),
+  note: z.string().optional().describe('Optional note to attach to the adjustment transaction.'),
+};
+
 export function registerAdjustAccountBalance(server: McpServer) {
   server.registerTool(
     'adjust_account_balance',
     {
       description:
         'Set an account to a specific balance by creating an adjustment transaction for the difference. Returns the previous balance, new balance, and the generated transaction (null if the balance was already at the target).',
-      inputSchema: {
-        accountId: recordId().describe('ID of the account to adjust.'),
-        newBalance: z
-          .number()
-          .describe('Target balance as a decimal (e.g. 1500.00). An adjustment transaction is created for the diff.'),
-        note: z.string().optional().describe('Optional note to attach to the adjustment transaction.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/archive-account.ts
+++ b/packages/backend/src/services/mcp/tools/archive-account.ts
@@ -7,16 +7,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  accountId: recordId().describe('ID of the account to archive or unarchive.'),
+  archived: z.boolean().describe('true to archive the account, false to unarchive (restore to active status).'),
+};
+
 export function registerArchiveAccount(server: McpServer) {
   server.registerTool(
     'archive_account',
     {
       description:
         'Archive or unarchive a user account. Archiving removes the account from groups and unlinks subscriptions. Set archived=false to restore an archived account to active status.',
-      inputSchema: {
-        accountId: recordId().describe('ID of the account to archive or unarchive.'),
-        archived: z.boolean().describe('true to archive the account, false to unarchive (restore to active status).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/archive-budget.ts
+++ b/packages/backend/src/services/mcp/tools/archive-budget.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to archive or unarchive'),
+  isArchived: z.boolean().describe('true to archive the budget, false to restore it to active'),
+};
+
 export function registerArchiveBudget(server: McpServer) {
   server.registerTool(
     'archive_budget',
     {
       description:
         'Archive or unarchive a budget. Pass isArchived: true to archive (sets status to "archived"), false to restore it to active. Returns the updated budget.',
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to archive or unarchive'),
-        isArchived: z.boolean().describe('true to archive the budget, false to restore it to active'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/assign-tags-to-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/assign-tags-to-transaction.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  tagId: recordId().describe('ID of the tag to assign.'),
+  transactionIds: z.array(recordId()).describe('List of transaction IDs to tag.'),
+};
+
 export function registerAssignTagsToTransaction(server: McpServer) {
   server.registerTool(
     'assign_tags_to_transaction',
     {
       description:
         'Assign one or more tags to a transaction. Use when the user wants to label a transaction with existing tags. Already-assigned tags are silently skipped. Returns counts of added and skipped tags.',
-      inputSchema: {
-        tagId: recordId().describe('ID of the tag to assign.'),
-        transactionIds: z.array(recordId()).describe('List of transaction IDs to tag.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/bulk-update-transactions.ts
+++ b/packages/backend/src/services/mcp/tools/bulk-update-transactions.ts
@@ -6,22 +6,24 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  transactionIds: z.array(recordId()).min(1).describe('IDs of transactions to update'),
+  categoryId: recordId().optional().describe('New category ID to assign to all transactions'),
+  tagIds: z.array(recordId()).optional().describe('Tag IDs to apply according to tagMode'),
+  tagMode: z
+    .enum(['add', 'replace', 'remove'])
+    .optional()
+    .describe('How to apply tagIds: add (default) appends, replace overwrites, remove removes those tags'),
+  note: z.string().optional().describe('Note to set on all transactions'),
+};
+
 export function registerBulkUpdateTransactions(server: McpServer) {
   server.registerTool(
     'bulk_update_transactions',
     {
       description:
         'Update multiple transactions at once. Provide transactionIds plus at least one of categoryId, tagIds, or note. Tags can be added to, removed from, or replaced on all specified transactions.',
-      inputSchema: {
-        transactionIds: z.array(recordId()).min(1).describe('IDs of transactions to update'),
-        categoryId: recordId().optional().describe('New category ID to assign to all transactions'),
-        tagIds: z.array(recordId()).optional().describe('Tag IDs to apply according to tagMode'),
-        tagMode: z
-          .enum(['add', 'replace', 'remove'])
-          .optional()
-          .describe('How to apply tagIds: add (default) appends, replace overwrites, remove removes those tags'),
-        note: z.string().optional().describe('Note to set on all transactions'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-budget.ts
+++ b/packages/backend/src/services/mcp/tools/create-budget.ts
@@ -8,39 +8,38 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Budget name'),
+  status: z
+    .enum([BUDGET_STATUSES.active, BUDGET_STATUSES.archived, BUDGET_STATUSES.closed])
+    .optional()
+    .describe('Budget status (default: active)'),
+  type: z
+    .enum([BUDGET_TYPES.manual, BUDGET_TYPES.category])
+    .optional()
+    .describe(
+      'Budget type: manual (transactions linked explicitly) or category (auto-tracks by category). Default: manual',
+    ),
+  categoryIds: z.array(recordId()).optional().describe('Category IDs to link (only used when type is "category")'),
+  startDate: z.string().optional().describe('Budget start date (ISO 8601)'),
+  endDate: z.string().optional().describe('Budget end date (ISO 8601)'),
+  autoInclude: z
+    .boolean()
+    .optional()
+    .describe('Auto-include transactions in the date range when creating (manual budgets only)'),
+  limitAmount: z
+    .number()
+    .optional()
+    .describe("Spending limit as a decimal amount in the user's base currency (e.g. 500.00)"),
+};
+
 export function registerCreateBudget(server: McpServer) {
   server.registerTool(
     'create_budget',
     {
       description:
         'Create a new budget with an optional spending limit, date range, and linked categories. Returns the created budget with its ID, status, type, and associated categories.',
-      inputSchema: {
-        name: z.string().describe('Budget name'),
-        status: z
-          .enum([BUDGET_STATUSES.active, BUDGET_STATUSES.archived, BUDGET_STATUSES.closed])
-          .optional()
-          .describe('Budget status (default: active)'),
-        type: z
-          .enum([BUDGET_TYPES.manual, BUDGET_TYPES.category])
-          .optional()
-          .describe(
-            'Budget type: manual (transactions linked explicitly) or category (auto-tracks by category). Default: manual',
-          ),
-        categoryIds: z
-          .array(recordId())
-          .optional()
-          .describe('Category IDs to link (only used when type is "category")'),
-        startDate: z.string().optional().describe('Budget start date (ISO 8601)'),
-        endDate: z.string().optional().describe('Budget end date (ISO 8601)'),
-        autoInclude: z
-          .boolean()
-          .optional()
-          .describe('Auto-include transactions in the date range when creating (manual budgets only)'),
-        limitAmount: z
-          .number()
-          .optional()
-          .describe("Spending limit as a decimal amount in the user's base currency (e.g. 500.00)"),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-category.ts
+++ b/packages/backend/src/services/mcp/tools/create-category.ts
@@ -7,22 +7,24 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Category name.'),
+  color: z.string().optional().describe('Hex color code (e.g. "#4CAF50"). Inherited from parent if omitted.'),
+  icon: z.string().nullable().optional().describe('Optional icon identifier for the category.'),
+  parentId: recordId().optional().describe('ID of the parent category to create a subcategory.'),
+  type: z
+    .enum([CATEGORY_TYPES.custom, CATEGORY_TYPES.internal])
+    .optional()
+    .describe('Category type: "custom" (default, user-editable) or "internal" (system-managed).'),
+};
+
 export function registerCreateCategory(server: McpServer) {
   server.registerTool(
     'create_category',
     {
       description:
         'Create a new transaction category. Supports nested categories via parentId — child categories inherit the parent color if none is provided. Use when the user wants a new category to classify transactions.',
-      inputSchema: {
-        name: z.string().describe('Category name.'),
-        color: z.string().optional().describe('Hex color code (e.g. "#4CAF50"). Inherited from parent if omitted.'),
-        icon: z.string().nullable().optional().describe('Optional icon identifier for the category.'),
-        parentId: recordId().optional().describe('ID of the parent category to create a subcategory.'),
-        type: z
-          .enum([CATEGORY_TYPES.custom, CATEGORY_TYPES.internal])
-          .optional()
-          .describe('Category type: "custom" (default, user-editable) or "internal" (system-managed).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-investment-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/create-investment-transaction.ts
@@ -7,37 +7,39 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
+  securityId: recordId().describe('Security ID — resolve via search_securities first'),
+  category: z
+    .enum([
+      INVESTMENT_TRANSACTION_CATEGORY.buy,
+      INVESTMENT_TRANSACTION_CATEGORY.sell,
+      INVESTMENT_TRANSACTION_CATEGORY.dividend,
+      INVESTMENT_TRANSACTION_CATEGORY.transfer,
+      INVESTMENT_TRANSACTION_CATEGORY.tax,
+      INVESTMENT_TRANSACTION_CATEGORY.fee,
+      INVESTMENT_TRANSACTION_CATEGORY.cancel,
+      INVESTMENT_TRANSACTION_CATEGORY.other,
+    ])
+    .describe('Transaction type: buy, sell, dividend, transfer, tax, fee, cancel, or other'),
+  date: z
+    .union([z.string().date(), z.string().datetime({ offset: true })])
+    .describe(
+      'When the trade occurred. Accepts a date-only value (ISO 8601, e.g. "2024-03-15") or a full datetime (e.g. "2024-03-15T09:30:00.000Z"); date-only is stored at UTC midnight.',
+    ),
+  quantity: z.string().describe('Number of shares/units as a decimal string (e.g. "10.5")'),
+  price: z.string().describe('Price per share/unit as a decimal string (e.g. "150.00")'),
+  fees: z.string().describe('Transaction fees/commissions as a decimal string (e.g. "0.00")'),
+  name: z.string().optional().describe('Optional label or note for this transaction'),
+};
+
 export function registerCreateInvestmentTransaction(server: McpServer) {
   server.registerTool(
     'create_investment_transaction',
     {
       description:
         'Record a new investment transaction (buy, sell, dividend, fee, etc.) in a portfolio. The security must already exist in the portfolio as a holding — call search_securities to resolve a ticker to a securityId, then ensure a holding exists. quantity, price, and fees are decimal strings (e.g. "10.5", "150.00", "0.00").',
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
-        securityId: recordId().describe('Security ID — resolve via search_securities first'),
-        category: z
-          .enum([
-            INVESTMENT_TRANSACTION_CATEGORY.buy,
-            INVESTMENT_TRANSACTION_CATEGORY.sell,
-            INVESTMENT_TRANSACTION_CATEGORY.dividend,
-            INVESTMENT_TRANSACTION_CATEGORY.transfer,
-            INVESTMENT_TRANSACTION_CATEGORY.tax,
-            INVESTMENT_TRANSACTION_CATEGORY.fee,
-            INVESTMENT_TRANSACTION_CATEGORY.cancel,
-            INVESTMENT_TRANSACTION_CATEGORY.other,
-          ])
-          .describe('Transaction type: buy, sell, dividend, transfer, tax, fee, cancel, or other'),
-        date: z
-          .union([z.string().date(), z.string().datetime({ offset: true })])
-          .describe(
-            'When the trade occurred. Accepts a date-only value (ISO 8601, e.g. "2024-03-15") or a full datetime (e.g. "2024-03-15T09:30:00.000Z"); date-only is stored at UTC midnight.',
-          ),
-        quantity: z.string().describe('Number of shares/units as a decimal string (e.g. "10.5")'),
-        price: z.string().describe('Price per share/unit as a decimal string (e.g. "150.00")'),
-        fees: z.string().describe('Transaction fees/commissions as a decimal string (e.g. "0.00")'),
-        name: z.string().optional().describe('Optional label or note for this transaction'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-payee.ts
+++ b/packages/backend/src/services/mcp/tools/create-payee.ts
@@ -5,19 +5,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Display name for the Payee, max 200 chars.'),
+  defaultCategoryId: z
+    .string()
+    .optional()
+    .describe('Optional category id automatically applied to future transactions linked to this Payee.'),
+};
+
 export function registerCreatePayee(server: McpServer) {
   server.registerTool(
     'create_payee',
     {
       description:
         'Create a Payee (merchant/counterparty) for the user. Use when the user wants to register a new merchant before linking transactions. Returns the created Payee.',
-      inputSchema: {
-        name: z.string().describe('Display name for the Payee, max 200 chars.'),
-        defaultCategoryId: z
-          .string()
-          .optional()
-          .describe('Optional category id automatically applied to future transactions linked to this Payee.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-portfolio.ts
+++ b/packages/backend/src/services/mcp/tools/create-portfolio.ts
@@ -6,20 +6,22 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Portfolio name (must be unique for this user)'),
+  portfolioType: z
+    .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
+    .describe('Type of portfolio: investment, retirement, savings, or other'),
+  description: z.string().optional().describe('Optional description of the portfolio'),
+  isEnabled: z.boolean().optional().describe('Whether the portfolio is active (default: true)'),
+};
+
 export function registerCreatePortfolio(server: McpServer) {
   server.registerTool(
     'create_portfolio',
     {
       description:
         'Create a new investment portfolio for the user. Use when the user wants to track a new brokerage account, retirement fund, or savings vehicle. Returns the created portfolio with its id, which can then be used with create_investment_transaction and get_portfolio_holdings.',
-      inputSchema: {
-        name: z.string().describe('Portfolio name (must be unique for this user)'),
-        portfolioType: z
-          .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
-          .describe('Type of portfolio: investment, retirement, savings, or other'),
-        description: z.string().optional().describe('Optional description of the portfolio'),
-        isEnabled: z.boolean().optional().describe('Whether the portfolio is active (default: true)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-subscription.ts
+++ b/packages/backend/src/services/mcp/tools/create-subscription.ts
@@ -7,60 +7,62 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Display name of the subscription (e.g. "Netflix", "Electricity")'),
+  frequency: z
+    .enum([
+      SUBSCRIPTION_FREQUENCIES.weekly,
+      SUBSCRIPTION_FREQUENCIES.biweekly,
+      SUBSCRIPTION_FREQUENCIES.monthly,
+      SUBSCRIPTION_FREQUENCIES.quarterly,
+      SUBSCRIPTION_FREQUENCIES.semiAnnual,
+      SUBSCRIPTION_FREQUENCIES.annual,
+    ])
+    .describe('Billing frequency: weekly, biweekly, monthly, quarterly, semi_annual, annual'),
+  startDate: z.string().describe('Start date of the subscription (ISO 8601, e.g. "2024-01-01")'),
+  type: z
+    .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
+    .optional()
+    .describe('Type: "subscription" (default), "bill", or "installment"'),
+  transactionType: z
+    .enum([TRANSACTION_TYPES.expense, TRANSACTION_TYPES.income])
+    .optional()
+    .describe('Transaction type: "expense" (default) or "income"'),
+  expectedAmount: z
+    .number()
+    .nullable()
+    .optional()
+    .describe('Expected payment amount as a decimal (e.g. 9.99). Use with expectedCurrencyCode'),
+  expectedCurrencyCode: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('Currency code for expectedAmount (e.g. "USD", "EUR")'),
+  endDate: z.string().nullable().optional().describe('End date if the subscription is finite (ISO 8601)'),
+  dueDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('First payment date (ISO 8601). Required for installments; enables a payment schedule.'),
+  maxOccurrences: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe('Total number of payments. Required for installments; null/omitted means an indefinite schedule.'),
+  accountId: recordId().nullable().optional().describe('Account ID to associate with this subscription'),
+  categoryId: recordId().nullable().optional().describe('Category ID to associate with this subscription'),
+  notes: z.string().nullable().optional().describe('Additional notes about the subscription'),
+};
+
 export function registerCreateSubscription(server: McpServer) {
   server.registerTool(
     'create_subscription',
     {
       description:
         'Create a new subscription, recurring bill, or installment plan. Use type="subscription" for SaaS/streaming services, type="bill" for utilities, and type="installment" for a finite financed purchase paid off over a fixed number of payments. An installment requires maxOccurrences (number of payments) and dueDate (first payment date). expectedAmount is a decimal in the subscription currency. Requires finance:write scope.',
-      inputSchema: {
-        name: z.string().describe('Display name of the subscription (e.g. "Netflix", "Electricity")'),
-        frequency: z
-          .enum([
-            SUBSCRIPTION_FREQUENCIES.weekly,
-            SUBSCRIPTION_FREQUENCIES.biweekly,
-            SUBSCRIPTION_FREQUENCIES.monthly,
-            SUBSCRIPTION_FREQUENCIES.quarterly,
-            SUBSCRIPTION_FREQUENCIES.semiAnnual,
-            SUBSCRIPTION_FREQUENCIES.annual,
-          ])
-          .describe('Billing frequency: weekly, biweekly, monthly, quarterly, semi_annual, annual'),
-        startDate: z.string().describe('Start date of the subscription (ISO 8601, e.g. "2024-01-01")'),
-        type: z
-          .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
-          .optional()
-          .describe('Type: "subscription" (default), "bill", or "installment"'),
-        transactionType: z
-          .enum([TRANSACTION_TYPES.expense, TRANSACTION_TYPES.income])
-          .optional()
-          .describe('Transaction type: "expense" (default) or "income"'),
-        expectedAmount: z
-          .number()
-          .nullable()
-          .optional()
-          .describe('Expected payment amount as a decimal (e.g. 9.99). Use with expectedCurrencyCode'),
-        expectedCurrencyCode: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('Currency code for expectedAmount (e.g. "USD", "EUR")'),
-        endDate: z.string().nullable().optional().describe('End date if the subscription is finite (ISO 8601)'),
-        dueDate: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('First payment date (ISO 8601). Required for installments; enables a payment schedule.'),
-        maxOccurrences: z
-          .number()
-          .int()
-          .positive()
-          .nullable()
-          .optional()
-          .describe('Total number of payments. Required for installments; null/omitted means an indefinite schedule.'),
-        accountId: recordId().nullable().optional().describe('Account ID to associate with this subscription'),
-        categoryId: recordId().nullable().optional().describe('Category ID to associate with this subscription'),
-        notes: z.string().nullable().optional().describe('Additional notes about the subscription'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-tag.ts
+++ b/packages/backend/src/services/mcp/tools/create-tag.ts
@@ -5,18 +5,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Tag name (must be unique for this user).'),
+  color: z.string().describe('Hex color code for the tag (e.g. "#FF5733").'),
+  icon: z.string().optional().describe('Optional icon identifier for the tag.'),
+  description: z.string().optional().describe('Optional description of the tag.'),
+};
+
 export function registerCreateTag(server: McpServer) {
   server.registerTool(
     'create_tag',
     {
       description:
         'Create a new tag that can be assigned to transactions. Use when the user wants to label or categorize transactions with a custom tag. Returns the created tag with its ID.',
-      inputSchema: {
-        name: z.string().describe('Tag name (must be unique for this user).'),
-        color: z.string().describe('Hex color code for the tag (e.g. "#FF5733").'),
-        icon: z.string().optional().describe('Optional icon identifier for the tag.'),
-        description: z.string().optional().describe('Optional description of the tag.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-transaction-group.ts
+++ b/packages/backend/src/services/mcp/tools/create-transaction-group.ts
@@ -6,19 +6,19 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Display name for the group'),
+  transactionIds: z.array(recordId()).describe('IDs of transactions to include in the group (minimum 2, maximum 50)'),
+  note: z.string().optional().describe('Optional note or description for the group'),
+};
+
 export function registerCreateTransactionGroup(server: McpServer) {
   server.registerTool(
     'create_transaction_group',
     {
       description:
         'Create a new transaction group that bundles related transactions together (e.g. a split bill). Requires at least 2 transactions. Transfer pairs are automatically included. Requires finance:write scope.',
-      inputSchema: {
-        name: z.string().describe('Display name for the group'),
-        transactionIds: z
-          .array(recordId())
-          .describe('IDs of transactions to include in the group (minimum 2, maximum 50)'),
-        note: z.string().optional().describe('Optional note or description for the group'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/create-transaction.ts
@@ -8,65 +8,61 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  accountId: recordId().describe('ID of the account the transaction belongs to'),
+  amount: z.number().describe('Transaction amount as a decimal (e.g. 12.50)'),
+  transactionType: z
+    .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
+    .describe('Whether this is income or expense'),
+  paymentType: z
+    .enum([
+      PAYMENT_TYPES.bankTransfer,
+      PAYMENT_TYPES.cash,
+      PAYMENT_TYPES.creditCard,
+      PAYMENT_TYPES.debitCard,
+      PAYMENT_TYPES.mobilePayment,
+      PAYMENT_TYPES.voucher,
+      PAYMENT_TYPES.webPayment,
+    ])
+    .describe('Payment method used'),
+  transferNature: z
+    .enum([
+      TRANSACTION_TRANSFER_NATURE.not_transfer,
+      TRANSACTION_TRANSFER_NATURE.common_transfer,
+      TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    ])
+    .describe('Transfer type. Use not_transfer for regular income/expense'),
+  categoryId: recordId().optional().describe('Category ID to assign to this transaction'),
+  time: z.string().optional().describe('Transaction date/time as ISO 8601 string. Defaults to now'),
+  note: z.string().optional().describe('Optional note or description for the transaction'),
+  destinationAccountId: recordId().optional().describe('For transfers: destination account ID'),
+  destinationAmount: z.number().optional().describe('For transfers: amount received in destination account (decimal)'),
+  destinationTransactionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('For transfers: link to an existing destination transaction instead of creating one'),
+  splits: z
+    .array(
+      z.object({
+        categoryId: recordId().describe('Category ID for this split portion'),
+        amount: z.number().describe('Amount for this split portion (decimal)'),
+        note: z.string().optional().nullable().describe('Optional note for this split'),
+      }),
+    )
+    .optional()
+    .describe('Split the transaction across multiple categories'),
+  tagIds: z.array(recordId()).optional().describe('Tag IDs to assign to this transaction'),
+  isPlanned: z.boolean().optional().describe('Mark the transaction as planned rather than an already-happened record'),
+};
+
 export function registerCreateTransaction(server: McpServer) {
   server.registerTool(
     'create_transaction',
     {
       description:
         'Create a new transaction (income, expense, or transfer). Requires accountId, amount (decimal), transactionType, paymentType, and transferNature. For transfers, also provide destinationAccountId and destinationAmount. Use splits to categorize portions of the amount.',
-      inputSchema: {
-        accountId: recordId().describe('ID of the account the transaction belongs to'),
-        amount: z.number().describe('Transaction amount as a decimal (e.g. 12.50)'),
-        transactionType: z
-          .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
-          .describe('Whether this is income or expense'),
-        paymentType: z
-          .enum([
-            PAYMENT_TYPES.bankTransfer,
-            PAYMENT_TYPES.cash,
-            PAYMENT_TYPES.creditCard,
-            PAYMENT_TYPES.debitCard,
-            PAYMENT_TYPES.mobilePayment,
-            PAYMENT_TYPES.voucher,
-            PAYMENT_TYPES.webPayment,
-          ])
-          .describe('Payment method used'),
-        transferNature: z
-          .enum([
-            TRANSACTION_TRANSFER_NATURE.not_transfer,
-            TRANSACTION_TRANSFER_NATURE.common_transfer,
-            TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
-          ])
-          .describe('Transfer type. Use not_transfer for regular income/expense'),
-        categoryId: recordId().optional().describe('Category ID to assign to this transaction'),
-        time: z.string().optional().describe('Transaction date/time as ISO 8601 string. Defaults to now'),
-        note: z.string().optional().describe('Optional note or description for the transaction'),
-        destinationAccountId: recordId().optional().describe('For transfers: destination account ID'),
-        destinationAmount: z
-          .number()
-          .optional()
-          .describe('For transfers: amount received in destination account (decimal)'),
-        destinationTransactionId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('For transfers: link to an existing destination transaction instead of creating one'),
-        splits: z
-          .array(
-            z.object({
-              categoryId: recordId().describe('Category ID for this split portion'),
-              amount: z.number().describe('Amount for this split portion (decimal)'),
-              note: z.string().optional().nullable().describe('Optional note for this split'),
-            }),
-          )
-          .optional()
-          .describe('Split the transaction across multiple categories'),
-        tagIds: z.array(recordId()).optional().describe('Tag IDs to assign to this transaction'),
-        isPlanned: z
-          .boolean()
-          .optional()
-          .describe('Mark the transaction as planned rather than an already-happened record'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-venture-deal.ts
+++ b/packages/backend/src/services/mcp/tools/create-venture-deal.ts
@@ -7,48 +7,50 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Deal name (e.g. "SK 116 — Series A")'),
+  currencyCode: currencyCode().describe('Three-letter ISO currency code (e.g. "USD")'),
+  principal: decimalString().describe('Principal amount as a decimal string (e.g. "16000")'),
+  investmentDate: dateString().describe('Investment date in YYYY-MM-DD'),
+  platformId: recordId().nullable().optional().describe('Optional platform id (from list_venture_platforms)'),
+  spvSubtype: z
+    .nativeEnum(VENTURE_SPV_SUBTYPE)
+    .nullable()
+    .optional()
+    .describe('SPV subtype: single_company or multi_company'),
+  targetCompany: z.string().nullable().optional().describe('Free-text portfolio company name'),
+  entryFeePct: percentageFraction()
+    .optional()
+    .describe('Entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%).'),
+  entryFee: decimalString()
+    .optional()
+    .describe('Entry fee absolute amount in currency units. Defaults to principal * entryFeePct.'),
+  mgmtFeePct: percentageFraction().optional().describe('Management fee as a decimal fraction in [0,1].'),
+  carryPct: percentageFraction().optional().describe('Carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%).'),
+  hurdlePct: percentageFraction().optional().describe('Hurdle rate as a decimal fraction in [0,1].'),
+  expectedExitDate: dateString().nullable().optional().describe('Expected exit date (YYYY-MM-DD)'),
+  notes: z.string().nullable().optional().describe('Free-text notes'),
+  initialInvestment: z
+    .object({
+      cashFlowMode: z.enum([VENTURE_CASH_FLOW_MODE.linked, VENTURE_CASH_FLOW_MODE.out_of_wallet]),
+      transactionIds: z
+        .array(recordId())
+        .optional()
+        .describe('Required when cashFlowMode=linked. Sum of linked tx amounts must equal principal + entryFee.'),
+    })
+    .optional()
+    .describe(
+      'Optional: also create the initial_investment event in the same transaction. cashFlowMode=out_of_wallet records the investment without linking to bank txs (event amount is stored but not reflected on cash-flow charts).',
+    ),
+};
+
 export function registerCreateVentureDeal(server: McpServer) {
   server.registerTool(
     'create_venture_deal',
     {
       description:
         'Create a venture deal (private/illiquid investment record). All monetary amounts are decimal strings in the deal\'s currency (e.g. "16000"). Fee percentages are decimal fractions in [0,1] — e.g. 0.085 for 8.5%, NOT 8.5. If platformId is provided, omitted fee fields are auto-filled from the platform\'s defaults. Optionally creates the initial_investment event in the same operation when `initialInvestment` is supplied. Only the SPV vehicle type is supported in v1.',
-      inputSchema: {
-        name: z.string().describe('Deal name (e.g. "SK 116 — Series A")'),
-        currencyCode: currencyCode().describe('Three-letter ISO currency code (e.g. "USD")'),
-        principal: decimalString().describe('Principal amount as a decimal string (e.g. "16000")'),
-        investmentDate: dateString().describe('Investment date in YYYY-MM-DD'),
-        platformId: recordId().nullable().optional().describe('Optional platform id (from list_venture_platforms)'),
-        spvSubtype: z
-          .nativeEnum(VENTURE_SPV_SUBTYPE)
-          .nullable()
-          .optional()
-          .describe('SPV subtype: single_company or multi_company'),
-        targetCompany: z.string().nullable().optional().describe('Free-text portfolio company name'),
-        entryFeePct: percentageFraction()
-          .optional()
-          .describe('Entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%).'),
-        entryFee: decimalString()
-          .optional()
-          .describe('Entry fee absolute amount in currency units. Defaults to principal * entryFeePct.'),
-        mgmtFeePct: percentageFraction().optional().describe('Management fee as a decimal fraction in [0,1].'),
-        carryPct: percentageFraction().optional().describe('Carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%).'),
-        hurdlePct: percentageFraction().optional().describe('Hurdle rate as a decimal fraction in [0,1].'),
-        expectedExitDate: dateString().nullable().optional().describe('Expected exit date (YYYY-MM-DD)'),
-        notes: z.string().nullable().optional().describe('Free-text notes'),
-        initialInvestment: z
-          .object({
-            cashFlowMode: z.enum([VENTURE_CASH_FLOW_MODE.linked, VENTURE_CASH_FLOW_MODE.out_of_wallet]),
-            transactionIds: z
-              .array(recordId())
-              .optional()
-              .describe('Required when cashFlowMode=linked. Sum of linked tx amounts must equal principal + entryFee.'),
-          })
-          .optional()
-          .describe(
-            'Optional: also create the initial_investment event in the same transaction. cashFlowMode=out_of_wallet records the investment without linking to bank txs (event amount is stored but not reflected on cash-flow charts).',
-          ),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-venture-event.ts
+++ b/packages/backend/src/services/mcp/tools/create-venture-event.ts
@@ -7,47 +7,49 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+  type: z.nativeEnum(VENTURE_EVENT_TYPE).describe('Event type'),
+  eventDate: dateString().describe('Event date in YYYY-MM-DD'),
+  cashFlowMode: z
+    .nativeEnum(VENTURE_CASH_FLOW_MODE)
+    .describe(
+      'linked = tie to existing bank txs; out_of_wallet = record event only; none = required for nav_update / writedown',
+    ),
+  grossAmount: decimalString()
+    .nullable()
+    .optional()
+    .describe('Gross amount (decimal string). Required for capital_call, fee_payment, distribution, exit.'),
+  navAfter: decimalString()
+    .nullable()
+    .optional()
+    .describe('Post-event NAV (decimal string). Required for nav_update, writedown, AND exit.'),
+  quantityPct: decimalString()
+    .nullable()
+    .optional()
+    .describe('Optional partial-exit quantity fraction in [0,1] (used for partial exits).'),
+  transactionIds: z
+    .array(recordId())
+    .optional()
+    .describe('Bank transaction ids to link. Required when cashFlowMode=linked; must NOT be provided otherwise.'),
+  lpNetAmountOverride: decimalString()
+    .nullable()
+    .optional()
+    .describe('Override the auto-computed lpNetAmount (distribution/exit only).'),
+  gpCarryOverride: decimalString()
+    .nullable()
+    .optional()
+    .describe('Override the auto-computed gpCarryAmount (distribution/exit only).'),
+  notes: z.string().nullable().optional().describe('Free-text notes'),
+};
+
 export function registerCreateVentureEvent(server: McpServer) {
   server.registerTool(
     'create_venture_event',
     {
       description:
         "Record an event on a venture deal. The deal must already have an initial_investment before any other event type can be created (initial_investment must come first). Event date cannot precede the initial_investment date.\n\nRules per type (the schema is flat but the service enforces these — invalid combinations return a clear ValidationError):\n  • initial_investment: grossAmount is auto-derived from the deal's principal + entryFee — do NOT pass it. cashFlowMode must be 'linked' or 'out_of_wallet'.\n  • capital_call, fee_payment, distribution: require grossAmount. cashFlowMode must be 'linked' or 'out_of_wallet'.\n  • exit: requires grossAmount AND navAfter. cashFlowMode must be 'linked' or 'out_of_wallet'.\n  • nav_update, writedown: require navAfter. cashFlowMode must be 'none'.\n\nFor cashFlowMode='linked', the sum of linked transactions' amounts must equal the event's lpNetAmount (derived from grossAmount minus auto-computed carry for distribution/exit). For cashFlowMode='out_of_wallet', no transactions are linked — the event amount is recorded but does NOT affect bank balances or cash-flow charts.\n\nCarry on distribution/exit is auto-computed (European waterfall by default). Pass `lpNetAmountOverride` / `gpCarryOverride` to override the computed values (e.g. when matching a GP's statement).",
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-        type: z.nativeEnum(VENTURE_EVENT_TYPE).describe('Event type'),
-        eventDate: dateString().describe('Event date in YYYY-MM-DD'),
-        cashFlowMode: z
-          .nativeEnum(VENTURE_CASH_FLOW_MODE)
-          .describe(
-            'linked = tie to existing bank txs; out_of_wallet = record event only; none = required for nav_update / writedown',
-          ),
-        grossAmount: decimalString()
-          .nullable()
-          .optional()
-          .describe('Gross amount (decimal string). Required for capital_call, fee_payment, distribution, exit.'),
-        navAfter: decimalString()
-          .nullable()
-          .optional()
-          .describe('Post-event NAV (decimal string). Required for nav_update, writedown, AND exit.'),
-        quantityPct: decimalString()
-          .nullable()
-          .optional()
-          .describe('Optional partial-exit quantity fraction in [0,1] (used for partial exits).'),
-        transactionIds: z
-          .array(recordId())
-          .optional()
-          .describe('Bank transaction ids to link. Required when cashFlowMode=linked; must NOT be provided otherwise.'),
-        lpNetAmountOverride: decimalString()
-          .nullable()
-          .optional()
-          .describe('Override the auto-computed lpNetAmount (distribution/exit only).'),
-        gpCarryOverride: decimalString()
-          .nullable()
-          .optional()
-          .describe('Override the auto-computed gpCarryAmount (distribution/exit only).'),
-        notes: z.string().nullable().optional().describe('Free-text notes'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/create-venture-platform.ts
+++ b/packages/backend/src/services/mcp/tools/create-venture-platform.ts
@@ -6,29 +6,31 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  name: z.string().describe('Platform name (must be unique for this user)'),
+  website: z.string().nullable().optional().describe('Platform website URL'),
+  description: z.string().nullable().optional().describe('Free-text description'),
+  defaultEntryFeePct: percentageFraction()
+    .optional()
+    .describe('Default entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%). Defaults to 0.'),
+  defaultMgmtFeePct: percentageFraction()
+    .optional()
+    .describe('Default management fee as a decimal fraction in [0,1]. Defaults to 0.'),
+  defaultCarryPct: percentageFraction()
+    .optional()
+    .describe('Default carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%). Defaults to 0.'),
+  defaultHurdlePct: percentageFraction()
+    .optional()
+    .describe('Default hurdle rate as a decimal fraction in [0,1]. Defaults to 0.'),
+};
+
 export function registerCreateVenturePlatform(server: McpServer) {
   server.registerTool(
     'create_venture_platform',
     {
       description:
         "Create a venture investment platform (e.g. AngelList, a syndicate, a fund manager) so its default fees can be auto-applied when creating new deals. Fee fields are decimal fractions in [0,1] — e.g. pass 0.085 for 8.5%, NOT 8.5. Returns the created platform's id for use with create_venture_deal.",
-      inputSchema: {
-        name: z.string().describe('Platform name (must be unique for this user)'),
-        website: z.string().nullable().optional().describe('Platform website URL'),
-        description: z.string().nullable().optional().describe('Free-text description'),
-        defaultEntryFeePct: percentageFraction()
-          .optional()
-          .describe('Default entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%). Defaults to 0.'),
-        defaultMgmtFeePct: percentageFraction()
-          .optional()
-          .describe('Default management fee as a decimal fraction in [0,1]. Defaults to 0.'),
-        defaultCarryPct: percentageFraction()
-          .optional()
-          .describe('Default carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%). Defaults to 0.'),
-        defaultHurdlePct: percentageFraction()
-          .optional()
-          .describe('Default hurdle rate as a decimal fraction in [0,1]. Defaults to 0.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-budget.ts
+++ b/packages/backend/src/services/mcp/tools/delete-budget.ts
@@ -5,15 +5,17 @@ import { deleteBudget } from '@services/budgets/delete-budget';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to delete'),
+};
+
 export function registerDeleteBudget(server: McpServer) {
   server.registerTool(
     'delete_budget',
     {
       description:
         'Permanently delete a budget and all its transaction links. This action cannot be undone. Returns { success: true } on completion.',
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to delete'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-category.ts
+++ b/packages/backend/src/services/mcp/tools/delete-category.ts
@@ -6,22 +6,22 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  categoryId: recordId().describe('ID of the category to delete.'),
+  replaceWithCategoryId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('ID of the category to reassign linked transactions to. Required when the category has transactions.'),
+};
+
 export function registerDeleteCategory(server: McpServer) {
   server.registerTool(
     'delete_category',
     {
       description:
         'Permanently delete a category by ID. This is destructive — if the category has linked transactions you must supply replaceWithCategoryId to reassign them first, otherwise the call will fail. Cannot delete a parent category that still has subcategories. Only call when the user explicitly confirms deletion.',
-      inputSchema: {
-        categoryId: recordId().describe('ID of the category to delete.'),
-        replaceWithCategoryId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe(
-            'ID of the category to reassign linked transactions to. Required when the category has transactions.',
-          ),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-investment-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/delete-investment-transaction.ts
@@ -5,18 +5,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  transactionId: z.string().uuid().describe('Investment transaction ID to delete (from get_investment_transactions)'),
+};
+
 export function registerDeleteInvestmentTransaction(server: McpServer) {
   server.registerTool(
     'delete_investment_transaction',
     {
       description:
         'Permanently delete an investment transaction. The holding and portfolio cash balance are automatically recalculated after deletion. This action is irreversible — confirm with the user before calling. Obtain transactionId from get_investment_transactions.',
-      inputSchema: {
-        transactionId: z
-          .string()
-          .uuid()
-          .describe('Investment transaction ID to delete (from get_investment_transactions)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-payee.ts
+++ b/packages/backend/src/services/mcp/tools/delete-payee.ts
@@ -5,15 +5,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('Payee id to delete.'),
+};
+
 export function registerDeletePayee(server: McpServer) {
   server.registerTool(
     'delete_payee',
     {
       description:
         'Delete a Payee. Linked transactions retain their categoryId but their payeeId is set to null. Use cautiously — this is irreversible.',
-      inputSchema: {
-        id: z.string().describe('Payee id to delete.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-portfolio.ts
+++ b/packages/backend/src/services/mcp/tools/delete-portfolio.ts
@@ -6,21 +6,23 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID to delete (from get_portfolios)'),
+  force: z
+    .boolean()
+    .optional()
+    .describe(
+      'If true, also deletes all holdings, transactions, and balances associated with this portfolio. Default: false.',
+    ),
+};
+
 export function registerDeletePortfolio(server: McpServer) {
   server.registerTool(
     'delete_portfolio',
     {
       description:
         'Permanently delete a portfolio and, if force is true, all its holdings, transactions, and cash balances. Without force, deletion is blocked when the portfolio has any data. This action is irreversible — confirm with the user before calling. Obtain portfolioId from get_portfolios.',
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID to delete (from get_portfolios)'),
-        force: z
-          .boolean()
-          .optional()
-          .describe(
-            'If true, also deletes all holdings, transactions, and balances associated with this portfolio. Default: false.',
-          ),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-split.ts
+++ b/packages/backend/src/services/mcp/tools/delete-split.ts
@@ -5,15 +5,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  splitId: z.string().describe('UUID of the split to delete'),
+};
+
 export function registerDeleteSplit(server: McpServer) {
   server.registerTool(
     'delete_split',
     {
       description:
         'Delete a single split from a transaction by its split ID (UUID string). DESTRUCTIVE: the split amount returns to the primary category. Fails if the split has refunds targeting it.',
-      inputSchema: {
-        splitId: z.string().describe('UUID of the split to delete'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-subscription.ts
+++ b/packages/backend/src/services/mcp/tools/delete-subscription.ts
@@ -5,15 +5,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('UUID of the subscription to delete'),
+};
+
 export function registerDeleteSubscription(server: McpServer) {
   server.registerTool(
     'delete_subscription',
     {
       description:
         'Permanently delete a subscription or recurring bill. Linked transaction associations are also removed. This action cannot be undone. Requires finance:delete scope.',
-      inputSchema: {
-        id: z.string().describe('UUID of the subscription to delete'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-tag.ts
+++ b/packages/backend/src/services/mcp/tools/delete-tag.ts
@@ -5,15 +5,17 @@ import { deleteTag } from '@services/tags/delete-tag';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the tag to delete.'),
+};
+
 export function registerDeleteTag(server: McpServer) {
   server.registerTool(
     'delete_tag',
     {
       description:
         'Permanently delete a tag by ID. This is destructive — the tag will be removed and unlinked from all transactions. Only call when the user explicitly confirms deletion.',
-      inputSchema: {
-        id: recordId().describe('ID of the tag to delete.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-transaction-group.ts
+++ b/packages/backend/src/services/mcp/tools/delete-transaction-group.ts
@@ -5,15 +5,17 @@ import { deleteTransactionGroup } from '@services/transaction-groups';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the transaction group to delete'),
+};
+
 export function registerDeleteTransactionGroup(server: McpServer) {
   server.registerTool(
     'delete_transaction_group',
     {
       description:
         'Permanently delete a transaction group. The transactions themselves are NOT deleted — only the grouping is removed. This action cannot be undone. Requires finance:delete scope.',
-      inputSchema: {
-        id: recordId().describe('ID of the transaction group to delete'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/delete-transaction.ts
@@ -5,15 +5,17 @@ import { deleteTransaction } from '@services/transactions/delete-transaction';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the transaction to delete'),
+};
+
 export function registerDeleteTransaction(server: McpServer) {
   server.registerTool(
     'delete_transaction',
     {
       description:
         'Permanently delete a transaction by ID. DESTRUCTIVE: this cannot be undone. For transfer transactions, both sides of the transfer are deleted.',
-      inputSchema: {
-        id: recordId().describe('ID of the transaction to delete'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-venture-deal.ts
+++ b/packages/backend/src/services/mcp/tools/delete-venture-deal.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+  force: z.boolean().optional().describe('If true, hard-delete the deal row. Default: false (soft-delete).'),
+};
+
 export function registerDeleteVentureDeal(server: McpServer) {
   server.registerTool(
     'delete_venture_deal',
     {
       description:
         "Delete a venture deal. Cascade-deletes its events and event-link rows. Bank transactions previously linked to the deal's events remain intact in the main transactions list with their original state restored. With force=true the deal row is hard-deleted; otherwise it is soft-deleted. Confirm with the user before calling.",
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-        force: z.boolean().optional().describe('If true, hard-delete the deal row. Default: false (soft-delete).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-venture-event.ts
+++ b/packages/backend/src/services/mcp/tools/delete-venture-event.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  eventId: recordId().describe('Venture event ID (from list_venture_events)'),
+  deleteLinkedTransactions: z
+    .boolean()
+    .optional()
+    .describe('If true, also delete the bank transaction rows that were linked. Default: false (unlink only).'),
+};
+
 export function registerDeleteVentureEvent(server: McpServer) {
   server.registerTool(
     'delete_venture_event',
     {
       description:
         'Delete a venture event. Linked bank transactions are unlinked first (their original state is restored). The initial_investment cannot be deleted while other events still exist on the deal — delete the other events first. Pass deleteLinkedTransactions=true to also remove the bank tx rows themselves (not just the link); only do this when the user explicitly asks. Confirm with the user before calling.',
-      inputSchema: {
-        eventId: recordId().describe('Venture event ID (from list_venture_events)'),
-        deleteLinkedTransactions: z
-          .boolean()
-          .optional()
-          .describe('If true, also delete the bank transaction rows that were linked. Default: false (unlink only).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/delete-venture-platform.ts
+++ b/packages/backend/src/services/mcp/tools/delete-venture-platform.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
+  force: z.boolean().optional().describe('If true, hard-delete the platform. Default: false (soft-delete).'),
+};
+
 export function registerDeleteVenturePlatform(server: McpServer) {
   server.registerTool(
     'delete_venture_platform',
     {
       description:
         "Delete a venture platform. Existing deals that reference it have their platformId cleared (deals are preserved). With force=true, hard-deletes the platform; otherwise it is soft-deleted. Confirm with the user before calling — operates against the user's records.",
-      inputSchema: {
-        platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
-        force: z.boolean().optional().describe('If true, hard-delete the platform. Default: false (soft-delete).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/dismiss-subscription-candidate.ts
+++ b/packages/backend/src/services/mcp/tools/dismiss-subscription-candidate.ts
@@ -5,15 +5,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  candidateId: z.string().describe('UUID of the subscription candidate to dismiss'),
+};
+
 export function registerDismissSubscriptionCandidate(server: McpServer) {
   server.registerTool(
     'dismiss_subscription_candidate',
     {
       description:
         'Dismiss a pending subscription candidate so it no longer appears in the candidate list. The underlying transactions are unaffected. Only pending candidates can be dismissed. Requires finance:write scope.',
-      inputSchema: {
-        candidateId: z.string().describe('UUID of the subscription candidate to dismiss'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-accounts.ts
+++ b/packages/backend/src/services/mcp/tools/get-accounts.ts
@@ -7,19 +7,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  type: z.string().optional().describe('Filter by account type (e.g., "checking", "savings", "credit_card")'),
+  includeExcludedFromStats: z.boolean().optional().describe('Include accounts excluded from stats. Default: false'),
+};
+
 export function registerGetAccounts(server: McpServer) {
   server.registerTool(
     'get_accounts',
     {
       description:
         'List all user accounts with current balances. Returns account name, type, currency, current balance (in original and base currency), and credit limit.',
-      inputSchema: {
-        type: z.string().optional().describe('Filter by account type (e.g., "checking", "savings", "credit_card")'),
-        includeExcludedFromStats: z
-          .boolean()
-          .optional()
-          .describe('Include accounts excluded from stats. Default: false'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-balance-history.ts
+++ b/packages/backend/src/services/mcp/tools/get-balance-history.ts
@@ -7,21 +7,23 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  startDate: z.string().optional().describe('Start date (ISO 8601). Default: 30 days ago'),
+  endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
+  accountId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Specific account ID. Omit for combined balance across all accounts.'),
+};
+
 export function registerGetBalanceHistory(server: McpServer) {
   server.registerTool(
     'get_balance_history',
     {
       description:
         'Get account balance over time. If accountId is provided, returns balance history for that specific account. Otherwise, returns combined balance across all accounts.',
-      inputSchema: {
-        startDate: z.string().optional().describe('Start date (ISO 8601). Default: 30 days ago'),
-        endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
-        accountId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Specific account ID. Omit for combined balance across all accounts.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-budget-spending-stats.ts
+++ b/packages/backend/src/services/mcp/tools/get-budget-spending-stats.ts
@@ -6,15 +6,17 @@ import { getBudgetSpendingStats } from '@services/budgets/spending-stats';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to retrieve spending stats for'),
+};
+
 export function registerGetBudgetSpendingStats(server: McpServer) {
   server.registerTool(
     'get_budget_spending_stats',
     {
       description:
         'Get spending statistics for a budget: spending broken down by category and a time-series of expense vs income over the budget period. Granularity is weekly for ranges ≤60 days, monthly otherwise. Amounts are decimals.',
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to retrieve spending stats for'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-budgets.ts
+++ b/packages/backend/src/services/mcp/tools/get-budgets.ts
@@ -7,18 +7,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  status: z
+    .enum([BUDGET_STATUSES.active, BUDGET_STATUSES.archived, BUDGET_STATUSES.closed])
+    .optional()
+    .describe('Filter by budget status. Default: active'),
+};
+
 export function registerGetBudgets(server: McpServer) {
   server.registerTool(
     'get_budgets',
     {
       description:
         'List budgets with their spending limits and associated categories. Filter by status (active, archived, closed). Returns budget name, limit amount, status, date range, and linked categories.',
-      inputSchema: {
-        status: z
-          .enum([BUDGET_STATUSES.active, BUDGET_STATUSES.archived, BUDGET_STATUSES.closed])
-          .optional()
-          .describe('Filter by budget status. Default: active'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-cash-flow.ts
+++ b/packages/backend/src/services/mcp/tools/get-cash-flow.ts
@@ -7,22 +7,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  startDate: z.string().describe('Period start date (ISO 8601). Required.'),
+  endDate: z.string().describe('Period end date (ISO 8601). Required.'),
+  granularity: z.enum(['monthly', 'biweekly', 'weekly']).optional().describe('Time granularity. Default: monthly'),
+  accountId: recordId().optional().describe('Filter by specific account ID'),
+  categoryIds: z.array(recordId()).optional().describe('Filter by category IDs'),
+};
+
 export function registerGetCashFlow(server: McpServer) {
   server.registerTool(
     'get_cash_flow',
     {
       description:
         'Get income, expenses, and net cash flow for a period with configurable granularity (monthly/biweekly/weekly). Returns period-by-period breakdown plus totals with savings rate.',
-      inputSchema: {
-        startDate: z.string().describe('Period start date (ISO 8601). Required.'),
-        endDate: z.string().describe('Period end date (ISO 8601). Required.'),
-        granularity: z
-          .enum(['monthly', 'biweekly', 'weekly'])
-          .optional()
-          .describe('Time granularity. Default: monthly'),
-        accountId: recordId().optional().describe('Filter by specific account ID'),
-        categoryIds: z.array(recordId()).optional().describe('Filter by category IDs'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-expenses-for-period.ts
+++ b/packages/backend/src/services/mcp/tools/get-expenses-for-period.ts
@@ -7,18 +7,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  startDate: z.string().optional().describe('Start date (ISO 8601). Default: start of current month'),
+  endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
+  accountId: recordId().optional().describe('Filter by specific account ID'),
+  excludedCategoryIds: z.array(recordId()).optional().describe('Exclude specific category IDs from total'),
+};
+
 export function registerGetExpensesForPeriod(server: McpServer) {
   server.registerTool(
     'get_expenses_for_period',
     {
       description:
         'Get total expense amount for a date range. Returns a single total number. Use this for quick "how much did I spend" queries instead of summing transactions manually.',
-      inputSchema: {
-        startDate: z.string().optional().describe('Start date (ISO 8601). Default: start of current month'),
-        endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
-        accountId: recordId().optional().describe('Filter by specific account ID'),
-        excludedCategoryIds: z.array(recordId()).optional().describe('Exclude specific category IDs from total'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-investment-transactions.ts
+++ b/packages/backend/src/services/mcp/tools/get-investment-transactions.ts
@@ -7,33 +7,35 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().optional().describe('Restrict to a specific portfolio'),
+  securityId: recordId().optional().describe('Restrict to a specific security'),
+  category: z
+    .enum([
+      INVESTMENT_TRANSACTION_CATEGORY.buy,
+      INVESTMENT_TRANSACTION_CATEGORY.sell,
+      INVESTMENT_TRANSACTION_CATEGORY.dividend,
+      INVESTMENT_TRANSACTION_CATEGORY.transfer,
+      INVESTMENT_TRANSACTION_CATEGORY.tax,
+      INVESTMENT_TRANSACTION_CATEGORY.fee,
+      INVESTMENT_TRANSACTION_CATEGORY.cancel,
+      INVESTMENT_TRANSACTION_CATEGORY.other,
+    ])
+    .optional()
+    .describe('Filter by transaction category'),
+  startDate: z.string().optional().describe('Start date (ISO 8601)'),
+  endDate: z.string().optional().describe('End date (ISO 8601)'),
+  limit: z.number().optional().describe('Max results (default: 20)'),
+  offset: z.number().optional().describe('Pagination offset (default: 0)'),
+};
+
 export function registerGetInvestmentTransactions(server: McpServer) {
   server.registerTool(
     'get_investment_transactions',
     {
       description:
         'Investment transaction history: buy, sell, dividend, transfer, tax, fee, cancel, other. Each transaction includes amount, quantity, price, fees, date, category, and the embedded security. Distinct from search_transactions, which covers regular (non-investment) spending. Default: 20 most recent across all portfolios.',
-      inputSchema: {
-        portfolioId: recordId().optional().describe('Restrict to a specific portfolio'),
-        securityId: recordId().optional().describe('Restrict to a specific security'),
-        category: z
-          .enum([
-            INVESTMENT_TRANSACTION_CATEGORY.buy,
-            INVESTMENT_TRANSACTION_CATEGORY.sell,
-            INVESTMENT_TRANSACTION_CATEGORY.dividend,
-            INVESTMENT_TRANSACTION_CATEGORY.transfer,
-            INVESTMENT_TRANSACTION_CATEGORY.tax,
-            INVESTMENT_TRANSACTION_CATEGORY.fee,
-            INVESTMENT_TRANSACTION_CATEGORY.cancel,
-            INVESTMENT_TRANSACTION_CATEGORY.other,
-          ])
-          .optional()
-          .describe('Filter by transaction category'),
-        startDate: z.string().optional().describe('Start date (ISO 8601)'),
-        endDate: z.string().optional().describe('End date (ISO 8601)'),
-        limit: z.number().optional().describe('Max results (default: 20)'),
-        offset: z.number().optional().describe('Pagination offset (default: 0)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-payee.ts
+++ b/packages/backend/src/services/mcp/tools/get-payee.ts
@@ -6,15 +6,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('Payee id.'),
+};
+
 export function registerGetPayee(server: McpServer) {
   server.registerTool(
     'get_payee',
     {
       description:
         'Fetch a single Payee with aliases and computed stats. Useful when the user references a merchant by id and wants its full record.',
-      inputSchema: {
-        id: z.string().describe('Payee id.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-payees.ts
+++ b/packages/backend/src/services/mcp/tools/get-payees.ts
@@ -6,15 +6,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  q: z.string().optional().describe('Substring filter applied to the normalized Payee name.'),
+};
+
 export function registerGetPayees(server: McpServer) {
   server.registerTool(
     'get_payees',
     {
       description:
         'List Payees (merchants/counterparties) for the user, optionally filtered by a substring query. Returns Payee id, name, defaultCategoryId, and aggregated stats (transactionCount, netFlowRef, top category, last seen).',
-      inputSchema: {
-        q: z.string().optional().describe('Substring filter applied to the normalized Payee name.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-portfolio-balances.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolio-balances.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
+  currencyCode: z
+    .string()
+    .optional()
+    .describe('ISO 4217 currency code (e.g., "USD"). Omit to return balances in all currencies.'),
+};
+
 export function registerGetPortfolioBalances(server: McpServer) {
   server.registerTool(
     'get_portfolio_balances',
     {
       description:
         "Cash balances held in a portfolio, broken down per currency. Each entry includes totalCash and availableCash in the original currency plus their ref* equivalents converted to the user's base currency. Useful for answering 'how much cash do I have to invest'.",
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
-        currencyCode: z
-          .string()
-          .optional()
-          .describe('ISO 4217 currency code (e.g., "USD"). Omit to return balances in all currencies.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-portfolio-holdings.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolio-holdings.ts
@@ -6,20 +6,19 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
+  securityId: recordId().optional().describe('Filter to a specific security'),
+  date: z.string().optional().describe('Date for historical valuation (ISO 8601). Default: latest available prices'),
+};
+
 export function registerGetPortfolioHoldings(server: McpServer) {
   server.registerTool(
     'get_portfolio_holdings',
     {
       description:
         'Positions held in a portfolio with dynamically calculated market value, cost basis, and realized/unrealized gain (value and percent). Each holding includes the embedded security (symbol, name, asset class, currency). Filter by securityId to look at a single position.',
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
-        securityId: recordId().optional().describe('Filter to a specific security'),
-        date: z
-          .string()
-          .optional()
-          .describe('Date for historical valuation (ISO 8601). Default: latest available prices'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-portfolio-summary.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolio-summary.ts
@@ -6,19 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
+  date: z.string().optional().describe('Date for historical snapshot (ISO 8601). Default: latest available prices'),
+};
+
 export function registerGetPortfolioSummary(server: McpServer) {
   server.registerTool(
     'get_portfolio_summary',
     {
       description:
         "Portfolio-level aggregates for a single portfolio: total current market value, total cost basis, realized and unrealized gains (value and percent), cash balances, and total portfolio value (holdings + cash). All monetary values are decimals in the user's base currency.",
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
-        date: z
-          .string()
-          .optional()
-          .describe('Date for historical snapshot (ISO 8601). Default: latest available prices'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-portfolios.ts
+++ b/packages/backend/src/services/mcp/tools/get-portfolios.ts
@@ -6,21 +6,23 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  portfolioType: z
+    .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
+    .optional()
+    .describe('Filter by portfolio type'),
+  isEnabled: z.boolean().optional().describe('Filter by enabled state'),
+  limit: z.number().optional().describe('Max results'),
+  offset: z.number().optional().describe('Pagination offset (default: 0)'),
+};
+
 export function registerGetPortfolios(server: McpServer) {
   server.registerTool(
     'get_portfolios',
     {
       description:
         "List the user's investment portfolios. Returns id, name, portfolio type (investment/retirement/savings/other), description, enabled state, and creation date. Use the returned id with get_portfolio_summary, get_portfolio_holdings, get_portfolio_balances, and get_investment_transactions.",
-      inputSchema: {
-        portfolioType: z
-          .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
-          .optional()
-          .describe('Filter by portfolio type'),
-        isEnabled: z.boolean().optional().describe('Filter by enabled state'),
-        limit: z.number().optional().describe('Max results'),
-        offset: z.number().optional().describe('Pagination offset (default: 0)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-spending-by-categories.ts
+++ b/packages/backend/src/services/mcp/tools/get-spending-by-categories.ts
@@ -9,23 +9,25 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  startDate: z.string().optional().describe('Start date (ISO 8601). Default: start of current month'),
+  endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
+  accountId: recordId().optional().describe('Filter by specific account ID'),
+  transactionType: z
+    .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
+    .optional()
+    .describe('Transaction type. Default: expense'),
+  categoryIds: z.array(recordId()).optional().describe('Only include specific category IDs'),
+  excludedCategoryIds: z.array(recordId()).optional().describe('Exclude specific category IDs'),
+};
+
 export function registerGetSpendingByCategories(server: McpServer) {
   server.registerTool(
     'get_spending_by_categories',
     {
       description:
         'Get spending breakdown by category for a date range. Returns each category with its total amount. Great for understanding where money goes. Defaults to current month expenses.',
-      inputSchema: {
-        startDate: z.string().optional().describe('Start date (ISO 8601). Default: start of current month'),
-        endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
-        accountId: recordId().optional().describe('Filter by specific account ID'),
-        transactionType: z
-          .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
-          .optional()
-          .describe('Transaction type. Default: expense'),
-        categoryIds: z.array(recordId()).optional().describe('Only include specific category IDs'),
-        excludedCategoryIds: z.array(recordId()).optional().describe('Exclude specific category IDs'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-subscription-by-id.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscription-by-id.ts
@@ -6,15 +6,17 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('UUID of the subscription to retrieve'),
+};
+
 export function registerGetSubscriptionById(server: McpServer) {
   server.registerTool(
     'get_subscription_by_id',
     {
       description:
         'Retrieve a single subscription by its ID including all linked transactions (with match source and date) and the computed next expected payment date.',
-      inputSchema: {
-        id: z.string().describe('UUID of the subscription to retrieve'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-subscriptions-summary.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscriptions-summary.ts
@@ -6,18 +6,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  type: z
+    .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
+    .optional()
+    .describe('Limit the summary to a specific type: "subscription", "bill", or "installment"'),
+};
+
 export function registerGetSubscriptionsSummary(server: McpServer) {
   server.registerTool(
     'get_subscriptions_summary',
     {
       description:
         'Aggregate summary across all active subscriptions with an expected amount, split by direction. Returns estimated monthly cost and projected yearly cost from expense subscriptions, expected monthly income from income subscriptions, active counts as { expense, income }, the user\'s average monthly income over the last 6 complete months (observed from transaction history, separate from subscription-based expected income), and percent of that income spent on subscriptions (all monetary values in the user base currency). Useful for "how much am I spending on subscriptions per month?", "how much recurring income do I have?", or "what share of my income goes to subscriptions?"',
-      inputSchema: {
-        type: z
-          .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
-          .optional()
-          .describe('Limit the summary to a specific type: "subscription", "bill", or "installment"'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-subscriptions.ts
+++ b/packages/backend/src/services/mcp/tools/get-subscriptions.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  isActive: z.boolean().optional().describe('Filter by active state. Omit to return all subscriptions'),
+  type: z
+    .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
+    .optional()
+    .describe('Filter by type: "subscription", "bill", or "installment"'),
+};
+
 export function registerGetSubscriptions(server: McpServer) {
   server.registerTool(
     'get_subscriptions',
     {
       description:
         'List all subscriptions and recurring bills for the user. Returns name, frequency, expected amount, linked account/category, active state, and linked transaction count. Use isActive to filter active-only.',
-      inputSchema: {
-        isActive: z.boolean().optional().describe('Filter by active state. Omit to return all subscriptions'),
-        type: z
-          .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
-          .optional()
-          .describe('Filter by type: "subscription", "bill", or "installment"'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-transaction-groups.ts
+++ b/packages/backend/src/services/mcp/tools/get-transaction-groups.ts
@@ -11,18 +11,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  includeTransactions: z
+    .boolean()
+    .optional()
+    .describe('When true, embed full transaction data in each group. Default: false (aggregates only)'),
+};
+
 export function registerGetTransactionGroups(server: McpServer) {
   server.registerTool(
     'get_transaction_groups',
     {
       description:
         'List all transaction groups for the user. Groups bundle related transactions (e.g. split expenses). When includeTransactions is true, each group contains the full transaction list; otherwise returns aggregate counts and date ranges.',
-      inputSchema: {
-        includeTransactions: z
-          .boolean()
-          .optional()
-          .describe('When true, embed full transaction data in each group. Default: false (aggregates only)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-upcoming-subscription-payments.ts
+++ b/packages/backend/src/services/mcp/tools/get-upcoming-subscription-payments.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  limit: z.number().optional().describe('Maximum number of upcoming payments to return. Default: 5'),
+  type: z
+    .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
+    .optional()
+    .describe('Filter by type: "subscription", "bill", or "installment"'),
+};
+
 export function registerGetUpcomingSubscriptionPayments(server: McpServer) {
   server.registerTool(
     'get_upcoming_subscription_payments',
     {
       description:
         'List upcoming subscription payments sorted by next expected payment date (soonest first). Returns subscription name, expected amount, currency, next payment date, and category. Only active subscriptions with an expectedAmount are included.',
-      inputSchema: {
-        limit: z.number().optional().describe('Maximum number of upcoming payments to return. Default: 5'),
-        type: z
-          .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
-          .optional()
-          .describe('Filter by type: "subscription", "bill", or "installment"'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-venture-deal-metrics.ts
+++ b/packages/backend/src/services/mcp/tools/get-venture-deal-metrics.ts
@@ -5,16 +5,18 @@ import { getDealMetrics } from '@services/venture/metrics/get-deal-metrics.servi
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+  asOfDate: dateString().optional().describe('Compute metrics as of this date (YYYY-MM-DD). Defaults to today.'),
+};
+
 export function registerGetVentureDealMetrics(server: McpServer) {
   server.registerTool(
     'get_venture_deal_metrics',
     {
       description:
         'Compute aggregated metrics for a venture deal: cost basis, current value (latest NAV), total distributions, absolute and percent P&L, TVPI (total value to paid-in), DPI (distributions to paid-in), and IRR. IRR returns null for degenerate cash flows (e.g. no inflows yet). Pass asOfDate (YYYY-MM-DD) to compute metrics as of a specific date.',
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-        asOfDate: dateString().optional().describe('Compute metrics as of this date (YYYY-MM-DD). Defaults to today.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-venture-deal.ts
+++ b/packages/backend/src/services/mcp/tools/get-venture-deal.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+  includeEvents: z
+    .boolean()
+    .optional()
+    .describe("When true, embed the deal's event history in the response. Default: false."),
+};
+
 export function registerGetVentureDeal(server: McpServer) {
   server.registerTool(
     'get_venture_deal',
     {
       description:
         "Retrieve a single venture deal by id, including its platform and currency. Pass includeEvents=true to also embed the deal's event history (sorted asc). Obtain the dealId from list_venture_deals.",
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-        includeEvents: z
-          .boolean()
-          .optional()
-          .describe("When true, embed the deal's event history in the response. Default: false."),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-venture-event.ts
+++ b/packages/backend/src/services/mcp/tools/get-venture-event.ts
@@ -5,15 +5,17 @@ import { getVentureEvent } from '@services/venture/events/get.service';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  eventId: recordId().describe('Venture event ID (from list_venture_events)'),
+};
+
 export function registerGetVentureEvent(server: McpServer) {
   server.registerTool(
     'get_venture_event',
     {
       description:
         'Retrieve a single venture event by id, including its link rows (bank transactions linked to this event). Obtain the eventId from list_venture_events.',
-      inputSchema: {
-        eventId: recordId().describe('Venture event ID (from list_venture_events)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/get-venture-platform.ts
+++ b/packages/backend/src/services/mcp/tools/get-venture-platform.ts
@@ -5,15 +5,17 @@ import { getVenturePlatform } from '@services/venture/platforms/get.service';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
+};
+
 export function registerGetVenturePlatform(server: McpServer) {
   server.registerTool(
     'get_venture_platform',
     {
       description:
         'Retrieve a single venture platform by id. Returns full record including default fee fractions (decimals in [0,1]). Obtain the platformId from list_venture_platforms.',
-      inputSchema: {
-        platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/link-refund.ts
+++ b/packages/backend/src/services/mcp/tools/link-refund.ts
@@ -6,24 +6,23 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  originalTxId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe('ID of the original transaction being refunded. Pass null for a standalone refund'),
+  refundTxId: recordId().describe('ID of the transaction that represents the refund'),
+  splitId: z.string().optional().describe('UUID of a specific split on the original transaction this refund targets'),
+};
+
 export function registerLinkRefund(server: McpServer) {
   server.registerTool(
     'link_refund',
     {
       description:
         'Mark an existing transaction as a refund of another transaction. Provide originalTxId (the transaction being refunded) and refundTxId (the refund transaction). The two transactions must have opposite types (income vs expense). Optionally target a specific split of the original.',
-      inputSchema: {
-        originalTxId: z
-          .string()
-          .uuid()
-          .nullable()
-          .describe('ID of the original transaction being refunded. Pass null for a standalone refund'),
-        refundTxId: recordId().describe('ID of the transaction that represents the refund'),
-        splitId: z
-          .string()
-          .optional()
-          .describe('UUID of a specific split on the original transaction this refund targets'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/link-transactions-to-subscription.ts
+++ b/packages/backend/src/services/mcp/tools/link-transactions-to-subscription.ts
@@ -7,19 +7,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  subscriptionId: recordId().describe('UUID of the subscription'),
+  transactionIds: z.array(recordId()).describe('IDs of transactions to link to the subscription'),
+  matchSource: z
+    .enum([SUBSCRIPTION_MATCH_SOURCE.manual, SUBSCRIPTION_MATCH_SOURCE.rule, SUBSCRIPTION_MATCH_SOURCE.ai])
+    .describe('How the match was determined: manual, rule, or ai'),
+};
+
 export function registerLinkTransactionsToSubscription(server: McpServer) {
   server.registerTool(
     'link_transactions_to_subscription',
     {
       description:
         'Link one or more transactions to a subscription to mark them as payment instances. Use matchSource="manual" for user-initiated linking. If the subscription has a categoryId and matchSource="rule", the category is applied to the transactions automatically. Requires finance:write scope.',
-      inputSchema: {
-        subscriptionId: recordId().describe('UUID of the subscription'),
-        transactionIds: z.array(recordId()).describe('IDs of transactions to link to the subscription'),
-        matchSource: z
-          .enum([SUBSCRIPTION_MATCH_SOURCE.manual, SUBSCRIPTION_MATCH_SOURCE.rule, SUBSCRIPTION_MATCH_SOURCE.ai])
-          .describe('How the match was determined: manual, rule, or ai'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/link-transfer.ts
+++ b/packages/backend/src/services/mcp/tools/link-transfer.ts
@@ -7,19 +7,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  baseTxId: recordId().describe('ID of the base (source) transaction — typically the expense side'),
+  oppositeTxId: z.string().uuid().describe('ID of the opposite (destination) transaction — typically the income side'),
+};
+
 export function registerLinkTransfer(server: McpServer) {
   server.registerTool(
     'link_transfer',
     {
       description:
         'Link two existing transactions as a transfer pair. The two transactions must be in different accounts and have opposite types (one income, one expense). Provide baseTxId (the source/expense side) and oppositeTxId (the destination/income side).',
-      inputSchema: {
-        baseTxId: recordId().describe('ID of the base (source) transaction — typically the expense side'),
-        oppositeTxId: z
-          .string()
-          .uuid()
-          .describe('ID of the opposite (destination) transaction — typically the income side'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/list-subscription-candidates.ts
+++ b/packages/backend/src/services/mcp/tools/list-subscription-candidates.ts
@@ -6,22 +6,24 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  status: z
+    .enum([
+      SUBSCRIPTION_CANDIDATE_STATUS.pending,
+      SUBSCRIPTION_CANDIDATE_STATUS.accepted,
+      SUBSCRIPTION_CANDIDATE_STATUS.dismissed,
+    ])
+    .optional()
+    .describe('Filter by candidate status. Omit to return all statuses'),
+};
+
 export function registerListSubscriptionCandidates(server: McpServer) {
   server.registerTool(
     'list_subscription_candidates',
     {
       description:
         'List auto-detected subscription candidates sorted by confidence score. Call detect_subscription_candidates first to generate fresh candidates. Use status filter to see only pending, accepted, or dismissed candidates.',
-      inputSchema: {
-        status: z
-          .enum([
-            SUBSCRIPTION_CANDIDATE_STATUS.pending,
-            SUBSCRIPTION_CANDIDATE_STATUS.accepted,
-            SUBSCRIPTION_CANDIDATE_STATUS.dismissed,
-          ])
-          .optional()
-          .describe('Filter by candidate status. Omit to return all statuses'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/list-venture-deals.ts
+++ b/packages/backend/src/services/mcp/tools/list-venture-deals.ts
@@ -7,18 +7,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  status: z.nativeEnum(VENTURE_DEAL_STATUS).optional().describe('Filter by status'),
+  platformId: recordId().optional().describe('Filter by platform id'),
+  limit: z.number().optional().describe('Max results'),
+  offset: z.number().optional().describe('Pagination offset (default: 0)'),
+};
+
 export function registerListVentureDeals(server: McpServer) {
   server.registerTool(
     'list_venture_deals',
     {
       description:
         "List the user's venture deals (private/illiquid investments through SPVs, syndicates, or direct vehicles). Returns each deal's id, name, status (outstanding | partial_exit | fully_exited | written_off), platform, currency, principal, entry fee, fee fractions, dates, and target company. Use the returned id with get_venture_deal, get_venture_deal_metrics, list_venture_events, and update_venture_deal.",
-      inputSchema: {
-        status: z.nativeEnum(VENTURE_DEAL_STATUS).optional().describe('Filter by status'),
-        platformId: recordId().optional().describe('Filter by platform id'),
-        limit: z.number().optional().describe('Max results'),
-        offset: z.number().optional().describe('Pagination offset (default: 0)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/list-venture-events.ts
+++ b/packages/backend/src/services/mcp/tools/list-venture-events.ts
@@ -5,15 +5,17 @@ import { listVentureEvents } from '@services/venture/events/list.service';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+};
+
 export function registerListVentureEvents(server: McpServer) {
   server.registerTool(
     'list_venture_events',
     {
       description:
         'List events for a venture deal in chronological order (oldest first). Each event has a type (initial_investment | capital_call | distribution | nav_update | exit | writedown | fee_payment), date, amounts, cashFlowMode, and embedded link rows (when the event is tied to bank transactions). Use the returned event ids with get_venture_event, update_venture_event, and delete_venture_event.',
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/list-venture-platforms.ts
+++ b/packages/backend/src/services/mcp/tools/list-venture-platforms.ts
@@ -5,16 +5,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  limit: z.number().optional().describe('Max results'),
+  offset: z.number().optional().describe('Pagination offset (default: 0)'),
+};
+
 export function registerListVenturePlatforms(server: McpServer) {
   server.registerTool(
     'list_venture_platforms',
     {
       description:
         "List the user's venture investment platforms (SPV syndicators, fund managers). Returns each platform's id, name, website, description, and default fee fractions (entry fee, management fee, carry, hurdle). Fee values are decimals in [0,1] — e.g. 0.085 means 8.5%. Use the returned id with get_venture_platform, create_venture_deal, and update_venture_platform.",
-      inputSchema: {
-        limit: z.number().optional().describe('Max results'),
-        offset: z.number().optional().describe('Pagination offset (default: 0)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/merge-payees.ts
+++ b/packages/backend/src/services/mcp/tools/merge-payees.ts
@@ -5,16 +5,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  sourceId: z.string().describe('Payee id to merge from (will be deleted).'),
+  targetId: z.string().describe('Payee id to merge into (kept).'),
+};
+
 export function registerMergePayees(server: McpServer) {
   server.registerTool(
     'merge_payees',
     {
       description:
         'Merge a source Payee into a target Payee. Transactions and aliases move to the target; the target wins silently on defaultCategoryId conflict; the source is deleted. Use to dedupe near-duplicates like "Amazon" and "AMZN MKT".',
-      inputSchema: {
-        sourceId: z.string().describe('Payee id to merge from (will be deleted).'),
-        targetId: z.string().describe('Payee id to merge into (kept).'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/remove-tags-from-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/remove-tags-from-transaction.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  tagId: recordId().describe('ID of the tag to remove from transactions.'),
+  transactionIds: z.array(recordId()).describe('List of transaction IDs to remove the tag from.'),
+};
+
 export function registerRemoveTagsFromTransaction(server: McpServer) {
   server.registerTool(
     'remove_tags_from_transaction',
     {
       description:
         'Remove a tag from one or more transactions. Use when the user wants to untag transactions. Returns the count of removed tag links.',
-      inputSchema: {
-        tagId: recordId().describe('ID of the tag to remove from transactions.'),
-        transactionIds: z.array(recordId()).describe('List of transaction IDs to remove the tag from.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/remove-transactions-from-budget.ts
+++ b/packages/backend/src/services/mcp/tools/remove-transactions-from-budget.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to unlink transactions from'),
+  transactionIds: z.array(recordId()).describe('IDs of the transactions to remove from the budget'),
+};
+
 export function registerRemoveTransactionsFromBudget(server: McpServer) {
   server.registerTool(
     'remove_transactions_from_budget',
     {
       description:
         'Unlink one or more transactions from a budget. Does not delete the transactions themselves. Returns nothing on success.',
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to unlink transactions from'),
-        transactionIds: z.array(recordId()).describe('IDs of the transactions to remove from the budget'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/remove-transactions-from-group.ts
+++ b/packages/backend/src/services/mcp/tools/remove-transactions-from-group.ts
@@ -6,22 +6,24 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  groupId: recordId().describe('ID of the transaction group'),
+  transactionIds: z.array(recordId()).describe('IDs of transactions to remove from the group'),
+  force: z
+    .boolean()
+    .optional()
+    .describe(
+      'When true, dissolves the group if too few transactions would remain. Default: false (returns error instead)',
+    ),
+};
+
 export function registerRemoveTransactionsFromGroup(server: McpServer) {
   server.registerTool(
     'remove_transactions_from_group',
     {
       description:
         'Remove transactions from a group. If removal would leave fewer than 2 transactions, pass force=true to dissolve the group entirely (transactions are kept). Requires finance:write scope.',
-      inputSchema: {
-        groupId: recordId().describe('ID of the transaction group'),
-        transactionIds: z.array(recordId()).describe('IDs of transactions to remove from the group'),
-        force: z
-          .boolean()
-          .optional()
-          .describe(
-            'When true, dissolves the group if too few transactions would remain. Default: false (returns error instead)',
-          ),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/search-securities.ts
+++ b/packages/backend/src/services/mcp/tools/search-securities.ts
@@ -5,21 +5,23 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  query: z.string().describe('Ticker symbol or company name to search for (e.g. "AAPL", "Apple")'),
+  portfolioId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('Portfolio ID to annotate results with isInPortfolio flag (from get_portfolios)'),
+  limit: z.number().optional().describe('Maximum number of results to return (default: 20)'),
+};
+
 export function registerSearchSecurities(server: McpServer) {
   server.registerTool(
     'search_securities',
     {
       description:
         'Search for securities (stocks, ETFs, crypto, etc.) by ticker symbol or company name. Call this before create_investment_transaction to resolve a human-readable ticker (e.g. "AAPL") into a securityId. If portfolioId is provided, each result includes isInPortfolio to indicate whether the security is already tracked in that portfolio.',
-      inputSchema: {
-        query: z.string().describe('Ticker symbol or company name to search for (e.g. "AAPL", "Apple")'),
-        portfolioId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('Portfolio ID to annotate results with isInPortfolio flag (from get_portfolios)'),
-        limit: z.number().optional().describe('Maximum number of results to return (default: 20)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/search-transactions.ts
+++ b/packages/backend/src/services/mcp/tools/search-transactions.ts
@@ -10,31 +10,33 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent } from './helpers';
 
+const inputSchema = {
+  startDate: z.string().optional().describe('Start date (ISO 8601). Default: 30 days ago'),
+  endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
+  accountIds: z.array(recordId()).optional().describe('Filter by account IDs'),
+  categoryIds: z.array(recordId()).optional().describe('Filter by category IDs'),
+  tagIds: z.array(recordId()).optional().describe('Filter by tag IDs'),
+  transactionType: z
+    .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
+    .optional()
+    .describe('Filter by transaction type'),
+  amountMin: z.number().optional().describe('Minimum amount (decimal, in original currency)'),
+  amountMax: z.number().optional().describe('Maximum amount (decimal, in original currency)'),
+  search: z.string().optional().describe('Search in transaction notes'),
+  limit: z.number().optional().describe('Max results (default: 50, max: 500)'),
+  offset: z.number().optional().describe('Pagination offset (default: 0)'),
+  order: z.enum(['asc', 'desc']).optional().describe('Sort order by date (default: desc)'),
+  excludeTransfers: z.boolean().optional().describe('Exclude transfer transactions'),
+  excludeRefunds: z.boolean().optional().describe('Exclude refund transactions'),
+};
+
 export function registerSearchTransactions(server: McpServer) {
   server.registerTool(
     'search_transactions',
     {
       description:
         'Search and filter transactions. Returns transaction amount (original + base currency), category, account, note, date, type, and tags. Use date filters to limit results. Default: last 30 days, 50 items.',
-      inputSchema: {
-        startDate: z.string().optional().describe('Start date (ISO 8601). Default: 30 days ago'),
-        endDate: z.string().optional().describe('End date (ISO 8601). Default: today'),
-        accountIds: z.array(recordId()).optional().describe('Filter by account IDs'),
-        categoryIds: z.array(recordId()).optional().describe('Filter by category IDs'),
-        tagIds: z.array(recordId()).optional().describe('Filter by tag IDs'),
-        transactionType: z
-          .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
-          .optional()
-          .describe('Filter by transaction type'),
-        amountMin: z.number().optional().describe('Minimum amount (decimal, in original currency)'),
-        amountMax: z.number().optional().describe('Maximum amount (decimal, in original currency)'),
-        search: z.string().optional().describe('Search in transaction notes'),
-        limit: z.number().optional().describe('Max results (default: 50, max: 500)'),
-        offset: z.number().optional().describe('Pagination offset (default: 0)'),
-        order: z.enum(['asc', 'desc']).optional().describe('Sort order by date (default: desc)'),
-        excludeTransfers: z.boolean().optional().describe('Exclude transfer transactions'),
-        excludeRefunds: z.boolean().optional().describe('Exclude refund transactions'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/split-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/split-transaction.ts
@@ -9,25 +9,27 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  transactionId: recordId().describe('ID of the transaction to split'),
+  splits: z
+    .array(
+      z.object({
+        categoryId: recordId().describe('Category ID for this split portion'),
+        amount: z.number().describe('Amount for this split portion (decimal)'),
+        note: z.string().optional().nullable().describe('Optional note for this split'),
+      }),
+    )
+    .min(1)
+    .describe('Split portions — amounts must sum to the full transaction amount'),
+};
+
 export function registerSplitTransaction(server: McpServer) {
   server.registerTool(
     'split_transaction',
     {
       description:
         'Split a transaction across multiple categories. Provide the transactionId and an array of splits whose amounts sum to the transaction total. Replaces any existing splits on the transaction.',
-      inputSchema: {
-        transactionId: recordId().describe('ID of the transaction to split'),
-        splits: z
-          .array(
-            z.object({
-              categoryId: recordId().describe('Category ID for this split portion'),
-              amount: z.number().describe('Amount for this split portion (decimal)'),
-              note: z.string().optional().nullable().describe('Optional note for this split'),
-            }),
-          )
-          .min(1)
-          .describe('Split portions — amounts must sum to the full transaction amount'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/toggle-subscription-active.ts
+++ b/packages/backend/src/services/mcp/tools/toggle-subscription-active.ts
@@ -5,16 +5,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('UUID of the subscription'),
+  isActive: z.boolean().describe('True to activate the subscription, false to deactivate it'),
+};
+
 export function registerToggleSubscriptionActive(server: McpServer) {
   server.registerTool(
     'toggle_subscription_active',
     {
       description:
         'Activate or deactivate a subscription. Inactive subscriptions are excluded from upcoming payment calculations and summary totals. Requires finance:write scope.',
-      inputSchema: {
-        id: z.string().describe('UUID of the subscription'),
-        isActive: z.boolean().describe('True to activate the subscription, false to deactivate it'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/unlink-refund.ts
+++ b/packages/backend/src/services/mcp/tools/unlink-refund.ts
@@ -6,20 +6,22 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  originalTxId: z
+    .string()
+    .uuid()
+    .nullable()
+    .describe('ID of the original transaction. Pass null if no original was set'),
+  refundTxId: recordId().describe('ID of the refund transaction'),
+};
+
 export function registerUnlinkRefund(server: McpServer) {
   server.registerTool(
     'unlink_refund',
     {
       description:
         'Remove the refund link between two transactions. DESTRUCTIVE: both transactions will no longer be marked as refund-linked. Requires both originalTxId and refundTxId that were previously linked.',
-      inputSchema: {
-        originalTxId: z
-          .string()
-          .uuid()
-          .nullable()
-          .describe('ID of the original transaction. Pass null if no original was set'),
-        refundTxId: recordId().describe('ID of the refund transaction'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/unlink-transactions-from-subscription.ts
+++ b/packages/backend/src/services/mcp/tools/unlink-transactions-from-subscription.ts
@@ -6,16 +6,18 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  subscriptionId: z.string().describe('UUID of the subscription'),
+  transactionIds: z.array(recordId()).describe('IDs of transactions to unlink from the subscription'),
+};
+
 export function registerUnlinkTransactionsFromSubscription(server: McpServer) {
   server.registerTool(
     'unlink_transactions_from_subscription',
     {
       description:
         'Unlink transactions from a subscription without deleting them. The link record is marked as unlinked and excluded from subscription history. Requires finance:write scope.',
-      inputSchema: {
-        subscriptionId: z.string().describe('UUID of the subscription'),
-        transactionIds: z.array(recordId()).describe('IDs of transactions to unlink from the subscription'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/unlink-transfer.ts
+++ b/packages/backend/src/services/mcp/tools/unlink-transfer.ts
@@ -6,18 +6,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  transferIds: z
+    .array(z.string())
+    .min(1)
+    .describe('One or more transferId UUID strings identifying transfer pairs to unlink'),
+};
+
 export function registerUnlinkTransfer(server: McpServer) {
   server.registerTool(
     'unlink_transfer',
     {
       description:
         'Unlink transfer transactions by their shared transferId (UUID string). Both transactions in the pair will become independent income/expense entries. Use search_transactions to find the transferId of a linked pair.',
-      inputSchema: {
-        transferIds: z
-          .array(z.string())
-          .min(1)
-          .describe('One or more transferId UUID strings identifying transfer pairs to unlink'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-budget.ts
+++ b/packages/backend/src/services/mcp/tools/update-budget.ts
@@ -7,27 +7,29 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  budgetId: recordId().describe('ID of the budget to update'),
+  name: z.string().optional().describe('New budget name'),
+  startDate: z.string().optional().describe('New start date (ISO 8601)'),
+  endDate: z.string().optional().describe('New end date (ISO 8601)'),
+  limitAmount: z
+    .number()
+    .optional()
+    .describe("New spending limit as a decimal amount in the user's base currency (e.g. 500.00)"),
+  autoInclude: z.boolean().optional().describe('Whether to auto-include transactions in the date range'),
+  categoryIds: z
+    .array(recordId())
+    .optional()
+    .describe('Replace the linked category IDs (only applies to category-type budgets)'),
+};
+
 export function registerUpdateBudget(server: McpServer) {
   server.registerTool(
     'update_budget',
     {
       description:
         "Update an existing budget's name, date range, spending limit, or linked categories. Returns the updated budget record.",
-      inputSchema: {
-        budgetId: recordId().describe('ID of the budget to update'),
-        name: z.string().optional().describe('New budget name'),
-        startDate: z.string().optional().describe('New start date (ISO 8601)'),
-        endDate: z.string().optional().describe('New end date (ISO 8601)'),
-        limitAmount: z
-          .number()
-          .optional()
-          .describe("New spending limit as a decimal amount in the user's base currency (e.g. 500.00)"),
-        autoInclude: z.boolean().optional().describe('Whether to auto-include transactions in the date range'),
-        categoryIds: z
-          .array(recordId())
-          .optional()
-          .describe('Replace the linked category IDs (only applies to category-type budgets)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-category.ts
+++ b/packages/backend/src/services/mcp/tools/update-category.ts
@@ -6,18 +6,20 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  categoryId: recordId().describe('ID of the category to update.'),
+  name: z.string().optional().describe('New category name.'),
+  color: z.string().optional().describe('New hex color code (e.g. "#4CAF50").'),
+  icon: z.string().nullable().optional().describe('New icon identifier, or null to clear it.'),
+};
+
 export function registerUpdateCategory(server: McpServer) {
   server.registerTool(
     'update_category',
     {
       description:
         'Update an existing category by ID. Use when the user wants to rename, recolor, or change the icon of a category. Returns the updated category records.',
-      inputSchema: {
-        categoryId: recordId().describe('ID of the category to update.'),
-        name: z.string().optional().describe('New category name.'),
-        color: z.string().optional().describe('New hex color code (e.g. "#4CAF50").'),
-        icon: z.string().nullable().optional().describe('New icon identifier, or null to clear it.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-investment-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/update-investment-transaction.ts
@@ -7,38 +7,40 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  transactionId: recordId().describe('Investment transaction ID (from get_investment_transactions)'),
+  category: z
+    .enum([
+      INVESTMENT_TRANSACTION_CATEGORY.buy,
+      INVESTMENT_TRANSACTION_CATEGORY.sell,
+      INVESTMENT_TRANSACTION_CATEGORY.dividend,
+      INVESTMENT_TRANSACTION_CATEGORY.transfer,
+      INVESTMENT_TRANSACTION_CATEGORY.tax,
+      INVESTMENT_TRANSACTION_CATEGORY.fee,
+      INVESTMENT_TRANSACTION_CATEGORY.cancel,
+      INVESTMENT_TRANSACTION_CATEGORY.other,
+    ])
+    .optional()
+    .describe('New transaction category'),
+  date: z
+    .union([z.string().date(), z.string().datetime({ offset: true })])
+    .optional()
+    .describe(
+      'When the trade occurred. Accepts a date-only value (ISO 8601, e.g. "2024-03-15") or a full datetime (e.g. "2024-03-15T09:30:00.000Z"); date-only is stored at UTC midnight.',
+    ),
+  quantity: z.string().optional().describe('New share quantity as a decimal string'),
+  price: z.string().optional().describe('New price per share as a decimal string'),
+  fees: z.string().optional().describe('New fees/commissions as a decimal string'),
+  name: z.string().optional().describe('New label or note'),
+};
+
 export function registerUpdateInvestmentTransaction(server: McpServer) {
   server.registerTool(
     'update_investment_transaction',
     {
       description:
         'Update an existing investment transaction — correct the date, quantity, price, fees, category, or label. Obtain the transactionId from get_investment_transactions. Only provided fields are changed; the holding recalculation runs automatically after every update.',
-      inputSchema: {
-        transactionId: recordId().describe('Investment transaction ID (from get_investment_transactions)'),
-        category: z
-          .enum([
-            INVESTMENT_TRANSACTION_CATEGORY.buy,
-            INVESTMENT_TRANSACTION_CATEGORY.sell,
-            INVESTMENT_TRANSACTION_CATEGORY.dividend,
-            INVESTMENT_TRANSACTION_CATEGORY.transfer,
-            INVESTMENT_TRANSACTION_CATEGORY.tax,
-            INVESTMENT_TRANSACTION_CATEGORY.fee,
-            INVESTMENT_TRANSACTION_CATEGORY.cancel,
-            INVESTMENT_TRANSACTION_CATEGORY.other,
-          ])
-          .optional()
-          .describe('New transaction category'),
-        date: z
-          .union([z.string().date(), z.string().datetime({ offset: true })])
-          .optional()
-          .describe(
-            'When the trade occurred. Accepts a date-only value (ISO 8601, e.g. "2024-03-15") or a full datetime (e.g. "2024-03-15T09:30:00.000Z"); date-only is stored at UTC midnight.',
-          ),
-        quantity: z.string().optional().describe('New share quantity as a decimal string'),
-        price: z.string().optional().describe('New price per share as a decimal string'),
-        fees: z.string().optional().describe('New fees/commissions as a decimal string'),
-        name: z.string().optional().describe('New label or note'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-payee.ts
+++ b/packages/backend/src/services/mcp/tools/update-payee.ts
@@ -5,17 +5,19 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('Payee id.'),
+  name: z.string().optional().describe('New display name.'),
+  defaultCategoryId: z.string().nullable().optional().describe('New default category id, or null to clear.'),
+};
+
 export function registerUpdatePayee(server: McpServer) {
   server.registerTool(
     'update_payee',
     {
       description:
         'Rename a Payee or set/clear its defaultCategoryId. Renaming preserves the previous canonical name as an alias so historical matches still resolve.',
-      inputSchema: {
-        id: z.string().describe('Payee id.'),
-        name: z.string().optional().describe('New display name.'),
-        defaultCategoryId: z.string().nullable().optional().describe('New default category id, or null to clear.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-portfolio.ts
+++ b/packages/backend/src/services/mcp/tools/update-portfolio.ts
@@ -7,22 +7,24 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
+  name: z.string().optional().describe('New portfolio name (must be unique for this user)'),
+  portfolioType: z
+    .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
+    .optional()
+    .describe('New portfolio type: investment, retirement, savings, or other'),
+  description: z.string().nullable().optional().describe('New description (pass null to clear)'),
+  isEnabled: z.boolean().optional().describe('Enable or disable the portfolio'),
+};
+
 export function registerUpdatePortfolio(server: McpServer) {
   server.registerTool(
     'update_portfolio',
     {
       description:
         "Update an existing portfolio's name, type, description, or enabled state. Use when the user wants to rename, recategorize, or disable one of their portfolios. Obtain the portfolioId from get_portfolios first. Only the fields provided are changed.",
-      inputSchema: {
-        portfolioId: recordId().describe('Portfolio ID (from get_portfolios)'),
-        name: z.string().optional().describe('New portfolio name (must be unique for this user)'),
-        portfolioType: z
-          .enum([PORTFOLIO_TYPE.investment, PORTFOLIO_TYPE.retirement, PORTFOLIO_TYPE.savings, PORTFOLIO_TYPE.other])
-          .optional()
-          .describe('New portfolio type: investment, retirement, savings, or other'),
-        description: z.string().nullable().optional().describe('New description (pass null to clear)'),
-        isEnabled: z.boolean().optional().describe('Enable or disable the portfolio'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-subscription.ts
+++ b/packages/backend/src/services/mcp/tools/update-subscription.ts
@@ -7,57 +7,55 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: z.string().describe('UUID of the subscription to update'),
+  name: z.string().optional().describe('New display name'),
+  frequency: z
+    .enum([
+      SUBSCRIPTION_FREQUENCIES.weekly,
+      SUBSCRIPTION_FREQUENCIES.biweekly,
+      SUBSCRIPTION_FREQUENCIES.monthly,
+      SUBSCRIPTION_FREQUENCIES.quarterly,
+      SUBSCRIPTION_FREQUENCIES.semiAnnual,
+      SUBSCRIPTION_FREQUENCIES.annual,
+    ])
+    .optional()
+    .describe('New billing frequency'),
+  startDate: z.string().optional().describe('New start date (ISO 8601)'),
+  type: z
+    .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
+    .optional()
+    .describe(
+      'New type: "subscription", "bill", or "installment". Switching to installment requires maxOccurrences and dueDate to be set (pass them in the same call).',
+    ),
+  expectedAmount: z.number().nullable().optional().describe('New expected payment amount as a decimal (e.g. 9.99)'),
+  expectedCurrencyCode: currencyCode().nullable().optional().describe('New currency code for expectedAmount'),
+  endDate: z.string().nullable().optional().describe('New end date (ISO 8601), or null to clear'),
+  dueDate: z
+    .string()
+    .nullable()
+    .optional()
+    .describe('New first/next payment date (ISO 8601), or null to clear the schedule'),
+  maxOccurrences: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .optional()
+    .describe('New total number of payments, or null for an indefinite schedule'),
+  accountId: recordId().nullable().optional().describe('New account ID, or null to clear'),
+  categoryId: recordId().nullable().optional().describe('New category ID, or null to clear'),
+  notes: z.string().nullable().optional().describe('New notes, or null to clear'),
+  isActive: z.boolean().optional().describe('Active state (prefer toggle_subscription_active instead)'),
+};
+
 export function registerUpdateSubscription(server: McpServer) {
   server.registerTool(
     'update_subscription',
     {
       description:
         'Update fields on an existing subscription or bill. Only provided fields are changed. To toggle active state use toggle_subscription_active instead. Requires finance:write scope.',
-      inputSchema: {
-        id: z.string().describe('UUID of the subscription to update'),
-        name: z.string().optional().describe('New display name'),
-        frequency: z
-          .enum([
-            SUBSCRIPTION_FREQUENCIES.weekly,
-            SUBSCRIPTION_FREQUENCIES.biweekly,
-            SUBSCRIPTION_FREQUENCIES.monthly,
-            SUBSCRIPTION_FREQUENCIES.quarterly,
-            SUBSCRIPTION_FREQUENCIES.semiAnnual,
-            SUBSCRIPTION_FREQUENCIES.annual,
-          ])
-          .optional()
-          .describe('New billing frequency'),
-        startDate: z.string().optional().describe('New start date (ISO 8601)'),
-        type: z
-          .enum([SUBSCRIPTION_TYPES.subscription, SUBSCRIPTION_TYPES.bill, SUBSCRIPTION_TYPES.installment])
-          .optional()
-          .describe(
-            'New type: "subscription", "bill", or "installment". Switching to installment requires maxOccurrences and dueDate to be set (pass them in the same call).',
-          ),
-        expectedAmount: z
-          .number()
-          .nullable()
-          .optional()
-          .describe('New expected payment amount as a decimal (e.g. 9.99)'),
-        expectedCurrencyCode: currencyCode().nullable().optional().describe('New currency code for expectedAmount'),
-        endDate: z.string().nullable().optional().describe('New end date (ISO 8601), or null to clear'),
-        dueDate: z
-          .string()
-          .nullable()
-          .optional()
-          .describe('New first/next payment date (ISO 8601), or null to clear the schedule'),
-        maxOccurrences: z
-          .number()
-          .int()
-          .positive()
-          .nullable()
-          .optional()
-          .describe('New total number of payments, or null for an indefinite schedule'),
-        accountId: recordId().nullable().optional().describe('New account ID, or null to clear'),
-        categoryId: recordId().nullable().optional().describe('New category ID, or null to clear'),
-        notes: z.string().nullable().optional().describe('New notes, or null to clear'),
-        isActive: z.boolean().optional().describe('Active state (prefer toggle_subscription_active instead)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-tag.ts
+++ b/packages/backend/src/services/mcp/tools/update-tag.ts
@@ -6,19 +6,21 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the tag to update.'),
+  name: z.string().optional().describe('New tag name (must be unique for this user).'),
+  color: z.string().optional().describe('New hex color code for the tag (e.g. "#FF5733").'),
+  icon: z.string().nullable().optional().describe('New icon identifier, or null to clear it.'),
+  description: z.string().nullable().optional().describe('New description, or null to clear it.'),
+};
+
 export function registerUpdateTag(server: McpServer) {
   server.registerTool(
     'update_tag',
     {
       description:
         'Update an existing tag by ID. Use when the user wants to rename, recolor, or change the icon/description of a tag. Returns the updated tag.',
-      inputSchema: {
-        id: recordId().describe('ID of the tag to update.'),
-        name: z.string().optional().describe('New tag name (must be unique for this user).'),
-        color: z.string().optional().describe('New hex color code for the tag (e.g. "#FF5733").'),
-        icon: z.string().nullable().optional().describe('New icon identifier, or null to clear it.'),
-        description: z.string().nullable().optional().describe('New description, or null to clear it.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-transaction-group.ts
+++ b/packages/backend/src/services/mcp/tools/update-transaction-group.ts
@@ -6,17 +6,19 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the transaction group to update'),
+  name: z.string().optional().describe('New display name for the group'),
+  note: z.string().nullable().optional().describe('New note for the group (pass null to clear)'),
+};
+
 export function registerUpdateTransactionGroup(server: McpServer) {
   server.registerTool(
     'update_transaction_group',
     {
       description:
         'Update the name or note of an existing transaction group. To change group membership use add_transactions_to_group or remove_transactions_from_group. Requires finance:write scope.',
-      inputSchema: {
-        id: recordId().describe('ID of the transaction group to update'),
-        name: z.string().optional().describe('New display name for the group'),
-        note: z.string().nullable().optional().describe('New note for the group (pass null to clear)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-transaction.ts
+++ b/packages/backend/src/services/mcp/tools/update-transaction.ts
@@ -9,70 +9,72 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  id: recordId().describe('ID of the transaction to update'),
+  accountId: recordId().optional().describe('Move transaction to a different account'),
+  amount: z.number().optional().describe('New amount as a decimal (e.g. 12.50)'),
+  transactionType: z
+    .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
+    .optional()
+    .describe('Change whether this is income or expense'),
+  paymentType: z
+    .enum([
+      PAYMENT_TYPES.bankTransfer,
+      PAYMENT_TYPES.cash,
+      PAYMENT_TYPES.creditCard,
+      PAYMENT_TYPES.debitCard,
+      PAYMENT_TYPES.mobilePayment,
+      PAYMENT_TYPES.voucher,
+      PAYMENT_TYPES.webPayment,
+    ])
+    .optional()
+    .describe('Payment method used'),
+  transferNature: z
+    .enum([
+      TRANSACTION_TRANSFER_NATURE.not_transfer,
+      TRANSACTION_TRANSFER_NATURE.common_transfer,
+      TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
+    ])
+    .optional()
+    .describe('Transfer type'),
+  categoryId: recordId().optional().describe('New category ID'),
+  time: z.string().optional().describe('New date/time as ISO 8601 string'),
+  note: z.string().optional().nullable().describe('New note. Pass null to clear'),
+  destinationAccountId: recordId().optional().describe('For transfers: new destination account ID'),
+  destinationAmount: z
+    .number()
+    .optional()
+    .describe('For transfers: new amount received in destination account (decimal)'),
+  destinationTransactionId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('For transfers: link to an existing destination transaction'),
+  splits: z
+    .array(
+      z.object({
+        categoryId: recordId().describe('Category ID for this split portion'),
+        amount: z.number().describe('Amount for this split portion (decimal)'),
+        note: z.string().optional().nullable().describe('Optional note for this split'),
+      }),
+    )
+    .nullable()
+    .optional()
+    .describe('Replace splits. Pass null or empty array to clear all splits'),
+  tagIds: z
+    .array(recordId())
+    .nullable()
+    .optional()
+    .describe('Replace tags. Pass null or empty array to clear all tags'),
+};
+
 export function registerUpdateTransaction(server: McpServer) {
   server.registerTool(
     'update_transaction',
     {
       description:
         'Update an existing transaction by ID. All fields except id are optional — only provide what you want to change. Pass tagIds: null to clear all tags, or tagIds: [] to do the same. Pass splits: null to clear all splits.',
-      inputSchema: {
-        id: recordId().describe('ID of the transaction to update'),
-        accountId: recordId().optional().describe('Move transaction to a different account'),
-        amount: z.number().optional().describe('New amount as a decimal (e.g. 12.50)'),
-        transactionType: z
-          .enum([TRANSACTION_TYPES.income, TRANSACTION_TYPES.expense])
-          .optional()
-          .describe('Change whether this is income or expense'),
-        paymentType: z
-          .enum([
-            PAYMENT_TYPES.bankTransfer,
-            PAYMENT_TYPES.cash,
-            PAYMENT_TYPES.creditCard,
-            PAYMENT_TYPES.debitCard,
-            PAYMENT_TYPES.mobilePayment,
-            PAYMENT_TYPES.voucher,
-            PAYMENT_TYPES.webPayment,
-          ])
-          .optional()
-          .describe('Payment method used'),
-        transferNature: z
-          .enum([
-            TRANSACTION_TRANSFER_NATURE.not_transfer,
-            TRANSACTION_TRANSFER_NATURE.common_transfer,
-            TRANSACTION_TRANSFER_NATURE.transfer_out_wallet,
-          ])
-          .optional()
-          .describe('Transfer type'),
-        categoryId: recordId().optional().describe('New category ID'),
-        time: z.string().optional().describe('New date/time as ISO 8601 string'),
-        note: z.string().optional().nullable().describe('New note. Pass null to clear'),
-        destinationAccountId: recordId().optional().describe('For transfers: new destination account ID'),
-        destinationAmount: z
-          .number()
-          .optional()
-          .describe('For transfers: new amount received in destination account (decimal)'),
-        destinationTransactionId: z
-          .string()
-          .uuid()
-          .optional()
-          .describe('For transfers: link to an existing destination transaction'),
-        splits: z
-          .array(
-            z.object({
-              categoryId: recordId().describe('Category ID for this split portion'),
-              amount: z.number().describe('Amount for this split portion (decimal)'),
-              note: z.string().optional().nullable().describe('Optional note for this split'),
-            }),
-          )
-          .nullable()
-          .optional()
-          .describe('Replace splits. Pass null or empty array to clear all splits'),
-        tagIds: z
-          .array(recordId())
-          .nullable()
-          .optional()
-          .describe('Replace tags. Pass null or empty array to clear all tags'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-venture-deal.ts
+++ b/packages/backend/src/services/mcp/tools/update-venture-deal.ts
@@ -7,32 +7,32 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
+  name: z.string().optional().describe('New deal name'),
+  platformId: recordId().nullable().optional().describe('Move to a different platform (or null to clear)'),
+  spvSubtype: z.nativeEnum(VENTURE_SPV_SUBTYPE).nullable().optional().describe('New SPV subtype'),
+  targetCompany: z.string().nullable().optional().describe('New target company name'),
+  currencyCode: currencyCode().optional().describe('New currency code (locked once events exist)'),
+  status: z.nativeEnum(VENTURE_DEAL_STATUS).optional().describe('Override the deal status manually'),
+  principal: decimalString().optional().describe('New principal (locked once events exist)'),
+  entryFee: decimalString().optional().describe('New entry fee amount (locked once events exist)'),
+  entryFeePct: percentageFraction().optional().describe('New entry fee fraction in [0,1] (locked once events exist)'),
+  mgmtFeePct: percentageFraction().optional().describe('New management fee fraction in [0,1]'),
+  carryPct: percentageFraction().optional().describe('New carry fraction in [0,1] (locked once events exist)'),
+  hurdlePct: percentageFraction().optional().describe('New hurdle fraction in [0,1] (locked once events exist)'),
+  investmentDate: dateString().optional().describe('New investment date (locked once events exist)'),
+  expectedExitDate: dateString().nullable().optional().describe('New expected exit date (or null to clear)'),
+  notes: z.string().nullable().optional().describe('New notes (or null to clear)'),
+};
+
 export function registerUpdateVentureDeal(server: McpServer) {
   server.registerTool(
     'update_venture_deal',
     {
       description:
         'Update a venture deal. Only provided fields change. Once any event exists on the deal, the terms (principal, entryFee, entryFeePct, carryPct, hurdlePct, investmentDate, currencyCode) are locked — changing them would silently stale the carry math. Delete the events first if the user needs to fix terms. Status can be overridden manually (auto-progression normally derives it from events). Fee percentages are decimal fractions in [0,1].',
-      inputSchema: {
-        dealId: recordId().describe('Venture deal ID (from list_venture_deals)'),
-        name: z.string().optional().describe('New deal name'),
-        platformId: recordId().nullable().optional().describe('Move to a different platform (or null to clear)'),
-        spvSubtype: z.nativeEnum(VENTURE_SPV_SUBTYPE).nullable().optional().describe('New SPV subtype'),
-        targetCompany: z.string().nullable().optional().describe('New target company name'),
-        currencyCode: currencyCode().optional().describe('New currency code (locked once events exist)'),
-        status: z.nativeEnum(VENTURE_DEAL_STATUS).optional().describe('Override the deal status manually'),
-        principal: decimalString().optional().describe('New principal (locked once events exist)'),
-        entryFee: decimalString().optional().describe('New entry fee amount (locked once events exist)'),
-        entryFeePct: percentageFraction()
-          .optional()
-          .describe('New entry fee fraction in [0,1] (locked once events exist)'),
-        mgmtFeePct: percentageFraction().optional().describe('New management fee fraction in [0,1]'),
-        carryPct: percentageFraction().optional().describe('New carry fraction in [0,1] (locked once events exist)'),
-        hurdlePct: percentageFraction().optional().describe('New hurdle fraction in [0,1] (locked once events exist)'),
-        investmentDate: dateString().optional().describe('New investment date (locked once events exist)'),
-        expectedExitDate: dateString().nullable().optional().describe('New expected exit date (or null to clear)'),
-        notes: z.string().nullable().optional().describe('New notes (or null to clear)'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-venture-event.ts
+++ b/packages/backend/src/services/mcp/tools/update-venture-event.ts
@@ -6,36 +6,36 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  eventId: recordId().describe('Venture event ID (from list_venture_events)'),
+  eventDate: dateString().optional().describe('New event date (YYYY-MM-DD)'),
+  grossAmount: decimalString().nullable().optional().describe('New gross amount (decimal string)'),
+  navAfter: decimalString().nullable().optional().describe('New post-event NAV (decimal string)'),
+  quantityPct: decimalString().nullable().optional().describe('New partial-exit quantity fraction in [0,1]'),
+  notes: z.string().nullable().optional().describe('New notes (or null to clear)'),
+  gpCarryAmount: decimalString()
+    .nullable()
+    .optional()
+    .describe('Set the manual gpCarry override; flips gpCarryOverridden=true. To clear, use resetOverrides=true.'),
+  lpNetAmount: decimalString()
+    .nullable()
+    .optional()
+    .describe(
+      'Set the manual lpNetAmount override; flips lpNetAmountOverridden=true. To clear, use resetOverrides=true.',
+    ),
+  resetOverrides: z
+    .boolean()
+    .optional()
+    .describe('When true, clears both override flags and re-computes carry from deal terms.'),
+};
+
 export function registerUpdateVentureEvent(server: McpServer) {
   server.registerTool(
     'update_venture_event',
     {
       description:
         'Update a venture event. Only provided fields change. eventDate must stay on/after the initial_investment date (and moving an initial_investment past existing later events is rejected).\n\nOverride semantics for gpCarryAmount / lpNetAmount:\n  • Omit the field → no change.\n  • Pass a string value → set the manual override; flips the corresponding *Overridden flag to true.\n  • Pass null → currently treated the same as omitting (no semantic clear). To clear an existing override, use `resetOverrides: true` instead.\n\nThe event type cannot be changed — delete and recreate instead.',
-      inputSchema: {
-        eventId: recordId().describe('Venture event ID (from list_venture_events)'),
-        eventDate: dateString().optional().describe('New event date (YYYY-MM-DD)'),
-        grossAmount: decimalString().nullable().optional().describe('New gross amount (decimal string)'),
-        navAfter: decimalString().nullable().optional().describe('New post-event NAV (decimal string)'),
-        quantityPct: decimalString().nullable().optional().describe('New partial-exit quantity fraction in [0,1]'),
-        notes: z.string().nullable().optional().describe('New notes (or null to clear)'),
-        gpCarryAmount: decimalString()
-          .nullable()
-          .optional()
-          .describe(
-            'Set the manual gpCarry override; flips gpCarryOverridden=true. To clear, use resetOverrides=true.',
-          ),
-        lpNetAmount: decimalString()
-          .nullable()
-          .optional()
-          .describe(
-            'Set the manual lpNetAmount override; flips lpNetAmountOverridden=true. To clear, use resetOverrides=true.',
-          ),
-        resetOverrides: z
-          .boolean()
-          .optional()
-          .describe('When true, clears both override flags and re-computes carry from deal terms.'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });

--- a/packages/backend/src/services/mcp/tools/update-venture-platform.ts
+++ b/packages/backend/src/services/mcp/tools/update-venture-platform.ts
@@ -6,30 +6,30 @@ import { z } from 'zod';
 
 import { getUserId, jsonContent, requireScope } from './helpers';
 
+const inputSchema = {
+  platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
+  name: z.string().optional().describe('New platform name (must be unique for this user)'),
+  website: z.string().nullable().optional().describe('New website URL (pass null to clear)'),
+  description: z.string().nullable().optional().describe('New description (pass null to clear)'),
+  defaultEntryFeePct: percentageFraction()
+    .optional()
+    .describe('New default entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%).'),
+  defaultMgmtFeePct: percentageFraction()
+    .optional()
+    .describe('New default management fee as a decimal fraction in [0,1].'),
+  defaultCarryPct: percentageFraction()
+    .optional()
+    .describe('New default carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%).'),
+  defaultHurdlePct: percentageFraction().optional().describe('New default hurdle rate as a decimal fraction in [0,1].'),
+};
+
 export function registerUpdateVenturePlatform(server: McpServer) {
   server.registerTool(
     'update_venture_platform',
     {
       description:
         "Update an existing venture platform's name, website, description, or default fees. Only provided fields change. Updating default fees does NOT retroactively change fees on existing deals — those are snapshotted at deal creation. Fee fractions are decimals in [0,1].",
-      inputSchema: {
-        platformId: recordId().describe('Venture platform ID (from list_venture_platforms)'),
-        name: z.string().optional().describe('New platform name (must be unique for this user)'),
-        website: z.string().nullable().optional().describe('New website URL (pass null to clear)'),
-        description: z.string().nullable().optional().describe('New description (pass null to clear)'),
-        defaultEntryFeePct: percentageFraction()
-          .optional()
-          .describe('New default entry fee as a decimal fraction in [0,1] (e.g. 0.085 for 8.5%).'),
-        defaultMgmtFeePct: percentageFraction()
-          .optional()
-          .describe('New default management fee as a decimal fraction in [0,1].'),
-        defaultCarryPct: percentageFraction()
-          .optional()
-          .describe('New default carry as a decimal fraction in [0,1] (e.g. 0.2 for 20%).'),
-        defaultHurdlePct: percentageFraction()
-          .optional()
-          .describe('New default hurdle rate as a decimal fraction in [0,1].'),
-      },
+      inputSchema,
     },
     async (args, extra) => {
       const userId = getUserId({ extra });


### PR DESCRIPTION
- reduces memory usage by MCP server from 12MB to 0.4MB per each session
- stops storing `req` in the CLS context. Saves up to 64KB memory usage on some requests
- registers SSE disconnect before the initial sync happens, so dropped user won't leave connection open
- store better-auth rate limiting in the Redis; better-auth cannot manage stale rate-limiting data until the same IP calls the app again, so it was causing cheap yet memory leak. Redis is able to self-clean using TTL