### PR TITLE
Allow counting selected categories as savings in cash flow

### DIFF
--- a/packages/backend/src/models/user-settings.model.ts
+++ b/packages/backend/src/models/user-settings.model.ts
@@ -263,6 +263,10 @@ export const ZodSettingsSchema = z.object({
   // matcher. Opt-in because linking turns a manually recorded row into a transfer leg, and
   // transfer legs carry no category, so the row disappears from category stats.
   matchTransfersWithManualAccounts: z.boolean().optional(),
+  // Categories whose legs leave the cash-flow report entirely, so money moved into them counts as
+  // savings rather than spend. Descendants are expanded server-side. Plain z.uuid(), not
+  // recordId(): the branded RecordId output breaks the SettingsPatchSchemaIsInSync assertion below.
+  savingsCategoryIds: z.array(z.uuid()).optional(),
 });
 
 export type SettingsSchema = z.infer<typeof ZodSettingsSchema>;
@@ -351,6 +355,7 @@ export const ZodSettingsPatchSchema = z.object({
   showSupportButton: z.boolean().optional(),
   hideZeroBalances: z.boolean().optional(),
   matchTransfersWithManualAccounts: z.boolean().optional(),
+  savingsCategoryIds: z.array(z.uuid()).optional(),
 });
 
 export type SettingsPatchSchema = z.infer<typeof ZodSettingsPatchSchema>;

--- a/packages/backend/src/services/stats/get-cash-flow.e2e.ts
+++ b/packages/backend/src/services/stats/get-cash-flow.e2e.ts
@@ -1224,3 +1224,133 @@ describe('GET /stats/cash-flow — refunds and splits', () => {
     });
   });
 });
+
+describe('GET /stats/cash-flow — savings categories setting', () => {
+  type TxCategoryId = Parameters<typeof helpers.buildTransactionPayload>[0]['categoryId'];
+
+  /** One bucket holding $1000 income, $200 spent in the savings category and $100 elsewhere. */
+  const seedPeriod = async ({
+    savingsCategoryId,
+    otherCategoryId,
+  }: {
+    savingsCategoryId: TxCategoryId;
+    otherCategoryId: TxCategoryId;
+  }) => {
+    const account = await helpers.createAccount({ raw: true });
+
+    await helpers.createTransaction({
+      payload: {
+        ...helpers.buildTransactionPayload({
+          accountId: account.id,
+          amount: 1000,
+          transactionType: TRANSACTION_TYPES.income,
+        }),
+        time: TX_TIME,
+      },
+      raw: true,
+    });
+
+    for (const [categoryId, amount] of [
+      [savingsCategoryId, 200],
+      [otherCategoryId, 100],
+    ] as const) {
+      await helpers.createTransaction({
+        payload: {
+          ...helpers.buildTransactionPayload({
+            accountId: account.id,
+            amount,
+            transactionType: TRANSACTION_TYPES.expense,
+            categoryId,
+          }),
+          time: TX_TIME,
+        },
+        raw: true,
+      });
+    }
+  };
+
+  const createCategoryPair = () =>
+    Promise.all([
+      helpers.addCustomCategory({ name: uniqueName('Savings'), color: '#00aa88', raw: true }),
+      helpers.addCustomCategory({ name: uniqueName('Groceries'), color: '#aa0088', raw: true }),
+    ]);
+
+  it('counts the spend as an expense while the setting is unset', async () => {
+    const [savingsCategory, otherCategory] = await createCategoryPair();
+    await seedPeriod({ savingsCategoryId: savingsCategory.id, otherCategoryId: otherCategory.id });
+
+    const result = await helpers.getCashFlow({ ...RANGE, raw: true });
+
+    const period = result.periods[0]!;
+    expect(period.expenses).toBe(300);
+    expect(period.netFlow).toBe(700);
+    expect(result.totals.savingsRate).toBe(70);
+    expect(period.categories!.find((entry) => entry.categoryId === savingsCategory.id)!.expenseAmount).toBe(200);
+  });
+
+  it('drops a savings category from the expenses and raises netFlow and savingsRate', async () => {
+    const [savingsCategory, otherCategory] = await createCategoryPair();
+    await seedPeriod({ savingsCategoryId: savingsCategory.id, otherCategoryId: otherCategory.id });
+
+    await helpers.patchUserSettings({ patch: { savingsCategoryIds: [savingsCategory.id] }, raw: true });
+
+    const result = await helpers.getCashFlow({ ...RANGE, raw: true });
+
+    const period = result.periods[0]!;
+    expect(period.expenses).toBe(100);
+    expect(period.income).toBe(1000);
+    expect(period.netFlow).toBe(900);
+    expect(result.totals.expenses).toBe(100);
+    expect(result.totals.savingsRate).toBe(90);
+    expect(period.categories!.some((entry) => entry.categoryId === savingsCategory.id)).toBe(false);
+    expect(period.categories!.find((entry) => entry.categoryId === otherCategory.id)!.expenseAmount).toBe(100);
+  });
+
+  it('excludes spend filed under a subcategory of a listed savings category', async () => {
+    const parentCategory = await helpers.addCustomCategory({
+      name: uniqueName('SavingsParent'),
+      color: '#00aa88',
+      raw: true,
+    });
+    const [childCategory, otherCategory] = await Promise.all([
+      helpers.addCustomCategory({
+        name: uniqueName('SavingsChild'),
+        color: '#0088aa',
+        parentId: parentCategory.id,
+        raw: true,
+      }),
+      helpers.addCustomCategory({ name: uniqueName('Groceries'), color: '#aa0088', raw: true }),
+    ]);
+
+    await seedPeriod({ savingsCategoryId: childCategory.id, otherCategoryId: otherCategory.id });
+    await helpers.patchUserSettings({ patch: { savingsCategoryIds: [parentCategory.id] }, raw: true });
+
+    const result = await helpers.getCashFlow({ ...RANGE, raw: true });
+
+    const period = result.periods[0]!;
+    expect(period.expenses).toBe(100);
+    expect(period.netFlow).toBe(900);
+    // The breakdown rolls to roots, so a leaked child would resurface under the savings parent.
+    expect(period.categories!.some((entry) => entry.categoryId === parentCategory.id)).toBe(false);
+  });
+
+  it('leaves the report untouched when the setting lists an unrelated category', async () => {
+    const [savingsCategory, otherCategory] = await createCategoryPair();
+    const unrelatedCategory = await helpers.addCustomCategory({
+      name: uniqueName('Unrelated'),
+      color: '#010203',
+      raw: true,
+    });
+    await seedPeriod({ savingsCategoryId: savingsCategory.id, otherCategoryId: otherCategory.id });
+
+    const baseline = await helpers.getCashFlow({ ...RANGE, raw: true });
+
+    await helpers.patchUserSettings({ patch: { savingsCategoryIds: [unrelatedCategory.id] }, raw: true });
+
+    const result = await helpers.getCashFlow({ ...RANGE, raw: true });
+
+    expect(result.periods).toEqual(baseline.periods);
+    expect(result.totals).toEqual(baseline.totals);
+    expect(result.totals.expenses).toBe(300);
+  });
+});

--- a/packages/backend/src/services/stats/get-cash-flow.ts
+++ b/packages/backend/src/services/stats/get-cash-flow.ts
@@ -8,6 +8,7 @@ import {
 } from '@services/categories/get-accessible-category-map.service';
 import { withTransaction } from '@services/common/with-transaction';
 import { statsTransactions } from '@services/stats/stats-transactions';
+import { getUserSettings } from '@services/user-settings/get-user-settings';
 import { format } from 'date-fns';
 import { Op } from 'sequelize';
 
@@ -180,12 +181,17 @@ export const getCashFlow = withTransaction(
     // Create a set of target categories for aggregation (when specific categories are selected)
     const targetCategoryIds = aggregateToSelectedCategories ? new Set<string>(categoryIds) : undefined;
 
+    // Categories the user counts as savings drop out of the report the same way an explicitly
+    // excluded one does: money moved there is saved rather than spent, so it must not lower netFlow.
+    const { savingsCategoryIds } = await getUserSettings({ userId });
+    const hiddenCategoryIds = [...(excludedCategoryIds ?? []), ...(savingsCategoryIds ?? [])];
+
     // Hiding a parent hides everything under it, including subcategories created after the caller
     // saved the exclusion list.
     const excludedCategoryIdSet = new Set<string>(
-      excludedCategoryIds && excludedCategoryIds.length > 0
+      hiddenCategoryIds.length > 0
         ? expandCategoryIdsWithDescendants({
-            categoryIds: excludedCategoryIds,
+            categoryIds: hiddenCategoryIds,
             categories: allCategories,
             byId: categoryMap,
           })

--- a/packages/frontend/src/api/user-settings.ts
+++ b/packages/frontend/src/api/user-settings.ts
@@ -106,6 +106,11 @@ export interface UserSettingsSchema {
     defaultAccountId?: string | null;
     showArchivedInDropdowns?: boolean;
   };
+  /**
+   * Categories whose spending counts as savings in the cash-flow analytics instead of as an
+   * expense. Subcategories inherit from their parent. Empty or unset leaves cash flow unchanged.
+   */
+  savingsCategoryIds?: string[];
 }
 
 export const getUserSettings = async (): Promise<UserSettingsSchema> => {

--- a/packages/frontend/src/i18n/locales/chunks/en/settings/general.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/settings/general.json
@@ -15,6 +15,12 @@
         "successNotification": "Transfer matching setting updated",
         "errorNotification": "Failed to update transfer matching setting"
       },
+      "savingsCategories": {
+        "label": "Count categories as savings",
+        "description": "Spending in these categories (and their subcategories) is excluded from expenses in cash-flow analytics, so it counts toward monthly savings and the savings rate.",
+        "successNotification": "Savings categories updated",
+        "errorNotification": "Failed to update savings categories"
+      },
       "accountDropdowns": {
         "defaultAccount": {
           "label": "Default account",

--- a/packages/frontend/src/pages/settings/subpages/general/index.vue
+++ b/packages/frontend/src/pages/settings/subpages/general/index.vue
@@ -46,6 +46,27 @@
         <div class="flex flex-wrap items-center justify-between gap-4">
           <div class="min-w-48 flex-1">
             <div class="text-sm font-medium">
+              {{ $t('settings.general.savingsCategories.label') }}
+            </div>
+            <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
+              {{ $t('settings.general.savingsCategories.description') }}
+            </p>
+          </div>
+          <!-- The field's own root is w-full, so the width lives on a wrapper instead of its class. -->
+          <div class="w-64 shrink-0">
+            <CategoryMultiSelectField
+              :model-value="savingsCategoryIds"
+              :disabled="isUpdating"
+              @update:model-value="handleSavingsCategoriesChange"
+            />
+          </div>
+        </div>
+
+        <Separator />
+
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <div class="min-w-48 flex-1">
+            <div class="text-sm font-medium">
               {{ $t('settings.general.accountDropdowns.defaultAccount.label') }}
             </div>
             <p class="text-muted-foreground mt-1 text-xs leading-relaxed">
@@ -88,6 +109,7 @@
 <script setup lang="ts">
 import { VUE_QUERY_CACHE_KEYS } from '@/common/const';
 import AccountSelectField from '@/components/fields/account-select-field.vue';
+import CategoryMultiSelectField from '@/components/fields/category-multi-select-field.vue';
 import { Card, CardContent, CardHeader } from '@/components/lib/ui/card';
 import { Separator } from '@/components/lib/ui/separator';
 import { Switch } from '@/components/lib/ui/switch';
@@ -116,6 +138,7 @@ const {
 
 const includeCreditLimitInStats = computed(() => userSettings.value?.includeCreditLimitInStats ?? false);
 const matchTransfersWithManualAccounts = computed(() => userSettings.value?.matchTransfersWithManualAccounts ?? false);
+const savingsCategoryIds = computed(() => userSettings.value?.savingsCategoryIds ?? []);
 
 const defaultAccount = computed<AccountModel | null>(() =>
   defaultAccountId.value ? (accountsRecord.value[defaultAccountId.value] ?? null) : null,
@@ -155,6 +178,26 @@ const handleManualTransferMatchingToggle = async (value: boolean) => {
     addSuccessNotification(t('settings.general.manualTransferMatching.successNotification'));
   } catch {
     addErrorNotification(t('settings.general.manualTransferMatching.errorNotification'));
+  }
+};
+
+const handleSavingsCategoriesChange = async (value: string[]) => {
+  try {
+    await mutateAsync({
+      ...userSettings.value,
+      savingsCategoryIds: value,
+    });
+
+    addSuccessNotification(t('settings.general.savingsCategories.successNotification'));
+
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: [...VUE_QUERY_CACHE_KEYS.analyticsCashFlow] }),
+      queryClient.invalidateQueries({ queryKey: [...VUE_QUERY_CACHE_KEYS.widgetCashFlow] }),
+      queryClient.invalidateQueries({ queryKey: [...VUE_QUERY_CACHE_KEYS.widgetCashFlowPrev] }),
+      queryClient.invalidateQueries({ queryKey: [...VUE_QUERY_CACHE_KEYS.widgetCashFlowTrend] }),
+    ]);
+  } catch {
+    addErrorNotification(t('settings.general.savingsCategories.errorNotification'));
   }
 };
 


### PR DESCRIPTION
Spending in user-picked categories (subcategories inherit) is excluded from cash-flow expenses, so investment-style outflows raise monthly savings and savings rate instead of lowering them