### PR TITLE
Optionally delete portfolio transfers when deleting an account

### DIFF
--- a/packages/backend/src/controllers/accounts.controller.ts
+++ b/packages/backend/src/controllers/accounts.controller.ts
@@ -1,5 +1,5 @@
 import { ACCOUNT_CATEGORIES, ACCOUNT_STATUSES, ACCOUNT_TYPES } from '@bt/shared/types';
-import { currencyCode, recordId } from '@common/lib/zod/custom-types';
+import { booleanQuery, currencyCode, recordId } from '@common/lib/zod/custom-types';
 import { Money } from '@common/types/money';
 import { findOrThrowNotFound } from '@common/utils/find-or-throw-not-found';
 import { logoFieldsShape, refineLogoFields, refineLogoFieldsOnCreate } from '@controllers/common/logo-fields.schema';
@@ -192,10 +192,19 @@ export const deleteAccount = createController(
     params: z.object({
       id: recordId(),
     }),
+    query: z
+      .object({
+        removePortfolioTransfers: booleanQuery().optional(),
+      })
+      .optional(),
   }),
-  async ({ user, params }) => {
+  async ({ user, params, query }) => {
     const { id } = params;
     const { id: userId } = user;
-    await accountsService.deleteAccountById({ id, userId });
+    await accountsService.deleteAccountById({
+      id,
+      userId,
+      removePortfolioTransfers: query?.removePortfolioTransfers,
+    });
   },
 );

--- a/packages/backend/src/services/accounts.service.ts
+++ b/packages/backend/src/services/accounts.service.ts
@@ -16,6 +16,7 @@ import { logger } from '@js/utils/logger';
 import * as Accounts from '@models/accounts.model';
 import Balances from '@models/balances.model';
 import BankDataProviderConnections from '@models/bank-data-provider-connections.model';
+import PortfolioTransfers from '@models/investments/portfolio-transfers.model';
 import { countTransactions } from '@models/transactions-query';
 import { getBaseCurrency } from '@models/users-currencies.model';
 import Users from '@models/users.model';
@@ -437,7 +438,15 @@ interface DeleteAccountByIdInTxResult {
 }
 
 const deleteAccountByIdInTx = withTransaction(
-  async ({ id, userId }: { id: string; userId: number }): Promise<DeleteAccountByIdInTxResult> => {
+  async ({
+    id,
+    userId,
+    removePortfolioTransfers = false,
+  }: {
+    id: string;
+    userId: number;
+    removePortfolioTransfers?: boolean;
+  }): Promise<DeleteAccountByIdInTxResult> => {
     const account = await Accounts.default.findOne({ where: { id, userId } });
     if (!account) {
       throw new NotFoundError({ message: t({ key: 'accounts.accountNotFound' }) });
@@ -477,6 +486,16 @@ const deleteAccountByIdInTx = withTransaction(
 
     await pauseAutomationsReferencing({ userId, refType: 'account', refId: account.id, label: account.name });
 
+    // Must run before the account destroy — the FK is ON DELETE SET NULL, so afterwards
+    // these rows would no longer reference the account and couldn't be targeted. Without
+    // this opt-in they survive as orphaned contributions and double-count if the user
+    // re-creates the account and re-links the same transfers.
+    if (removePortfolioTransfers) {
+      await PortfolioTransfers.destroy({
+        where: { userId, [Op.or]: [{ fromAccountId: id }, { toAccountId: id }] },
+      });
+    }
+
     const affectedRows = await Accounts.deleteAccountById({ id, userId });
     if (affectedRows === 0) {
       // Defensive: the findOne above succeeded, so a 0-affectedRows here is a concurrency
@@ -493,8 +512,16 @@ const deleteAccountByIdInTx = withTransaction(
   },
 );
 
-export const deleteAccountById = async ({ id, userId }: { id: string; userId: number }) => {
-  const result = await deleteAccountByIdInTx({ id, userId });
+export const deleteAccountById = async ({
+  id,
+  userId,
+  removePortfolioTransfers,
+}: {
+  id: string;
+  userId: number;
+  removePortfolioTransfers?: boolean;
+}) => {
+  const result = await deleteAccountByIdInTx({ id, userId, removePortfolioTransfers });
 
   // Post-commit fan-out: the durable changes (share rows deleted, invitations revoked,
   // account row destroyed) committed in the transaction above. Notifications are

--- a/packages/backend/src/services/accounts/delete-account.e2e.ts
+++ b/packages/backend/src/services/accounts/delete-account.e2e.ts
@@ -7,6 +7,23 @@ import {
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import * as helpers from '@tests/helpers';
 
+const setupAccountWithTransfer = async () => {
+  const account = await helpers.createAccount({ raw: true });
+  const portfolio = await helpers.createPortfolio({ raw: true });
+
+  await helpers.accountToPortfolioTransfer({
+    portfolioId: portfolio.id,
+    payload: {
+      accountId: account.id,
+      amount: '100',
+      date: '2024-01-15',
+    },
+    raw: true,
+  });
+
+  return { account, portfolio };
+};
+
 describe('Delete Account', () => {
   describe('Account deletion with account groups', () => {
     let account;
@@ -233,6 +250,49 @@ describe('Delete Account', () => {
         raw: true,
       });
       expect(updatedSubscription.accountId ?? null).toBeNull();
+    });
+  });
+
+  describe('Account deletion with portfolio transfers', () => {
+    it('keeps portfolio transfers as orphans by default', async () => {
+      const { account, portfolio } = await setupAccountWithTransfer();
+
+      await helpers.deleteAccount({ id: account.id, raw: true });
+
+      const { data: transfers } = await helpers.listPortfolioTransfers({ portfolioId: portfolio.id, raw: true });
+      expect(transfers).toHaveLength(1);
+      expect(transfers[0]!.fromAccountId).toBeNull();
+      expect(transfers[0]!.transactionId).toBeNull();
+    });
+
+    it('deletes portfolio transfers when removePortfolioTransfers is passed', async () => {
+      const { account, portfolio } = await setupAccountWithTransfer();
+
+      await helpers.deleteAccount({ id: account.id, removePortfolioTransfers: true, raw: true });
+
+      const { data: transfers } = await helpers.listPortfolioTransfers({ portfolioId: portfolio.id, raw: true });
+      expect(transfers).toHaveLength(0);
+    });
+
+    it('does not touch transfers of other accounts', async () => {
+      const { account, portfolio } = await setupAccountWithTransfer();
+
+      const otherAccount = await helpers.createAccount({ raw: true });
+      await helpers.accountToPortfolioTransfer({
+        portfolioId: portfolio.id,
+        payload: {
+          accountId: otherAccount.id,
+          amount: '50',
+          date: '2024-02-15',
+        },
+        raw: true,
+      });
+
+      await helpers.deleteAccount({ id: account.id, removePortfolioTransfers: true, raw: true });
+
+      const { data: transfers } = await helpers.listPortfolioTransfers({ portfolioId: portfolio.id, raw: true });
+      expect(transfers).toHaveLength(1);
+      expect(transfers[0]!.fromAccountId).toBe(otherAccount.id);
     });
   });
 });

--- a/packages/backend/src/tests/helpers/account.ts
+++ b/packages/backend/src/tests/helpers/account.ts
@@ -82,12 +82,24 @@ export function updateAccount<T = AccountApiResponse, R extends boolean | undefi
   });
 }
 
-export function deleteAccount({ id, raw }: { id: string; raw: false }): Promise<Response>;
-export function deleteAccount({ id, raw }: { id: string; raw: true }): Promise<void>;
-export function deleteAccount({ id, raw = false }: { id: string; raw?: boolean }) {
+export function deleteAccount(params: {
+  id: string;
+  removePortfolioTransfers?: boolean;
+  raw: false;
+}): Promise<Response>;
+export function deleteAccount(params: { id: string; removePortfolioTransfers?: boolean; raw: true }): Promise<void>;
+export function deleteAccount({
+  id,
+  removePortfolioTransfers,
+  raw = false,
+}: {
+  id: string;
+  removePortfolioTransfers?: boolean;
+  raw?: boolean;
+}) {
   return makeRequest({
     method: 'delete',
-    url: `/accounts/${id}`,
+    url: `/accounts/${id}${removePortfolioTransfers ? '?removePortfolioTransfers=true' : ''}`,
     raw,
   });
 }

--- a/packages/frontend/src/api/accounts.ts
+++ b/packages/frontend/src/api/accounts.ts
@@ -29,8 +29,10 @@ export const editAccount = async ({
 
 export interface DeleteAccountPayload {
   id: string;
+  removePortfolioTransfers?: boolean;
 }
-export const deleteAccount = async ({ id }: DeleteAccountPayload): Promise<void> => api.delete(`/accounts/${id}`);
+export const deleteAccount = async ({ id, removePortfolioTransfers }: DeleteAccountPayload): Promise<void> =>
+  api.delete(`/accounts/${id}`, { query: { removePortfolioTransfers } });
 
 export interface UnlinkAccountFromBankConnectionPayload {
   id: string;

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/account.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/account.json
@@ -95,7 +95,8 @@
         "transactionCount": "You have {count} transactions associated with this account, they will also be deleted.",
         "deleteConfirm": "Do you really want to delete this account?",
         "noTransactions": "You have zero transactions associated.",
-        "accountNameLabel": "Account name (click to copy)"
+        "accountNameLabel": "Account name (click to copy)",
+        "removePortfolioTransfers": "Also delete portfolio contribution records linked to this account"
       },
       "archive": {
         "title": "Archive Account",

--- a/packages/frontend/src/pages/account/components/account-deletion-section.vue
+++ b/packages/frontend/src/pages/account/components/account-deletion-section.vue
@@ -2,6 +2,7 @@
 import { AlertDialog, ClickToCopy } from '@/components/common';
 import { InputField } from '@/components/fields';
 import { Button } from '@/components/lib/ui/button';
+import { Checkbox } from '@/components/lib/ui/checkbox';
 import { useNotificationCenter } from '@/components/notification-center';
 import { isApiErrorWithCode } from '@/js/errors';
 import { ROUTES_NAMES } from '@/routes';
@@ -22,6 +23,7 @@ const { addSuccessNotification, addErrorNotification } = useNotificationCenter()
 const accountsStore = useAccountsStore();
 const { t } = useI18n();
 const confirmAccountName = ref('');
+const removePortfolioTransfers = ref(true);
 const accountHasTransactions = computed(() => props.transactions.length > 0);
 
 const deleteAccount = async () => {
@@ -31,6 +33,7 @@ const deleteAccount = async () => {
   try {
     await accountsStore.deleteAccount({
       id: props.account.id,
+      removePortfolioTransfers: removePortfolioTransfers.value,
     });
     addSuccessNotification(t('pages.account.deletion.success', { accountName }));
     router.push({ name: ROUTES_NAMES.accounts });
@@ -95,6 +98,11 @@ const deleteAccount = async () => {
             :placeholder="$t('pages.account.deletion.confirmPlaceholder')"
             class="border-destructive focus-visible:outline-destructive"
           />
+
+          <label class="mt-3 flex cursor-pointer items-start gap-2 text-sm">
+            <Checkbox v-model="removePortfolioTransfers" class="mt-0.5" />
+            {{ t('pages.account.deletion.removePortfolioTransfers') }}
+          </label>
         </template>
       </AlertDialog>
     </div>

--- a/packages/frontend/src/stores/accounts.ts
+++ b/packages/frontend/src/stores/accounts.ts
@@ -116,8 +116,8 @@ export const useAccountsStore = defineStore('accounts', () => {
     });
   };
 
-  const deleteAccount = async ({ id }: DeleteAccountPayload) => {
-    await apiDeleteAccount({ id });
+  const deleteAccount = async ({ id, removePortfolioTransfers }: DeleteAccountPayload) => {
+    await apiDeleteAccount({ id, removePortfolioTransfers });
     await refetchAccounts();
     // Invalidate all queries that depend on transaction changes
     // since deleting an account will delete all associated transactions


### PR DESCRIPTION
Orphaned transfer records survived account deletion and double-counted contributions once the account was re-added and re-linked; the delete dialog now offers (default-on) removal of them