### PR TITLE
Add account skipping to all import flows & AI mapping

### DIFF
--- a/docs/csv-import-architecture.html
+++ b/docs/csv-import-architecture.html
@@ -561,8 +561,10 @@
         <ul>
           <li>
             <strong>Field parsing.</strong> <code>core/parse/parse-amount.ts</code> normalizes US / EU / accounting
-            number formats to cents; <code>core/parse/date-engine.ts</code> (<code>detectDateColumnFormat</code> +
-            <code>parseImportDate</code>) infers a single safe day/month order for the whole column;
+            number formats to cents; <code>@bt/shared/import-export/date-engine.ts</code> (<code
+              >detectDateColumnFormat</code
+            >
+            + <code>parseImportDate</code>) infers a single safe day/month order for the whole column;
             <code>core/parse/anchor-import-date.ts</code> anchors date-only and zone-less values to the user's IANA
             <code>timezone</code> (UTC fallback); <code>core/parse/split-tag-cell.ts</code> splits the tag cell.
           </li>
@@ -694,11 +696,13 @@
           <strong>no base class, no inheritance</strong>. Providers <em>compose</em> these functions; they do not
           implement a common parse interface.
         </p>
-        <pre><code>import-export/
+        <pre><code>shared/src/import-export/
+  date-engine.ts          # shape grammar + parse (shared with the frontend wizard preview; unit test lives in backend core/parse/)
+
+import-export/
   core/
     parse/
       parse-amount.ts        (+ parse-amount.unit.ts)   # string → integer cents (US/EU/accounting)
-      date-engine.ts         (+ unit)                    # detect single safe day/month order for a column
       anchor-import-date.ts  (+ unit)                    # anchor date-only / zone-less values to user TZ
       parse-date.ts          (+ unit)                    # multi-format date → YYYY-MM-DD (also used by investment-parser)
       split-tag-cell.ts      (+ unit)
@@ -903,9 +907,9 @@ export const parseBudgetBakersWalletController = createParseController({
           <li>
             <strong><code>services/import-export/revolut-import/parse-revolut.service.ts</code></strong> — the only file
             with new logic. A pure function producing <code>ParsedTransactionRow[]</code> (+ invalid rows). Reuse
-            <code>core/parse/parse-amount.ts</code> and <code>core/parse/date-engine.ts</code>; write only the Revolut
-            column-name mapping (and a vendor-specific <code>parse-amount</code>/<code>parse-date</code> only if the
-            format is unusual).
+            <code>core/parse/parse-amount.ts</code> and <code>@bt/shared/import-export/date-engine.ts</code>; write only
+            the Revolut column-name mapping (and a vendor-specific <code>parse-amount</code>/<code>parse-date</code>
+            only if the format is unusual).
           </li>
           <li>
             <strong>execute service</strong> — compose the core resolve helpers + a per-row

--- a/packages/backend/src/controllers/import-export/ai-map-categories.controller.ts
+++ b/packages/backend/src/controllers/import-export/ai-map-categories.controller.ts
@@ -1,0 +1,15 @@
+import { createController } from '@controllers/helpers/controller-factory';
+import { aiMapImportCategories } from '@services/import-export/core/ai-map-categories.service';
+import { z } from 'zod';
+
+export const aiMapCategoriesController = createController(
+  z.object({
+    body: z.object({
+      sourceCategories: z.array(z.string().min(1).max(200)).min(1).max(1000),
+    }),
+  }),
+  async ({ user, body }) => {
+    const data = await aiMapImportCategories({ userId: user.id, sourceCategories: body.sourceCategories });
+    return { data };
+  },
+);

--- a/packages/backend/src/controllers/import-export/budget-bakers-wallet/shared-schemas.ts
+++ b/packages/backend/src/controllers/import-export/budget-bakers-wallet/shared-schemas.ts
@@ -21,6 +21,8 @@ const linkExistingSchema = z.object({
   accountId: recordId(),
 });
 
+const skipSchema = z.object({ action: z.literal('skip') });
+
 // Budget Bakers Wallet's `create-new` variant carries a required `currencyCode`
 // (the CSV importer derives currency from the rows instead) and a required-but-nullable
 // `currentBalance`, which makes it a different shape from the CSV importer's
@@ -28,5 +30,5 @@ const linkExistingSchema = z.object({
 // the distinct contract.
 export const budgetBakersWalletAccountMappingSchema = z.record(
   z.string(),
-  z.discriminatedUnion('action', [createNewSchema, linkExistingSchema]),
+  z.discriminatedUnion('action', [createNewSchema, linkExistingSchema, skipSchema]),
 );

--- a/packages/backend/src/controllers/import-export/shared-schemas.ts
+++ b/packages/backend/src/controllers/import-export/shared-schemas.ts
@@ -91,6 +91,7 @@ export const accountMappingValueSchema = z.discriminatedUnion('action', [
     currentBalance: boundedImportBalance({ label: 'Current balance' }).nullable().default(null),
   }),
   z.object({ action: z.literal('link-existing'), accountId: recordId() }),
+  z.object({ action: z.literal('skip') }),
 ]);
 
 export const categoryMappingValueSchema = z.discriminatedUnion('action', [

--- a/packages/backend/src/controllers/import-export/ynab/execute-ynab.controller.ts
+++ b/packages/backend/src/controllers/import-export/ynab/execute-ynab.controller.ts
@@ -3,9 +3,19 @@ import { createController } from '@controllers/helpers/controller-factory';
 import { queueYnabImport } from '@root/services/import-export/ynab-import';
 import { z } from 'zod';
 
-const accountMappingValueSchema = z.object({
-  currencyCode: currencyCode(),
-});
+// A skipped account is never created, so an empty `currencyCode` is valid on it.
+// The refine re-issues the shared validator's message at the `currencyCode` path
+// so the client can attach it to the picker.
+const accountMappingValueSchema = z
+  .object({ skip: z.boolean().optional(), currencyCode: z.string().trim().toUpperCase() })
+  .superRefine((mapping, ctx) => {
+    if (mapping.skip) return;
+
+    const parsed = currencyCode().safeParse(mapping.currencyCode);
+    if (!parsed.success) {
+      ctx.addIssue({ code: 'custom', message: parsed.error.issues[0]!.message, path: ['currencyCode'] });
+    }
+  });
 
 export const executeYnabController = createController(
   z.object({

--- a/packages/backend/src/models/user-settings.model.ts
+++ b/packages/backend/src/models/user-settings.model.ts
@@ -4,12 +4,13 @@ import {
   AI_CUSTOM_INSTRUCTIONS_MAX_LENGTH,
   AI_FEATURE,
   AI_KEY_PROVIDERS,
+  MAX_CATEGORY_MAPPING_PRESETS,
   NOTIFICATION_TYPES,
   RecordId,
   endpointsTypes,
   isCustomModelId,
 } from '@bt/shared/types';
-import type { Equals, Expect } from '@bt/shared/types';
+import type { CategoryMappingPreset, Equals, Expect } from '@bt/shared/types';
 import { dateRange, withDateOrder } from '@common/lib/zod/custom-types';
 import { IdColumn } from '@common/types/id-column';
 import {
@@ -194,11 +195,27 @@ const ZodSubscriptionsSettingsSchema = z.object({
   defaultAutoRecord: z.boolean().optional(),
 });
 
+// A category mapping remembered from a finished import, keyed by a fingerprint of the source
+// layout. Untrusted client input, so the per-value union is validated in full.
+const ZodCategoryMappingPresetSchema = z.object({
+  fingerprint: z.string().min(1).max(128),
+  name: z.string().trim().min(1).max(64).optional(),
+  categoryMapping: z.record(
+    z.string(),
+    z.union([
+      z.object({ action: z.literal('create-new') }),
+      z.object({ action: z.literal('link-existing'), categoryId: z.string().min(1) }),
+    ]),
+  ),
+  updatedAt: z.string(),
+});
+
 // Data-import defaults. `recalculateAccountBalance` only seeds the "update account balances
 // from imported transactions" checkbox; the execute request's `recalculateBalance` is what
 // actually applies.
 const ZodImportSettingsSchema = z.object({
   recalculateAccountBalance: z.boolean().optional(),
+  categoryMappingPresets: z.array(ZodCategoryMappingPresetSchema).max(MAX_CATEGORY_MAPPING_PRESETS).optional(),
 });
 
 // Account-picker defaults. `defaultAccountId` pre-selects account pickers, null means cleared.
@@ -346,6 +363,8 @@ export const ZodSettingsPatchSchema = z.object({
   import: z
     .object({
       recalculateAccountBalance: z.boolean().optional(),
+      // Same element schema as `ZodSettingsSchema`, so the two can't drift.
+      categoryMappingPresets: z.array(ZodCategoryMappingPresetSchema).max(MAX_CATEGORY_MAPPING_PRESETS).optional(),
     })
     .optional(),
   accounts: ZodAccountsSettingsSchema.optional(),
@@ -389,6 +408,16 @@ export type SettingsPatchSchemaIsInSync = Expect<Equals<SettingsPatchSchema, Dee
  */
 export type SavedPivotViewSchemaIsInSync = Expect<
   Equals<z.infer<typeof ZodSavedPivotViewSchema>, endpointsTypes.SavedPivotView>
+>;
+
+/**
+ * Compile-time drift guard: the persisted category preset must infer exactly the shared
+ * `CategoryMappingPreset` contract the frontend also builds against.
+ *
+ * @public exported only so the assertion isn't flagged as unused.
+ */
+export type CategoryMappingPresetSchemaIsInSync = Expect<
+  Equals<z.infer<typeof ZodCategoryMappingPresetSchema>, CategoryMappingPreset>
 >;
 
 /**

--- a/packages/backend/src/routes/base-currency-guard-coverage.e2e.ts
+++ b/packages/backend/src/routes/base-currency-guard-coverage.e2e.ts
@@ -69,6 +69,9 @@ const GUARD_EXEMPT_ROUTES = new Set<string>([
   // so a base-currency migration and a run cannot corrupt each other.
   'POST /api/v1/user/ai/categorization/trigger',
 
+  // AI suggestion call — reads nothing monetary, writes nothing.
+  'POST /api/v1/import/ai-map-categories',
+
   // Admin-only investment price maintenance — these write GLOBAL SecurityPricing
   // reference data, not any user's ref amounts, so a per-user base-currency
   // migration has no bearing on them.

--- a/packages/backend/src/routes/import-export/ai-mapping.route.ts
+++ b/packages/backend/src/routes/import-export/ai-mapping.route.ts
@@ -1,0 +1,19 @@
+import { aiMapCategoriesController } from '@controllers/import-export/ai-map-categories.controller';
+import { authenticateSession } from '@middlewares/better-auth';
+import { validateEndpoint } from '@middlewares/validations';
+import { Router } from 'express';
+
+const router = Router({});
+
+/**
+ * Ask AI to match imported source category names to the user's existing categories
+ * POST /import/ai-map-categories
+ */
+router.post(
+  '/ai-map-categories',
+  authenticateSession,
+  validateEndpoint(aiMapCategoriesController.schema),
+  aiMapCategoriesController.handler,
+);
+
+export default router;

--- a/packages/backend/src/services/ai-categorization/utils/parse-response.ts
+++ b/packages/backend/src/services/ai-categorization/utils/parse-response.ts
@@ -12,7 +12,7 @@ const VALID_SKIP_REASONS = new Set<string>(Object.values(CATEGORIZATION_SKIP_REA
  * list bullets around tokens, or a bare row number. Every verdict lost to formatting
  * becomes a permanent `skip:unspecified` stamp, so recover what is still unambiguous.
  */
-function normalizeToken({ raw, aliasPrefix }: { raw: string; aliasPrefix: string }): string {
+export function normalizeToken({ raw, aliasPrefix }: { raw: string; aliasPrefix: string }): string {
   const stripped = raw.replace(/^[-*_`\s]+|[-*_`\s]+$/g, '').toLowerCase();
   return /^\d+$/.test(stripped) ? `${aliasPrefix}${stripped}` : stripped;
 }

--- a/packages/backend/src/services/import-export/budget-bakers-wallet-import/execute-import.e2e.ts
+++ b/packages/backend/src/services/import-export/budget-bakers-wallet-import/execute-import.e2e.ts
@@ -1,4 +1,4 @@
-import { TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
+import { type BudgetBakersWalletAccountMapping, TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
 import { generateRandomRecordId } from '@common/lib/record-id-helpers';
 import { describe, expect, it } from '@jest/globals';
 import { ERROR_CODES } from '@js/errors';
@@ -24,6 +24,21 @@ async function buildCreateNewMappingFromFixture({ fileContent }: { fileContent: 
     ]),
   );
   return { parsed: result, accountMapping };
+}
+
+async function buildMappingWithSkippedAccounts({
+  fileContent,
+  skippedAccountNames,
+}: {
+  fileContent: string;
+  skippedAccountNames: string[];
+}) {
+  const { parsed, accountMapping } = await buildCreateNewMappingFromFixture({ fileContent });
+  const skipped = new Set(skippedAccountNames);
+  const mapping: BudgetBakersWalletAccountMapping = Object.fromEntries(
+    Object.entries(accountMapping).map(([name, value]) => [name, skipped.has(name) ? { action: 'skip' } : value]),
+  );
+  return { parsed, accountMapping: mapping };
 }
 
 // ---------------------------------------------------------------------------
@@ -929,5 +944,124 @@ describe('Execute Budget Bakers Wallet import endpoint', () => {
       // rowIndex is number | null per WalletImportSummary — both are valid.
       expect(entry.rowIndex === null || typeof entry.rowIndex === 'number').toBe(true);
     }
+  });
+  describe('skipped accounts', () => {
+    it('leaves out a skipped account: its account, its rows and its out-of-wallet leg', async () => {
+      const accountsBefore = await helpers.getAccounts();
+      const fileContent = helpers.loadBudgetBakersWalletFixture('multi-currency.csv');
+      const { accountMapping } = await buildMappingWithSkippedAccounts({
+        fileContent,
+        skippedAccountNames: ['Monobank UAH'],
+      });
+
+      const { jobId } = await helpers.executeBudgetBakersWallet({
+        payload: { fileContent, accountMapping, skipDuplicateIndices: [] },
+        raw: true,
+      });
+      const progress = await waitForBudgetBakersWalletCompletion({ jobId });
+      expectCompleted(progress);
+      const { summary } = progress;
+
+      expect(summary.accountsSkipped).toBe(1);
+      expect(summary.accountsCreated).toBe(4);
+      // Monobank UAH owned 2 ordinary rows and the lone (out-of-wallet) leg.
+      expect(summary.transactionsImported).toBe(2);
+      expect(summary.outOfWalletImported).toBe(0);
+      // Neither transfer pair touches Monobank UAH, so both still land.
+      expect(summary.transfersImported).toBe(2);
+      // "Refund" only ever labelled a Monobank row; "Travel" also labels a PKO row.
+      expect(summary.tagsCreated).toBe(1);
+      expect(summary.errors).toHaveLength(0);
+      // 2 transactions + 2 transfers.
+      expect(progress.totalCount).toBe(4);
+
+      const accountsAfter = await helpers.getAccounts();
+      expect(accountsAfter.length).toBe(accountsBefore.length + 4);
+      expect(accountsAfter.find((a) => a.name === 'Monobank UAH')).toBeUndefined();
+
+      const transactionsAfter = await helpers.getTransactions({ raw: true });
+      const notes = transactionsAfter.map((t) => t.note);
+      expect(notes).toContain('Project payment');
+      expect(notes).toContain('Morning coffee');
+      expect(notes).not.toContain('Weekly shop');
+      expect(notes).not.toContain('December salary');
+      expect(
+        transactionsAfter.filter((t) => t.transferNature === TRANSACTION_TRANSFER_NATURE.transfer_out_wallet),
+      ).toHaveLength(0);
+    });
+
+    it('drops a transfer whole when one of its legs belongs to a skipped account', async () => {
+      const fileContent = helpers.loadBudgetBakersWalletFixture('multi-currency.csv');
+      const { accountMapping } = await buildMappingWithSkippedAccounts({
+        fileContent,
+        skippedAccountNames: ['Wise USD'],
+      });
+
+      const { jobId } = await helpers.executeBudgetBakersWallet({
+        payload: { fileContent, accountMapping, skipDuplicateIndices: [] },
+        raw: true,
+      });
+      const progress = await waitForBudgetBakersWalletCompletion({ jobId });
+      expectCompleted(progress);
+      const { summary } = progress;
+
+      expect(summary.accountsSkipped).toBe(1);
+      expect(summary.accountsCreated).toBe(4);
+      // Wise USD owns no ordinary rows, so every non-transfer row still lands.
+      expect(summary.transactionsImported).toBe(4);
+      expect(summary.outOfWalletImported).toBe(1);
+      // Only PKO USD -> PKO PLN survives; Crypto USD -> Wise USD is dropped whole.
+      expect(summary.transfersImported).toBe(1);
+      expect(summary.errors).toHaveLength(0);
+      // 4 ordinary rows + 1 out-of-wallet leg + 1 transfer.
+      expect(progress.totalCount).toBe(6);
+
+      const accountsAfter = await helpers.getAccounts();
+      expect(accountsAfter.find((a) => a.name === 'Wise USD')).toBeUndefined();
+
+      // The surviving leg of the dropped transfer must not be written on its
+      // own: Crypto USD is created but stays empty.
+      const cryptoAccount = accountsAfter.find((a) => a.name === 'Crypto USD')!;
+      const transactionsAfter = await helpers.getTransactions({ raw: true });
+      expect(transactionsAfter.filter((t) => t.accountId === cryptoAccount.id)).toHaveLength(0);
+      expect(
+        transactionsAfter.filter((t) => t.transferNature === TRANSACTION_TRANSFER_NATURE.common_transfer),
+      ).toHaveLength(2);
+    });
+
+    it('completes with zeroed counts when every account is mapped to skip', async () => {
+      const accountsBefore = await helpers.getAccounts();
+      const fileContent = helpers.loadBudgetBakersWalletFixture('multi-currency.csv');
+      const { parsed } = await buildCreateNewMappingFromFixture({ fileContent });
+      const accountMapping: BudgetBakersWalletAccountMapping = Object.fromEntries(
+        parsed.accounts.map((account) => [account.originalName, { action: 'skip' }]),
+      );
+
+      const { jobId } = await helpers.executeBudgetBakersWallet({
+        payload: { fileContent, accountMapping, skipDuplicateIndices: [] },
+        raw: true,
+      });
+      const progress = await waitForBudgetBakersWalletCompletion({ jobId });
+      expectCompleted(progress);
+
+      expect(progress.processedCount).toBe(0);
+      expect(progress.totalCount).toBe(0);
+      expect(progress.summary).toMatchObject({
+        accountsSkipped: parsed.accounts.length,
+        accountsCreated: 0,
+        accountsLinked: 0,
+        categoriesCreated: 0,
+        tagsCreated: 0,
+        payeesCreated: 0,
+        transactionsImported: 0,
+        transfersImported: 0,
+        outOfWalletImported: 0,
+        duplicatesSkipped: 0,
+        errors: [],
+      });
+
+      expect((await helpers.getAccounts()).length).toBe(accountsBefore.length);
+      expect(await helpers.getTransactions({ raw: true })).toHaveLength(0);
+    });
   });
 });

--- a/packages/backend/src/services/import-export/budget-bakers-wallet-import/execute-import.service.ts
+++ b/packages/backend/src/services/import-export/budget-bakers-wallet-import/execute-import.service.ts
@@ -22,6 +22,7 @@ import { createAccountsIfNeeded } from '@services/import-export/core/resolve/cre
 import { createCategoriesIfNeeded } from '@services/import-export/core/resolve/create-categories-if-needed';
 import { createPayeesIfNeeded } from '@services/import-export/core/resolve/create-payees-if-needed';
 import { createNamedTagsIfNeeded } from '@services/import-export/core/resolve/create-tags-if-needed';
+import { excludeSkippedAccounts } from '@services/import-export/core/resolve/exclude-skipped-accounts';
 import { signedRowContribution } from '@services/import-export/core/signed-row-contribution';
 import { applyPayeeDefaultTags } from '@services/payees/apply-default-tags';
 import { createTransaction } from '@services/transactions';
@@ -93,6 +94,15 @@ export async function executeBudgetBakersWalletImport({
     });
   }
 
+  const skippedAccountNames = new Set(
+    parsed.accounts
+      .filter((account) => accountMapping[account.originalName]!.action === 'skip')
+      .map((account) => account.originalName),
+  );
+  const importableAccounts = parsed.accounts.filter((account) => !skippedAccountNames.has(account.originalName));
+
+  const importableMapping = excludeSkippedAccounts({ accountMapping });
+
   const importDetails: TransactionImportDetails = {
     batchId: uuidv4(),
     importedAt: new Date().toISOString(),
@@ -109,6 +119,7 @@ export async function executeBudgetBakersWalletImport({
   } = {
     accountsCreated: 0,
     accountsLinked: 0,
+    accountsSkipped: skippedAccountNames.size,
     categoriesCreated: 0,
     payeesCreated: 0,
     tagsCreated: 0,
@@ -123,11 +134,18 @@ export async function executeBudgetBakersWalletImport({
 
   const skipSet = new Set(skipDuplicateIndices);
 
+  // Drop a transfer when either leg lands on a skipped account: writing the
+  // surviving leg alone would reference an account that was never resolved.
+  const importableTransactions = parsed.transactions.filter((tx) => !skippedAccountNames.has(tx.accountName));
+  const transfersToWrite = parsed.transfers.filter(
+    (xfer) => !skippedAccountNames.has(xfer.sourceAccountName) && !skippedAccountNames.has(xfer.destinationAccountName),
+  );
+
   // Progress total counts only rows that will actually be written: transactions
   // not flagged as duplicates, plus every paired transfer. Skipped rows never
   // tick, so the worker's `processedCount === totalCount` completion check holds.
-  const transactionsToWrite = parsed.transactions.filter((tx) => !skipSet.has(tx.rowIndex));
-  const totalCount = transactionsToWrite.length + parsed.transfers.length;
+  const transactionsToWrite = importableTransactions.filter((tx) => !skipSet.has(tx.rowIndex));
+  const totalCount = transactionsToWrite.length + transfersToWrite.length;
 
   // Report the real total once up front. The per-row `tick` is the only other
   // caller of `onProgress`, so an import that writes no rows would otherwise
@@ -142,7 +160,7 @@ export async function executeBudgetBakersWalletImport({
   // Phase 1: bootstrap currencies for every account that will be created. Linked
   // accounts already have their currency connected (it's an existing account).
   const currencyCodes = new Set<string>();
-  for (const account of parsed.accounts) {
+  for (const account of importableAccounts) {
     const mapping = accountMapping[account.originalName]!;
     if (mapping.action === 'create-new') currencyCodes.add(mapping.currencyCode);
   }
@@ -157,7 +175,7 @@ export async function executeBudgetBakersWalletImport({
   // Wallet-specific messages and tallies `accountsLinked`; the actual id
   // resolution and new-account creation is then delegated to
   // `createAccountsIfNeeded`.
-  for (const account of parsed.accounts) {
+  for (const account of importableAccounts) {
     const mapping = accountMapping[account.originalName]!;
     if (mapping.action !== 'link-existing') continue;
 
@@ -175,7 +193,7 @@ export async function executeBudgetBakersWalletImport({
     summary.accountsLinked += 1;
   }
 
-  // Resolve every parsed account to an app account id, creating new ones with a
+  // Resolve every importable account to an app account id, creating new ones with a
   // zero starting balance (the imported rows build the balance up; the
   // user-entered target is restored in Phase 7). New-account currency comes from
   // the user-confirmed mapping; the fx reference date is the earliest CSV date.
@@ -183,8 +201,8 @@ export async function executeBudgetBakersWalletImport({
   // create-new. `accountsCreated` counts only genuine inserts.
   const { accountNameToId: accountIdByName, accountsCreated } = await createAccountsIfNeeded({
     userId,
-    accountNames: parsed.accounts.map((account) => account.originalName),
-    accountMapping,
+    accountNames: importableAccounts.map((account) => account.originalName),
+    accountMapping: importableMapping,
     resolveCurrencyCode: (accountName) => {
       const mapping = accountMapping[accountName];
       return mapping?.action === 'create-new' ? mapping.currencyCode : undefined;
@@ -199,7 +217,7 @@ export async function executeBudgetBakersWalletImport({
   // they have no history to protect and follow the Phase-7 target-balance path.
   const { capturedAccountIds, createdAccounts } = partitionReconcileAccounts({
     accountNameToId: accountIdByName,
-    accountMapping,
+    accountMapping: importableMapping,
   });
   const reconciler = await startBalanceReconciliation({ userId, accountIds: capturedAccountIds });
 
@@ -218,10 +236,14 @@ export async function executeBudgetBakersWalletImport({
   // Phase 4: tags. Find-or-create each verbatim Wallet label, picking a random
   // colour per requested name for the create case. The shared helper batches the
   // existing-lookup and is fail-fast: a failing tag insert aborts the whole
-  // import rather than being swallowed into `summary.errors`.
+  // import rather than being swallowed into `summary.errors`. Narrowed to labels
+  // the surviving rows use so a skipped account leaves no orphan tag.
+  const importableTagNames = new Set(importableTransactions.flatMap((tx) => tx.tags));
   const { tagIdByName, tagsCreated } = await createNamedTagsIfNeeded({
     userId,
-    tags: parsed.tags.map((tag) => ({ name: tag.name, color: pickRandomColor() })),
+    tags: parsed.tags
+      .filter((tag) => importableTagNames.has(tag.name))
+      .map((tag) => ({ name: tag.name, color: pickRandomColor() })),
   });
   summary.tagsCreated = tagsCreated;
 
@@ -260,7 +282,7 @@ export async function executeBudgetBakersWalletImport({
 
   // Phase 5: transactions (ordinary rows + unpaired transfer legs). Rows the
   // user confirmed as duplicates are counted and skipped without a tick.
-  for (const tx of parsed.transactions) {
+  for (const tx of importableTransactions) {
     if (skipSet.has(tx.rowIndex)) {
       summary.duplicatesSkipped += 1;
       continue;
@@ -396,7 +418,7 @@ export async function executeBudgetBakersWalletImport({
   // passed straight through: `createTransaction` with `common_transfer` writes
   // the source (expense) and destination (income) legs and links them via
   // `transferId`.
-  for (const xfer of parsed.transfers) {
+  for (const xfer of transfersToWrite) {
     try {
       const sourceAccountId = accountIdByName.get(xfer.sourceAccountName);
       const destinationAccountId = accountIdByName.get(xfer.destinationAccountName);

--- a/packages/backend/src/services/import-export/core/ai-map-categories.e2e.ts
+++ b/packages/backend/src/services/import-export/core/ai-map-categories.e2e.ts
@@ -1,0 +1,162 @@
+import { AI_FEATURE, getModelNameFromModelId } from '@bt/shared/types';
+import { afterEach, beforeEach, describe, expect, it } from '@jest/globals';
+import { getDefaultModelForFeature } from '@services/ai/models-config';
+import * as helpers from '@tests/helpers';
+import { useSelfHostWithoutServerAiKeys } from '@tests/helpers/ai-test-env';
+import {
+  GEMINI_API_URL,
+  VALID_GEMINI_API_KEY,
+  createGeminiMock,
+  rejectIfWrongModel,
+} from '@tests/mocks/gemini/mock-api';
+import { HttpResponse, http } from 'msw';
+
+const EXPECTED_MODEL = getModelNameFromModelId({
+  modelId: getDefaultModelForFeature({ feature: AI_FEATURE.categorization }),
+});
+
+/** Collects every `text` field of the Gemini request body (system + user parts). */
+function extractPromptText(body: unknown): string {
+  const texts: string[] = [];
+  JSON.stringify(body, (key, value) => {
+    if (key === 'text' && typeof value === 'string') texts.push(value);
+    return value;
+  });
+  return texts.join('\n');
+}
+
+/** Gemini mock that builds its answer from the prompt it actually received. */
+function createMappingGeminiMock({ respond }: { respond: (prompt: string) => string }) {
+  return http.post(GEMINI_API_URL, async ({ request }) => {
+    const modelMismatch = rejectIfWrongModel({ request, expectedModel: EXPECTED_MODEL });
+    if (modelMismatch) return modelMismatch;
+    const prompt = extractPromptText(await request.json());
+    return HttpResponse.json({
+      candidates: [{ content: { parts: [{ text: respond(prompt) }], role: 'model' }, finishReason: 'STOP', index: 0 }],
+      usageMetadata: { promptTokenCount: 100, candidatesTokenCount: 50, totalTokenCount: 150 },
+    });
+  });
+}
+
+describe('POST /import/ai-map-categories', () => {
+  describe('with a working AI provider', () => {
+    let originalGeminiApiKey: string | undefined;
+
+    beforeEach(() => {
+      originalGeminiApiKey = process.env.GEMINI_API_KEY;
+      process.env.GEMINI_API_KEY = VALID_GEMINI_API_KEY;
+    });
+
+    afterEach(() => {
+      if (originalGeminiApiKey === undefined) {
+        delete process.env.GEMINI_API_KEY;
+      } else {
+        process.env.GEMINI_API_KEY = originalGeminiApiKey;
+      }
+    });
+
+    it('maps sources to the categories the AI picked and returns null for "none"', async () => {
+      const categories = await helpers.getCategoriesList();
+      const target = categories.find((category) => category.name === 'Food & Drinks') ?? categories[0]!;
+
+      global.mswMockServer.use(
+        createMappingGeminiMock({
+          respond: (prompt) => {
+            // The prompt aliases category ids; recover the alias of our target by name.
+            const aliasMatch = new RegExp(`^(c\\d+)\\|[^|]*\\|${target.name}$`, 'm').exec(prompt);
+            return `s1:${aliasMatch?.[1] ?? 'none'}\ns2:none`;
+          },
+        }),
+      );
+
+      const { mappings } = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Продукти', 'Totally Unmatchable Source'] },
+        raw: true,
+      });
+
+      expect(mappings['Продукти']).toBe(target.id);
+      expect(mappings['Totally Unmatchable Source']).toBeNull();
+    });
+
+    it('serves cached verdicts for a repeated identical request without a second AI call', async () => {
+      const categories = await helpers.getCategoriesList();
+      const target = categories.find((category) => category.name === 'Food & Drinks') ?? categories[0]!;
+
+      global.mswMockServer.use(
+        createMappingGeminiMock({
+          respond: (prompt) => {
+            const aliasMatch = new RegExp(`^(c\\d+)\\|[^|]*\\|${target.name}$`, 'm').exec(prompt);
+            return `s1:${aliasMatch?.[1] ?? 'none'}`;
+          },
+        }),
+      );
+
+      const first = await helpers.aiMapImportCategories({ payload: { sourceCategories: ['Продукти'] }, raw: true });
+      expect(first.mappings['Продукти']).toBe(target.id);
+
+      // Any live call would now answer garbage; only the cache can reproduce the match.
+      global.mswMockServer.use(createMappingGeminiMock({ respond: () => 'nonsense' }));
+
+      const second = await helpers.aiMapImportCategories({ payload: { sourceCategories: ['Продукти'] }, raw: true });
+      expect(second.mappings['Продукти']).toBe(target.id);
+
+      // A different source list is a different cache key and must consult the AI
+      // again — proven by the live call failing on the garbage mock.
+      const third = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Продукти', 'Taxi'] },
+      });
+      expect(third.statusCode).toBe(422);
+    });
+
+    it('rejects when the AI answer contains no parseable verdict lines', async () => {
+      global.mswMockServer.use(createMappingGeminiMock({ respond: () => 'I cannot help with that.' }));
+
+      const response = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Bakery', 'Taxi'] },
+      });
+
+      expect(response.statusCode).toBe(422);
+    });
+
+    it('maps a hallucinated category alias to null instead of trusting it', async () => {
+      global.mswMockServer.use(createMappingGeminiMock({ respond: () => 's1:c9999\ns2:none' }));
+
+      const { mappings } = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Bakery', 'Taxi'] },
+        raw: true,
+      });
+
+      expect(mappings).toEqual({ Bakery: null, Taxi: null });
+    });
+
+    it('rejects a truncated AI response instead of returning partial verdicts', async () => {
+      global.mswMockServer.use(createGeminiMock({ rawText: 's1:c1', finishReason: 'MAX_TOKENS' }));
+
+      const response = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Bakery'] },
+      });
+
+      expect(response.statusCode).toBe(422);
+    });
+
+    it('rejects an empty source list', async () => {
+      const response = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: [] },
+      });
+
+      expect(response.statusCode).toBe(422);
+    });
+  });
+
+  describe('without any AI configured', () => {
+    useSelfHostWithoutServerAiKeys();
+
+    it('answers with a configuration error', async () => {
+      const response = await helpers.aiMapImportCategories({
+        payload: { sourceCategories: ['Groceries'] },
+      });
+
+      expect(response.statusCode).toBe(422);
+    });
+  });
+});

--- a/packages/backend/src/services/import-export/core/ai-map-categories.service.ts
+++ b/packages/backend/src/services/import-export/core/ai-map-categories.service.ts
@@ -1,0 +1,215 @@
+import { AI_FEATURE, type AiMapImportCategoriesResponse } from '@bt/shared/types';
+import { ValidationError } from '@js/errors';
+import { logger } from '@js/utils';
+import { CacheClient } from '@js/utils/cache';
+import { getCategories } from '@models/categories.model';
+import {
+  AI_MAX_OUTPUT_TOKENS,
+  AI_OUTPUT_TRUNCATED_MESSAGE,
+  aiCallGuards,
+  createAIClient,
+  describeMissingAiConfiguration,
+  hitOutputCeiling,
+} from '@services/ai';
+import { assignShortIds } from '@services/ai-categorization/utils/assign-short-ids';
+import { normalizeToken } from '@services/ai-categorization/utils/parse-response';
+import { resolveAiExtractionFailure } from '@services/import-export/core/ai-extraction-failure';
+import { generateText } from 'ai';
+import { createHash } from 'crypto';
+
+const sanitize = (value: string) => value.replace(/\|/g, ',').replace(/\n/g, ' ').slice(0, 200);
+
+/**
+ * Identical sources, categories, and model give identical verdicts, so a page refresh
+ * or wizard restart reuses them. The hash key self-invalidates on any input change.
+ * The week TTL is the only way to re-roll verdicts for unchanged inputs; keep it short.
+ */
+const verdictCache = new CacheClient<Record<string, string | null>>({
+  ttl: 7 * 24 * 60 * 60,
+  logPrefix: '[AI Category Mapping]',
+});
+
+function buildCacheKey({
+  userId,
+  modelId,
+  sources,
+  categories,
+}: {
+  userId: number;
+  modelId: string;
+  sources: string[];
+  categories: { id: string; parentId: string | null; name: string }[];
+}): string {
+  const fingerprint = JSON.stringify({
+    modelId,
+    sources: sources.toSorted(),
+    categories: categories.map((category) => [category.id, category.parentId, category.name]).toSorted(),
+  });
+  return `ai-map-categories:${userId}:${createHash('sha256').update(fingerprint).digest('hex')}`;
+}
+
+const SYSTEM_PROMPT = `You are matching imported transaction category names against a user's existing categories.
+
+RULES:
+1. For each source name, pick the existing category that represents the same kind of spending or income. Names may be in different languages or spellings — match by meaning (e.g. "Продукти" matches "Groceries", "Bar, cafe" matches "Restaurants").
+2. Only use category ids from the provided list.
+3. Answer "none" when no existing category is a reasonable match. Do not force a match.
+4. Every source MUST appear in your response exactly once.
+5. Output ONLY the results in the exact format specified, nothing else.
+
+OUTPUT FORMAT:
+One line per source, in one of these two exact formats:
+sourceId:categoryId
+sourceId:none
+
+Source ids look like "s1", "s2"; category ids look like "c1", "c2". Copy them exactly as given.
+
+Example:
+s1:c4
+s2:none
+s3:c12`;
+
+/**
+ * Ask the AI to link each imported source category name to one of the user's
+ * existing categories. Uses the same model the user configured for AI
+ * categorization. Sources the model cannot match come back as null.
+ */
+export async function aiMapImportCategories({
+  userId,
+  sourceCategories,
+}: {
+  userId: number;
+  sourceCategories: string[];
+}): Promise<AiMapImportCategoriesResponse> {
+  const aiClient = await createAIClient({ userId, feature: AI_FEATURE.categorization });
+
+  if (!aiClient) {
+    throw new ValidationError({ message: await describeMissingAiConfiguration({ userId }) });
+  }
+
+  const categories = await getCategories({ userId });
+  const sources = [...new Set(sourceCategories)];
+
+  // Every source answers, defaulting to "no match".
+  const mappings: Record<string, string | null> = Object.fromEntries(sources.map((name) => [name, null]));
+
+  if (categories.length === 0) return { mappings };
+
+  const cacheKey = buildCacheKey({ userId, modelId: aiClient.modelId, sources, categories });
+  const cachedMappings = await verdictCache.read(cacheKey);
+  if (cachedMappings) {
+    logger.info('[AI Category Mapping] Serving cached verdicts', { userId, sourceCount: sources.length });
+    // Sliding TTL: a hit means the import is still active, so re-arm the full week.
+    await verdictCache.write({ key: cacheKey, value: cachedMappings });
+    return { mappings: cachedMappings };
+  }
+
+  const { aliasedCategories, categoryIdByAlias } = assignShortIds({
+    transactions: [],
+    categories: categories.map((category) => ({ id: category.id, parentId: category.parentId, name: category.name })),
+  });
+
+  const sourceNameByAlias = new Map<string, string>();
+
+  const categoryLines = aliasedCategories.map(
+    (category) => `${category.id}|${category.parentId ?? ''}|${sanitize(category.name)}`,
+  );
+
+  const sourceLines = sources.map((name, index) => {
+    const alias = `s${index + 1}`;
+    sourceNameByAlias.set(alias, name);
+    return `${alias}|${sanitize(name)}`;
+  });
+
+  const userMessage = `EXISTING CATEGORIES:
+id|parentId|name
+${categoryLines.join('\n')}
+
+SOURCE CATEGORY NAMES:
+id|name
+${sourceLines.join('\n')}
+
+Match each source name to the best existing category, or "none". Output one line per source: sourceId:categoryId or sourceId:none.`;
+
+  logger.info('[AI Category Mapping] Starting', {
+    userId,
+    modelId: aiClient.modelId,
+    provider: aiClient.provider,
+    sourceCount: sources.length,
+    categoryCount: categories.length,
+  });
+
+  try {
+    const { abortSignal, maxRetries } = aiCallGuards({ provider: aiClient.provider });
+
+    const { text, usage, finishReason } = await generateText({
+      model: aiClient.model,
+      system: SYSTEM_PROMPT,
+      prompt: userMessage,
+      abortSignal,
+      maxRetries,
+      maxOutputTokens: AI_MAX_OUTPUT_TOKENS,
+    });
+
+    // A truncated answer silently loses the sources after the cut, which would
+    // read as "the AI found no match" instead of an error.
+    if (hitOutputCeiling({ finishReason, usage })) {
+      throw new ValidationError({ message: AI_OUTPUT_TRUNCATED_MESSAGE });
+    }
+
+    const answered = new Set<string>();
+    for (const line of text.split('\n')) {
+      const trimmed = line.trim();
+      const colonIndex = trimmed.indexOf(':');
+      if (colonIndex === -1) continue;
+      const sourceName = sourceNameByAlias.get(normalizeToken({ raw: trimmed.slice(0, colonIndex), aliasPrefix: 's' }));
+      if (sourceName === undefined) continue;
+      const verdict = normalizeToken({ raw: trimmed.slice(colonIndex + 1), aliasPrefix: 'c' });
+      answered.add(sourceName);
+      mappings[sourceName] = verdict === 'none' ? null : (categoryIdByAlias.get(verdict) ?? null);
+    }
+
+    if (answered.size === 0) {
+      logger.info('[AI Category Mapping] Unparseable AI response', { userId, excerpt: text.slice(0, 500) });
+      throw new ValidationError({ message: 'Failed to parse AI response. The output was not in expected format.' });
+    }
+    if (answered.size < sources.length) {
+      logger.warn('[AI Category Mapping] AI answered only some sources', {
+        userId,
+        answeredCount: answered.size,
+        sourceCount: sources.length,
+      });
+    }
+
+    const matchedCount = Object.values(mappings).filter(Boolean).length;
+
+    logger.info('[AI Category Mapping] Completed', {
+      userId,
+      modelId: aiClient.modelId,
+      sourceCount: sources.length,
+      matchedCount,
+      inputTokens: usage?.inputTokens ?? 0,
+      outputTokens: usage?.outputTokens ?? 0,
+    });
+
+    // Cache only complete, non-empty verdict sets: a partial answer would pin
+    // never-judged sources as null for the whole TTL, and an all-null set is
+    // more likely model drift than a real verdict.
+    if (matchedCount > 0 && answered.size === sources.length) {
+      await verdictCache.write({ key: cacheKey, value: mappings });
+    }
+
+    return { mappings };
+  } catch (error) {
+    if (error instanceof ValidationError) throw error;
+
+    const { error: resolved } = await resolveAiExtractionFailure({
+      userId,
+      aiClient,
+      error,
+      logPrefix: '[AI Category Mapping]',
+    });
+
+    throw new ValidationError({ message: resolved.message });
+  }
+}

--- a/packages/backend/src/services/import-export/core/parse/anchor-import-date.ts
+++ b/packages/backend/src/services/import-export/core/parse/anchor-import-date.ts
@@ -1,4 +1,4 @@
-import { type ParsedImportDate } from './date-engine';
+import { type ParsedImportDate } from '@bt/shared/import-export/date-engine';
 
 interface AnchorImportDateParams {
   parsed: ParsedImportDate;

--- a/packages/backend/src/services/import-export/core/parse/anchor-import-date.unit.ts
+++ b/packages/backend/src/services/import-export/core/parse/anchor-import-date.unit.ts
@@ -1,7 +1,7 @@
+import { type ParsedImportDate } from '@bt/shared/import-export/date-engine';
 import { describe, expect, it } from '@jest/globals';
 
 import { anchorImportDate } from './anchor-import-date';
-import { type ParsedImportDate } from './date-engine';
 
 describe('anchorImportDate', () => {
   describe('instant', () => {

--- a/packages/backend/src/services/import-export/core/parse/date-engine.unit.ts
+++ b/packages/backend/src/services/import-export/core/parse/date-engine.unit.ts
@@ -1,6 +1,5 @@
+import { type DateColumnFormat, detectDateColumnFormat, parseImportDate } from '@bt/shared/import-export/date-engine';
 import { describe, expect, it } from '@jest/globals';
-
-import { type DateColumnFormat, detectDateColumnFormat, parseImportDate } from './date-engine';
 
 // A neutral format for value-shape tests where field order is irrelevant
 // (ISO, ISO-datetime and compact values carry their order intrinsically).
@@ -188,5 +187,86 @@ describe('detectDateColumnFormat', () => {
     });
 
     expect(detection).toEqual({ ok: false, reason: 'mixed' });
+  });
+});
+
+describe('ambiguous family: two-digit years and time suffixes', () => {
+  it('parses DD/MM/YY with a comma-separated time (the "01/01/26, 10:58" report) as localDateTime', () => {
+    expect(parseImportDate({ value: '01/01/26, 10:58', format: { fieldOrder: 'day-first' } })).toEqual({
+      kind: 'localDateTime',
+      year: 2026,
+      month: 1,
+      day: 1,
+      hour: 10,
+      minute: 58,
+      second: 0,
+      ms: 0,
+    });
+  });
+
+  it('parses a plain two-digit-year date as dateOnly pivoted to the 2000s', () => {
+    expect(parseImportDate({ value: '15/01/26', format: { fieldOrder: 'day-first' } })).toEqual({
+      kind: 'dateOnly',
+      year: 2026,
+      month: 1,
+      day: 15,
+    });
+  });
+
+  it('pivots two-digit years ≥ 70 to the 1900s', () => {
+    expect(parseImportDate({ value: '15/01/99', format: { fieldOrder: 'day-first' } })).toEqual({
+      kind: 'dateOnly',
+      year: 1999,
+      month: 1,
+      day: 15,
+    });
+  });
+
+  it('parses a space-separated time with seconds on a four-digit-year date', () => {
+    expect(parseImportDate({ value: '15/01/2026 14:30:45', format: { fieldOrder: 'day-first' } })).toEqual({
+      kind: 'localDateTime',
+      year: 2026,
+      month: 1,
+      day: 15,
+      hour: 14,
+      minute: 30,
+      second: 45,
+      ms: 0,
+    });
+  });
+
+  it('respects the field order for timed values', () => {
+    expect(parseImportDate({ value: '01/02/26, 10:58', format: { fieldOrder: 'month-first' } })).toEqual({
+      kind: 'localDateTime',
+      year: 2026,
+      month: 1,
+      day: 2,
+      hour: 10,
+      minute: 58,
+      second: 0,
+      ms: 0,
+    });
+  });
+
+  it('returns null for impossible times instead of rolling them over', () => {
+    expect(parseImportDate({ value: '01/01/26, 25:00', format: { fieldOrder: 'day-first' } })).toBeNull();
+    expect(parseImportDate({ value: '01/01/26, 10:61', format: { fieldOrder: 'day-first' } })).toBeNull();
+  });
+
+  it('returns null for an impossible calendar date even when the time is valid', () => {
+    expect(parseImportDate({ value: '30/02/26, 10:00', format: { fieldOrder: 'day-first' } })).toBeNull();
+  });
+
+  it('reads day/month order signals through time suffixes and two-digit years', () => {
+    expect(detectDateColumnFormat({ values: ['13/06/26, 10:00', '08/06/26, 11:30'], locale: 'en' })).toEqual({
+      ok: true,
+      format: { fieldOrder: 'day-first' },
+    });
+  });
+});
+
+describe('ISO local datetime calendar validation', () => {
+  it('returns null for an impossible calendar date in an ISO datetime instead of rolling it over', () => {
+    expect(parseImportDate({ value: '2026-02-30 10:00', format: ANY_FORMAT })).toBeNull();
   });
 });

--- a/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
+++ b/packages/backend/src/services/import-export/core/resolve/create-accounts-if-needed.ts
@@ -1,4 +1,4 @@
-import type { AccountMappingConfig } from '@bt/shared/types';
+import type { AccountMappingValue } from '@bt/shared/types';
 import { ACCOUNT_CATEGORIES, ACCOUNT_TYPES } from '@bt/shared/types';
 import { Money } from '@common/types/money';
 import { ValidationError } from '@js/errors';
@@ -10,7 +10,7 @@ interface CreateAccountsIfNeededParams {
   userId: number;
   /** Distinct source account names to ensure an account exists for. */
   accountNames: string[];
-  accountMapping: AccountMappingConfig;
+  accountMapping: Record<string, Exclude<AccountMappingValue, { action: 'skip' }>>;
   /**
    * Currency code to use when creating a new account for `accountName`. CSV
    * passes the currency of the first row that uses the account. Returning

--- a/packages/backend/src/services/import-export/core/resolve/exclude-skipped-accounts.ts
+++ b/packages/backend/src/services/import-export/core/resolve/exclude-skipped-accounts.ts
@@ -1,0 +1,16 @@
+/** The shared account helpers model only create-new and link-existing, so the skip decision is resolved here. */
+export function excludeSkippedAccounts<T extends { action: string }>({
+  accountMapping,
+}: {
+  accountMapping: Record<string, T>;
+}): Record<string, Exclude<T, { action: 'skip' }>> {
+  const importableMapping: Record<string, Exclude<T, { action: 'skip' }>> = {};
+
+  for (const [accountName, mapping] of Object.entries(accountMapping)) {
+    if (mapping.action !== 'skip') {
+      importableMapping[accountName] = mapping as Exclude<T, { action: 'skip' }>;
+    }
+  }
+
+  return importableMapping;
+}

--- a/packages/backend/src/services/import-export/csv-import/detect-duplicates/index.ts
+++ b/packages/backend/src/services/import-export/csv-import/detect-duplicates/index.ts
@@ -61,7 +61,17 @@ export async function detectDuplicates({
 
   // Identify rows whose currency has no stored exchange rate. The result is
   // passed to the preview so the user can decide to skip or abort those rows.
-  const unpriceableRows = await findUnpriceableRows({ userId, validRows });
+  // Rows on a skipped account never reach the import, so they must not gate the
+  // preview on a missing rate.
+  const skippedAccountNames = new Set(
+    Object.entries(accountMapping)
+      .filter(([, mapping]) => mapping.action === 'skip')
+      .map(([accountName]) => accountName),
+  );
+  const unpriceableRows = await findUnpriceableRows({
+    userId,
+    validRows: validRows.filter((row) => !skippedAccountNames.has(row.accountName)),
+  });
 
   return {
     validRows,

--- a/packages/backend/src/services/import-export/csv-import/execute-import.e2e.ts
+++ b/packages/backend/src/services/import-export/csv-import/execute-import.e2e.ts
@@ -852,6 +852,207 @@ describe('Execute Import endpoint (async)', () => {
     });
   });
 
+  describe('skipped accounts', () => {
+    it('skips a mapped-out account and imports the remaining rows', async () => {
+      const accountsBefore = await helpers.getAccounts();
+
+      const fileContent = buildCsv([
+        {
+          date: '2024-01-15',
+          amount: '100.50',
+          description: 'skipped-row-1',
+          account: 'Skipped Account',
+          currency: 'USD',
+          type: 'expense',
+        },
+        {
+          date: '2024-01-16',
+          amount: '20.00',
+          description: 'skipped-row-2',
+          account: 'Skipped Account',
+          currency: 'USD',
+          type: 'expense',
+        },
+        {
+          date: '2024-01-17',
+          amount: '75.00',
+          description: 'kept-row',
+          account: 'Kept Account',
+          currency: 'USD',
+          type: 'expense',
+        },
+      ]);
+
+      const { progress } = await runImport({
+        fileContent,
+        accountMapping: {
+          'Skipped Account': { action: 'skip' },
+          'Kept Account': { action: 'create-new', currentBalance: null },
+        },
+      });
+      expectCsvImportCompleted(progress);
+      const { summary } = progress;
+
+      expect(summary.imported).toBe(1);
+      expect(summary.accountsSkipped).toBe(1);
+      expect(summary.accountsCreated).toBe(1);
+      expect(summary.errors).toHaveLength(0);
+      expect(progress.totalCount).toBe(1);
+
+      const accountsAfter = await helpers.getAccounts();
+      expect(accountsAfter.length).toBe(accountsBefore.length + 1);
+      expect(accountsAfter.find((a) => a.name === 'Skipped Account')).toBeUndefined();
+      const keptAccount = accountsAfter.find((a) => a.name === 'Kept Account');
+      expect(keptAccount).toBeDefined();
+
+      const transactions = await helpers.getTransactions({ raw: true });
+      const importedTxs = transactions.filter((tx) => summary.newTransactionIds.includes(tx.id));
+      expect(importedTxs).toHaveLength(1);
+      expect(importedTxs[0]!.note).toBe('kept-row');
+      expect(importedTxs[0]!.accountId).toBe(keptAccount!.id);
+    });
+
+    it('completes with zeroed counts when every account is mapped to skip', async () => {
+      const accountsBefore = await helpers.getAccounts();
+
+      const { progress } = await runImport({
+        fileContent: buildCsv(defaultRows({ account: 'Skipped Account', currency: 'USD' })),
+        accountMapping: { 'Skipped Account': { action: 'skip' } },
+      });
+      expectCsvImportCompleted(progress);
+
+      expect(progress.processedCount).toBe(0);
+      expect(progress.totalCount).toBe(0);
+      expect(progress.summary).toMatchObject({
+        imported: 0,
+        skipped: 0,
+        skippedUnpriceable: 0,
+        accountsSkipped: 1,
+        accountsCreated: 0,
+        categoriesCreated: 0,
+        tagsCreated: 0,
+        payeesCreated: 0,
+        errors: [],
+        newTransactionIds: [],
+        accountBalanceChanges: [],
+      });
+
+      expect((await helpers.getAccounts()).length).toBe(accountsBefore.length);
+      expect(await helpers.getTransactions({ raw: true })).toHaveLength(0);
+    });
+
+    it('imports only the linked account rows when the other source account is skipped', async () => {
+      const account = await helpers.createAccount({ raw: true });
+      const accountsBefore = await helpers.getAccounts();
+      // The skipped rows carry a currency the linked account does not use: they
+      // are filtered before the currency guard, so the import still completes.
+      const skippedCurrency = account.currencyCode === 'USD' ? 'EUR' : 'USD';
+
+      const fileContent = buildCsv([
+        {
+          date: '2024-01-15',
+          amount: '30.00',
+          description: 'linked-row',
+          account: 'Linked Account',
+          currency: account.currencyCode,
+          type: 'expense',
+        },
+        {
+          date: '2024-01-16',
+          amount: '40.00',
+          description: 'skipped-row',
+          account: 'Other Account',
+          currency: skippedCurrency,
+          type: 'expense',
+        },
+      ]);
+
+      const { progress } = await runImport({
+        fileContent,
+        accountMapping: {
+          'Linked Account': { action: 'link-existing', accountId: account.id },
+          'Other Account': { action: 'skip' },
+        },
+      });
+      expectCsvImportCompleted(progress);
+      const { summary } = progress;
+
+      expect(summary.imported).toBe(1);
+      expect(summary.accountsSkipped).toBe(1);
+      expect(summary.accountsCreated).toBe(0);
+      expect(summary.errors).toHaveLength(0);
+
+      const transactions = await helpers.getTransactions({ raw: true });
+      expect(transactions.map((tx) => tx.note)).toEqual(['linked-row']);
+      expect(transactions[0]!.accountId).toBe(account.id);
+      expect((await helpers.getAccounts()).length).toBe(accountsBefore.length);
+    });
+
+    it('creates no category or tag that only skipped-account rows reference', async () => {
+      const account = await helpers.createAccount({ raw: true });
+
+      const fileContent = buildCsv([
+        {
+          date: '2024-01-15',
+          amount: '100.50',
+          description: 'kept-row',
+          category: 'KeptCategory',
+          account: 'Kept Account',
+          currency: account.currencyCode,
+          type: 'expense',
+          tags: 'KeptTag',
+        },
+        {
+          date: '2024-01-16',
+          amount: '20.00',
+          description: 'skipped-row',
+          category: 'OrphanCategory',
+          account: 'Skipped Account',
+          currency: account.currencyCode,
+          type: 'expense',
+          tags: 'OrphanTag',
+        },
+      ]);
+
+      const { progress } = await runImport({
+        fileContent,
+        columnMapping: buildColumnMapping({
+          tags: { option: TagOptionValue.mapDataSourceColumn, columnName: 'Tags' },
+        }),
+        accountMapping: {
+          'Kept Account': { action: 'link-existing', accountId: account.id },
+          'Skipped Account': { action: 'skip' },
+        },
+        // The client sends the mapping it built before the account was skipped,
+        // so the orphan entries arrive alongside the surviving row's entries.
+        categoryMapping: {
+          KeptCategory: { action: 'create-new' },
+          OrphanCategory: { action: 'create-new' },
+        },
+        tagMapping: {
+          KeptTag: { action: 'create-new' },
+          OrphanTag: { action: 'create-new' },
+        },
+      });
+      expectCsvImportCompleted(progress);
+      const { summary } = progress;
+
+      expect(summary.imported).toBe(1);
+      expect(summary.accountsSkipped).toBe(1);
+      expect(summary.categoriesCreated).toBe(1);
+      expect(summary.tagsCreated).toBe(1);
+      expect(summary.errors).toHaveLength(0);
+
+      const categoryNames = (await helpers.getCategoriesList()).map((category) => category.name);
+      expect(categoryNames).toContain('KeptCategory');
+      expect(categoryNames).not.toContain('OrphanCategory');
+
+      const tagNames = (await helpers.getTags({ raw: true })).map((tag) => tag.name);
+      expect(tagNames).toContain('KeptTag');
+      expect(tagNames).not.toContain('OrphanTag');
+    });
+  });
+
   describe('error handling – failed jobs', () => {
     // The controller only validates the request shape; mapping/ownership failures
     // happen inside the worker and surface as `status: 'failed'`, mirroring the

--- a/packages/backend/src/services/import-export/csv-import/execute-import/index.ts
+++ b/packages/backend/src/services/import-export/csv-import/execute-import/index.ts
@@ -26,6 +26,7 @@ import { createAccountsIfNeeded } from '@services/import-export/core/resolve/cre
 import { createCategoriesIfNeeded } from '@services/import-export/core/resolve/create-categories-if-needed';
 import { createPayeesIfNeeded } from '@services/import-export/core/resolve/create-payees-if-needed';
 import { createTagsIfNeeded } from '@services/import-export/core/resolve/create-tags-if-needed';
+import { excludeSkippedAccounts } from '@services/import-export/core/resolve/exclude-skipped-accounts';
 import { resolveRowTagIds } from '@services/import-export/core/resolve/resolve-row-tag-ids';
 import { signedRowContribution } from '@services/import-export/core/signed-row-contribution';
 import { applyPayeeDefaultTags } from '@services/payees/apply-default-tags';
@@ -69,6 +70,10 @@ interface ExecuteImportParams {
   onProgress?: (processedCount: number, totalCount: number) => void | Promise<void>;
 }
 
+function pickReferenced<T>({ mapping, referenced }: { mapping: Record<string, T>; referenced: Set<string> }) {
+  return Object.fromEntries(Object.entries(mapping).filter(([sourceName]) => referenced.has(sourceName)));
+}
+
 /**
  * Execute a CSV import. Runs OUTSIDE a wrapping transaction so a single bad row
  * does not nuke the whole import — best-effort partial success is the contract
@@ -98,13 +103,27 @@ export async function executeImport({
   // filtered with a single pass. Both sets use the same rowIndex space as
   // ParsedTransactionRow.rowIndex and DetectDuplicatesResponse.unpriceableRows.
   const skipSet = new Set([...skipDuplicateIndices, ...(skipUnpriceableIndices ?? [])]);
-  const rowsToImport = validRows.filter((row) => !skipSet.has(row.rowIndex));
+
+  // Narrowed to names the parsed file actually contains so `accountsSkipped`
+  // counts real accounts rather than stale mapping keys the client kept around.
+  const accountNamesInFile = new Set(validRows.map((row) => row.accountName));
+  const skippedAccountNames = new Set(
+    Object.entries(accountMapping)
+      .filter(([accountName, mapping]) => mapping.action === 'skip' && accountNamesInFile.has(accountName))
+      .map(([accountName]) => accountName),
+  );
+
+  const importableMapping = excludeSkippedAccounts({ accountMapping });
+
+  const rowsToImport = validRows.filter(
+    (row) => !skipSet.has(row.rowIndex) && !skippedAccountNames.has(row.accountName),
+  );
 
   // Count each skipped row exactly once: `skipped` owns confirmed duplicates;
   // `skippedUnpriceable` owns rows that are unpriceable but not also duplicates.
   // A row in both sets is already counted under `skipped`, so excluding the
-  // duplicate-skip set from the unpriceable count prevents double-counting and
-  // keeps imported + skipped + skippedUnpriceable == rows considered.
+  // duplicate-skip set from the unpriceable count prevents double-counting.
+  // Rows on a skipped account are in neither count: `accountsSkipped` covers them.
   const dupSkipSet = new Set(skipDuplicateIndices);
   const skippedUnpriceableCount = (skipUnpriceableIndices ?? []).filter((i) => !dupSkipSet.has(i)).length;
 
@@ -119,6 +138,7 @@ export async function executeImport({
       skipped: skipDuplicateIndices.length,
       skippedUnpriceable: skippedUnpriceableCount,
       accountsCreated: 0,
+      accountsSkipped: skippedAccountNames.size,
       categoriesCreated: 0,
       tagsCreated: 0,
       payeesCreated: 0,
@@ -178,7 +198,7 @@ export async function executeImport({
   const { accountNameToId, accountsCreated } = await createAccountsIfNeeded({
     userId,
     accountNames: uniqueAccountNames,
-    accountMapping,
+    accountMapping: importableMapping,
     resolveCurrencyCode: (accountName) => rowsToImport.find((r) => r.accountName === accountName)?.currencyCode,
     resolveFxDate: () => new Date(),
     defaultAccountId,
@@ -189,24 +209,36 @@ export async function executeImport({
   // balance-before + boundary day. Accounts created above are excluded — they
   // have no history to protect, so the recalculate flag does not apply to them
   // (they are handed to `finalize` for their summary entries instead).
-  const { capturedAccountIds, createdAccounts } = partitionReconcileAccounts({ accountNameToId, accountMapping });
+  const { capturedAccountIds, createdAccounts } = partitionReconcileAccounts({
+    accountNameToId,
+    accountMapping: importableMapping,
+  });
   const reconciler = await startBalanceReconciliation({ userId, accountIds: capturedAccountIds });
 
   const plannedMatchAccountIds = await selectAccountsWithPlannedRows({ accountIds: capturedAccountIds });
+
+  // Resolve only the entities the surviving rows reference. A mapping entry for a
+  // skipped account's value, or one the client kept from an earlier column choice,
+  // would create a category or tag nothing points at.
+  const referencedCategoryNames = new Set(rowsToImport.flatMap((row) => row.categoryName ?? []));
+  const referencedTagNames = new Set(rowsToImport.flatMap((row) => row.tagNames ?? []));
 
   // Resolve categories that need to be created or linked. `categoriesCreated`
   // counts only genuine inserts — create-new entries that matched an existing
   // same-named category (case-insensitive) link to it instead.
   const { categoryNameToId, categoriesCreated } = await createCategoriesIfNeeded({
     userId,
-    categoryMapping,
+    categoryMapping: pickReferenced({ mapping: categoryMapping, referenced: referencedCategoryNames }),
   });
 
   // Resolve tags that need to be created or linked. `tagsCreated` counts only
   // genuine inserts — create-new entries that matched an existing same-named
   // tag (case-insensitive) link to it instead.
   const { tagNameToId, tagsCreated } = tagMapping
-    ? await createTagsIfNeeded({ userId, tagMapping })
+    ? await createTagsIfNeeded({
+        userId,
+        tagMapping: pickReferenced({ mapping: tagMapping, referenced: referencedTagNames }),
+      })
     : { tagNameToId: new Map<string, string>(), tagsCreated: 0 };
 
   // Resolve Payees for every mapped merchant string up front. `payeesCreated`
@@ -424,6 +456,7 @@ export async function executeImport({
     skipped: skipDuplicateIndices.length,
     skippedUnpriceable: skippedUnpriceableCount,
     accountsCreated,
+    accountsSkipped: skippedAccountNames.size,
     categoriesCreated,
     tagsCreated,
     payeesCreated,

--- a/packages/backend/src/services/import-export/csv-import/parse-valid-rows.ts
+++ b/packages/backend/src/services/import-export/csv-import/parse-valid-rows.ts
@@ -1,3 +1,4 @@
+import { parseImportDate } from '@bt/shared/import-export/date-engine';
 import type { ColumnMappingConfig, InvalidRow, ParsedTransactionRow } from '@bt/shared/types';
 import {
   AccountOptionValue,
@@ -11,7 +12,6 @@ import { t } from '@i18n/index';
 import { ValidationError } from '@js/errors';
 import * as Accounts from '@models/accounts.model';
 import { anchorImportDate } from '@services/import-export/core/parse/anchor-import-date';
-import { parseImportDate } from '@services/import-export/core/parse/date-engine';
 import { parseAmount } from '@services/import-export/core/parse/parse-amount';
 import { splitTagCell } from '@services/import-export/core/parse/split-tag-cell';
 

--- a/packages/backend/src/services/import-export/ms-money-import/execute-import.service.ts
+++ b/packages/backend/src/services/import-export/ms-money-import/execute-import.service.ts
@@ -1,7 +1,6 @@
 import {
   ACCOUNT_TYPES,
   type AccountBalanceChange,
-  type AccountMappingConfig,
   type CategoryMappingConfig,
   ImportSource,
   MS_MONEY_VOID_TAG,
@@ -22,6 +21,7 @@ import { startBalanceReconciliation } from '@services/import-export/core/reconci
 import { createAccountsIfNeeded } from '@services/import-export/core/resolve/create-accounts-if-needed';
 import { createPayeesIfNeeded } from '@services/import-export/core/resolve/create-payees-if-needed';
 import { createNamedTagsIfNeeded } from '@services/import-export/core/resolve/create-tags-if-needed';
+import { excludeSkippedAccounts } from '@services/import-export/core/resolve/exclude-skipped-accounts';
 import { signedRowContribution } from '@services/import-export/core/signed-row-contribution';
 import { createTransaction } from '@services/transactions';
 import { selectAccountsWithPlannedRows } from '@services/transactions/planned-matching';
@@ -113,17 +113,7 @@ export async function executeMsMoneyImport({
   );
   const importableAccounts = parsed.accounts.filter((account) => !skippedAccountNames.has(account.originalName));
 
-  // The shared account helpers model only create-new / link-existing, so the
-  // skip decision is resolved here and a mapping without it is handed down.
-  const importableMapping: AccountMappingConfig = {};
-  for (const account of importableAccounts) {
-    const mapping = accountMapping[account.originalName]!;
-    if (mapping.action === 'create-new') {
-      importableMapping[account.originalName] = { action: 'create-new', currentBalance: mapping.currentBalance };
-    } else if (mapping.action === 'link-existing') {
-      importableMapping[account.originalName] = { action: 'link-existing', accountId: mapping.accountId };
-    }
-  }
+  const importableMapping = excludeSkippedAccounts({ accountMapping });
 
   const importDetails: TransactionImportDetails = {
     batchId: uuidv4(),

--- a/packages/backend/src/services/import-export/ynab-import/execute-import.e2e.ts
+++ b/packages/backend/src/services/import-export/ynab-import/execute-import.e2e.ts
@@ -206,4 +206,130 @@ describe('Execute YNAB import endpoint', () => {
     const linkedPair = await helpers.getTransactionsByTransferId({ transferId: legA!.transferId!, raw: true });
     expect(linkedPair).toHaveLength(2);
   });
+
+  it('skips a mapped-to-skip account: no account, no rows, no orphan entities', async () => {
+    const fileContent = helpers.loadYnabFixture('register-basic.csv');
+    const parsed = await helpers.parseYnab({ payload: { fileContent }, raw: true });
+    const plnName = parsed.result.accounts.find((a) => a.detectedCurrency === 'PLN')!.originalName;
+
+    // The PLN account owns exactly one row (Carrefour / "Weekly shop"), the only
+    // user of the "Needs" category group and the green flag.
+    const accountMapping = Object.fromEntries(
+      parsed.result.accounts.map((a) => [
+        a.originalName,
+        { currencyCode: a.detectedCurrency!, ...(a.originalName === plnName ? { skip: true } : {}) },
+      ]),
+    );
+
+    const { jobId } = await helpers.executeYnab({ payload: { fileContent, accountMapping }, raw: true });
+    const progress = await waitForYnabImportCompletion({ jobId });
+    expectYnabImportCompleted(progress);
+    const summary = progress.summary;
+
+    expect(summary.accountsSkipped).toBe(1);
+    expect(summary.accountsCreated).toBe(2);
+    // 4 payees in the file, Carrefour belonged to the skipped account.
+    expect(summary.payeesCreated).toBe(3);
+    // 4 flag colors in the file, green was only used by the skipped row.
+    expect(summary.tagsCreated).toBe(3);
+    expect(summary.transactionsImported).toBe(3);
+    // The only transfer runs between the two kept accounts, so it survives.
+    expect(summary.transfersImported).toBe(1);
+    expect(summary.errors).toHaveLength(0);
+
+    const accountsAfter = await helpers.getAccounts();
+    expect(accountsAfter.map((a) => a.name)).not.toContain(plnName);
+    expect(accountsAfter).toHaveLength(2);
+
+    const transactionsAfter = await helpers.getTransactions({ raw: true });
+    expect(transactionsAfter.find((t) => t.note === 'Weekly shop')).toBeUndefined();
+
+    // "Needs" only exists in the CSV as the skipped row's category group; the
+    // seeded defaults never contain it, so its absence proves nothing orphaned.
+    const categoriesAfter = await helpers.getCategoriesList();
+    expect(categoriesAfter.map((c) => c.name)).not.toContain('Needs');
+
+    const tagsAfter = await helpers.getTags({ raw: true });
+    expect(tagsAfter.map((t) => t.name)).not.toContain('YNAB Green');
+  });
+
+  it('drops a transfer entirely when one of its two accounts is skipped', async () => {
+    const fileContent = helpers.loadYnabFixture('register-basic.csv');
+    const parsed = await helpers.parseYnab({ payload: { fileContent }, raw: true });
+    const eurName = parsed.result.accounts.find((a) => a.detectedCurrency === 'EUR')!.originalName;
+
+    // The fixture's only transfer is USD Checking → EUR Savings. Skipping the
+    // destination must remove BOTH legs, not just the one on the skipped account.
+    const accountMapping = Object.fromEntries(
+      parsed.result.accounts.map((a) => [
+        a.originalName,
+        { currencyCode: a.detectedCurrency!, ...(a.originalName === eurName ? { skip: true } : {}) },
+      ]),
+    );
+
+    const { jobId } = await helpers.executeYnab({ payload: { fileContent, accountMapping }, raw: true });
+    const progress = await waitForYnabImportCompletion({ jobId });
+    expectYnabImportCompleted(progress);
+    const summary = progress.summary;
+
+    expect(summary.accountsSkipped).toBe(1);
+    expect(summary.transfersImported).toBe(0);
+    // Every ordinary row belongs to a kept account, so none of them are lost.
+    expect(summary.transactionsImported).toBe(4);
+    // Blue was only used by the transfer pair.
+    expect(summary.tagsCreated).toBe(3);
+    expect(summary.errors).toHaveLength(0);
+
+    const transactionsAfter = await helpers.getTransactions({ raw: true });
+    expect(transactionsAfter.filter((t) => t.note === 'Move to savings')).toHaveLength(0);
+    expect(transactionsAfter.some((t) => t.transferId)).toBe(false);
+  });
+
+  it('completes with a zeroed summary when every account is skipped', async () => {
+    const fileContent = helpers.loadYnabFixture('register-basic.csv');
+    const parsed = await helpers.parseYnab({ payload: { fileContent }, raw: true });
+    // Empty currency on purpose: skipping is the escape hatch for an account
+    // whose currency the parser could not detect, so the payload must be accepted.
+    const accountMapping = Object.fromEntries(
+      parsed.result.accounts.map((a) => [a.originalName, { currencyCode: '', skip: true }]),
+    );
+
+    const { jobId } = await helpers.executeYnab({ payload: { fileContent, accountMapping }, raw: true });
+    const progress = await waitForYnabImportCompletion({ jobId });
+    expectYnabImportCompleted(progress);
+    const summary = progress.summary;
+
+    expect(summary.accountsSkipped).toBe(3);
+    expect(summary.accountsCreated).toBe(0);
+    expect(summary.categoriesCreated).toBe(0);
+    expect(summary.payeesCreated).toBe(0);
+    expect(summary.tagsCreated).toBe(0);
+    expect(summary.transactionsImported).toBe(0);
+    expect(summary.transfersImported).toBe(0);
+    expect(summary.errors).toHaveLength(0);
+    // Nothing will be written, so the progress bar must not advertise a total.
+    expect(progress.totalCount).toBe(0);
+
+    expect(await helpers.getAccounts()).toHaveLength(0);
+    expect(await helpers.getTransactions({ raw: true })).toHaveLength(0);
+  });
+
+  it('rejects an account that is kept but carries an invalid currencyCode', async () => {
+    const fileContent = helpers.loadYnabFixture('register-basic.csv');
+    const parsed = await helpers.parseYnab({ payload: { fileContent }, raw: true });
+    // Only skipping waives the ISO check, so an empty picker on a kept account
+    // must be refused with a message naming the field the wizard has to fix.
+    const accountMapping = Object.fromEntries(
+      parsed.result.accounts.map((a, index) => [
+        a.originalName,
+        index === 0 ? { currencyCode: '' } : { currencyCode: a.detectedCurrency! },
+      ]),
+    );
+
+    const response: unknown = await helpers.executeYnab({ payload: { fileContent, accountMapping } });
+    const rejection = response as helpers.CustomResponse<{ message: string }>;
+
+    expect(rejection.statusCode).toBe(ERROR_CODES.ValidationError);
+    expect(rejection.body.response.message).toContain('currencyCode');
+  });
 });

--- a/packages/backend/src/services/import-export/ynab-import/execute-import.service.ts
+++ b/packages/backend/src/services/import-export/ynab-import/execute-import.service.ts
@@ -24,7 +24,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createAccountsIfNeeded } from '../core/resolve/create-accounts-if-needed';
 import { createTwoLevelCategoriesIfNeeded } from '../core/resolve/create-categories-if-needed';
 import { createNamedTagsIfNeeded } from '../core/resolve/create-tags-if-needed';
-import { parseYnabRegister } from './parse-ynab.service';
+import { collectCategories, collectPayees, collectTagsUsed, parseYnabRegister } from './parse-ynab.service';
 
 /** User-facing tag name for each flag color. */
 function flagToTagName(color: YnabFlagColor): string {
@@ -59,6 +59,7 @@ export async function executeYnabImport({
   const importedAt = new Date().toISOString();
 
   // Validate every distinct account name in the parser output has a mapping.
+  // Skipped accounts need one too: `skip` is an explicit entry, not an omission.
   const missingMappings = parsed.accounts.filter((a) => !accountMapping[a.originalName]);
   if (missingMappings.length > 0) {
     throw new ValidationError({
@@ -66,8 +67,24 @@ export async function executeYnabImport({
     });
   }
 
+  const skippedAccountNames = new Set(
+    parsed.accounts.filter((a) => accountMapping[a.originalName]!.skip).map((a) => a.originalName),
+  );
+  const importableAccounts = parsed.accounts.filter((a) => !skippedAccountNames.has(a.originalName));
+  const transactionsToWrite = parsed.transactions.filter((tx) => !skippedAccountNames.has(tx.accountName));
+  const transfersToWrite = parsed.transfers.filter(
+    (xfer) => !skippedAccountNames.has(xfer.sourceAccountName) && !skippedAccountNames.has(xfer.destinationAccountName),
+  );
+
+  // Re-derive from the surviving rows: the parser's file-wide lists would create
+  // categories, payees and tags that no imported row references.
+  const categoriesToCreate = collectCategories({ transactions: transactionsToWrite });
+  const payeesToCreate = collectPayees({ transactions: transactionsToWrite });
+  const tagsToCreate = collectTagsUsed({ transactions: transactionsToWrite, transfers: transfersToWrite });
+
   const summary: YnabImportSummary = {
     accountsCreated: 0,
+    accountsSkipped: skippedAccountNames.size,
     categoriesCreated: 0,
     payeesCreated: 0,
     tagsCreated: 0,
@@ -77,7 +94,7 @@ export async function executeYnabImport({
     errors: [],
   };
 
-  const totalCount = parsed.transactions.length + parsed.transfers.length;
+  const totalCount = transactionsToWrite.length + transfersToWrite.length;
   // Stable `importDetails` blob attached to every created row — same batch for
   // every loop iteration, so build it once and share by reference.
   const importDetails: TransactionImportDetails = {
@@ -93,7 +110,7 @@ export async function executeYnabImport({
 
   // Phase 1: bootstrap currencies.
   const currencyCodes = new Set<string>();
-  for (const a of parsed.accounts) {
+  for (const a of importableAccounts) {
     currencyCodes.add(accountMapping[a.originalName]!.currencyCode);
   }
   if (currencyCodes.size > 0) {
@@ -107,12 +124,12 @@ export async function executeYnabImport({
   // currency comes from the per-account mapping and the starting balance is
   // converted at the earliest CSV date via `initialBalanceFxDate`.
   const startingBalanceCentsByName = new Map<string, number>();
-  for (const ynabAccount of parsed.accounts) {
+  for (const ynabAccount of importableAccounts) {
     startingBalanceCentsByName.set(ynabAccount.originalName, Money.fromDecimal(ynabAccount.startingBalance).toCents());
   }
   const { accountNameToId: accountIdByName, accountsCreated } = await createAccountsIfNeeded({
     userId,
-    accountNames: parsed.accounts.map((a) => a.originalName),
+    accountNames: importableAccounts.map((a) => a.originalName),
     accountMapping: {},
     alwaysCreate: true,
     resolveCurrencyCode: (accountName) => accountMapping[accountName]?.currencyCode,
@@ -129,7 +146,7 @@ export async function executeYnabImport({
   // transaction loop builds as `${categoryGroup}: ${categoryName}`.
   const { categoryIdByFullName: categoryByFullName, categoriesCreated } = await createTwoLevelCategoriesIfNeeded({
     userId,
-    categories: parsed.categories.map((c) => ({
+    categories: categoriesToCreate.map((c) => ({
       groupName: c.groupName,
       categoryName: c.categoryName,
       fullName: c.fullName,
@@ -141,7 +158,7 @@ export async function executeYnabImport({
   // lookup for everything that already exists.
   const payeeByName = new Map<string, string>();
   const normalizedByPayeeName = new Map<string, string>();
-  for (const payee of parsed.payees) {
+  for (const payee of payeesToCreate) {
     const normalized = normalizePayeeName({ raw: payee.name });
     if (normalized) normalizedByPayeeName.set(payee.name, normalized);
   }
@@ -183,12 +200,12 @@ export async function executeYnabImport({
   // color → id map the row loops use from that.
   const { tagIdByName, tagsCreated } = await createNamedTagsIfNeeded({
     userId,
-    tags: parsed.tagsUsed.map((t) => ({ name: flagToTagName(t.color), color: YNAB_FLAG_HEX[t.color] })),
+    tags: tagsToCreate.map((t) => ({ name: flagToTagName(t.color), color: YNAB_FLAG_HEX[t.color] })),
   });
   summary.tagsCreated = tagsCreated;
 
   const tagByColor = new Map<YnabFlagColor, string>();
-  for (const tagUsage of parsed.tagsUsed) {
+  for (const tagUsage of tagsToCreate) {
     tagByColor.set(tagUsage.color, tagIdByName.get(flagToTagName(tagUsage.color))!);
   }
 
@@ -199,7 +216,7 @@ export async function executeYnabImport({
   };
 
   // Phase 6: transactions.
-  for (const tx of parsed.transactions) {
+  for (const tx of transactionsToWrite) {
     try {
       const accountId = accountIdByName.get(tx.accountName);
       if (!accountId) throw new ValidationError({ message: `Unknown account "${tx.accountName}"` });
@@ -246,7 +263,7 @@ export async function executeYnabImport({
 
   // Phase 7: transfers. Use createTransaction with `common_transfer` so the
   // service writes both legs and links them via `transferId`.
-  for (const xfer of parsed.transfers) {
+  for (const xfer of transfersToWrite) {
     try {
       const sourceAccountId = accountIdByName.get(xfer.sourceAccountName);
       const destinationAccountId = accountIdByName.get(xfer.destinationAccountName);

--- a/packages/backend/src/services/import-export/ynab-import/parse-date.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-date.ts
@@ -1,5 +1,5 @@
+import { parseImportDate } from '@bt/shared/import-export/date-engine';
 import { type DateFieldOrder } from '@bt/shared/types';
-import { parseImportDate } from '@services/import-export/core/parse/date-engine';
 
 /** Year-last date with two 1-2 digit lead fields — the only shape whose
  *  day/month order is not intrinsic. Mirrors the date engine's family. */

--- a/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
@@ -411,7 +411,7 @@ function detectCurrencyFromAccountName(name: string): string | null {
   return match ? match[1]! : null;
 }
 
-function collectCategories({ transactions }: { transactions: YnabParseTransaction[] }): YnabParseCategory[] {
+export function collectCategories({ transactions }: { transactions: YnabParseTransaction[] }): YnabParseCategory[] {
   const byKey = new Map<string, YnabParseCategory>();
 
   for (const t of transactions) {
@@ -435,7 +435,7 @@ function collectCategories({ transactions }: { transactions: YnabParseTransactio
   );
 }
 
-function collectPayees({ transactions }: { transactions: YnabParseTransaction[] }): YnabParsePayee[] {
+export function collectPayees({ transactions }: { transactions: YnabParseTransaction[] }): YnabParsePayee[] {
   const byName = new Map<string, number>();
 
   for (const t of transactions) {
@@ -451,7 +451,7 @@ function collectPayees({ transactions }: { transactions: YnabParseTransaction[] 
     .toSorted((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 }
 
-function collectTagsUsed({
+export function collectTagsUsed({
   transactions,
   transfers,
 }: {

--- a/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
+++ b/packages/backend/src/services/import-export/ynab-import/parse-ynab.service.ts
@@ -1,3 +1,4 @@
+import { detectDateColumnFormat } from '@bt/shared/import-export/date-engine';
 import {
   YNAB_FLAG_COLORS,
   YNAB_MAX_REGISTER_ROWS,
@@ -15,7 +16,6 @@ import {
   type YnabParseWarning,
 } from '@bt/shared/types';
 import { ValidationError } from '@js/errors';
-import { detectDateColumnFormat } from '@services/import-export/core/parse/date-engine';
 import { roundCurrency } from '@services/import-export/core/round-currency';
 import { parse } from 'csv-parse/sync';
 

--- a/packages/backend/src/services/user-settings/patch-settings.e2e.ts
+++ b/packages/backend/src/services/user-settings/patch-settings.e2e.ts
@@ -233,6 +233,57 @@ describe('Patch user settings', () => {
     expect(response.statusCode).toBe(ERROR_CODES.ValidationError);
   });
 
+  it('persists category mapping presets and reads them back', async () => {
+    const preset = {
+      fingerprint: 'a'.repeat(64),
+      name: 'PKO Bank',
+      categoryMapping: {
+        Groceries: { action: 'link-existing', categoryId: generateRandomRecordId() },
+        Fuel: { action: 'create-new' },
+      },
+      updatedAt: new Date().toISOString(),
+    };
+
+    const patched = await helpers.patchUserSettings({
+      raw: true,
+      patch: { import: { categoryMappingPresets: [preset] } },
+    });
+    expect(patched.import?.categoryMappingPresets).toStrictEqual([preset]);
+
+    const fetched = await helpers.getUserSettings({ raw: true });
+    expect(fetched.import?.categoryMappingPresets).toStrictEqual([preset]);
+  });
+
+  it('rejects invalid category mapping presets', async () => {
+    const validPreset = { fingerprint: 'a'.repeat(64), categoryMapping: {}, updatedAt: new Date().toISOString() };
+
+    const missingCategoryId = await helpers.patchUserSettings({
+      patch: {
+        import: {
+          categoryMappingPresets: [{ ...validPreset, categoryMapping: { Groceries: { action: 'link-existing' } } }],
+        },
+      },
+    });
+    expect(missingCategoryId.statusCode).toBe(ERROR_CODES.ValidationError);
+
+    const blankName = await helpers.patchUserSettings({
+      patch: { import: { categoryMappingPresets: [{ ...validPreset, name: '' }] } },
+    });
+    expect(blankName.statusCode).toBe(ERROR_CODES.ValidationError);
+
+    const overCap = await helpers.patchUserSettings({
+      patch: {
+        import: {
+          categoryMappingPresets: Array.from({ length: 21 }, (_, index) => ({
+            ...validPreset,
+            fingerprint: `fingerprint-${index}`,
+          })),
+        },
+      },
+    });
+    expect(overCap.statusCode).toBe(ERROR_CODES.ValidationError);
+  });
+
   it('persists the accounts slice and reads both fields back', async () => {
     const accountId = generateRandomRecordId();
     const patched = await helpers.patchUserSettings({

--- a/packages/backend/src/setup-routes.ts
+++ b/packages/backend/src/setup-routes.ts
@@ -19,6 +19,7 @@ import modelsCurrenciesRoutes from './routes/currencies.route';
 import demoRoutes from './routes/demo.route';
 import exchangeRatesRoutes from './routes/exchange-rates';
 import githubRoutes from './routes/github.route';
+import aiMappingRoutes from './routes/import-export/ai-mapping.route';
 import batchesHistoryRoutes from './routes/import-export/batches-history.route';
 import budgetBakersWalletImportRoutes from './routes/import-export/budget-bakers-wallet.route';
 import csvImportExportRoutes from './routes/import-export/csv.route';
@@ -198,6 +199,7 @@ export function setupRoutes(app: Express) {
   app.use(`${API_PREFIX}/import`, budgetBakersWalletImportRoutes);
   app.use(`${API_PREFIX}/import`, msMoneyImportRoutes);
   app.use(`${API_PREFIX}/import`, batchesHistoryRoutes);
+  app.use(`${API_PREFIX}/import`, aiMappingRoutes);
   app.use(`${API_PREFIX}/resource-leases`, resourceLeasesRoutes);
   app.use(`${API_PREFIX}/sse`, sseRoutes);
   app.use(`${API_PREFIX}/webhooks`, webhooksRoutes);

--- a/packages/backend/src/tests/helpers/import-export.ts
+++ b/packages/backend/src/tests/helpers/import-export.ts
@@ -1,5 +1,6 @@
 import type {
   AccountMappingConfig,
+  AiMapImportCategoriesResponse,
   BudgetBakersWalletAccountMapping,
   BudgetBakersWalletImportProgress,
   CategoryMappingConfig,
@@ -96,6 +97,25 @@ export function parseCsv<R extends boolean | undefined = false>({
   return makeRequest<ParseCsvResponse, R>({
     method: 'post',
     url: '/import/csv/parse',
+    payload,
+    raw,
+  });
+}
+
+// ============================================
+// AI Category Mapping Endpoint
+// ============================================
+
+export function aiMapImportCategories<R extends boolean | undefined = false>({
+  payload,
+  raw,
+}: {
+  payload: { sourceCategories: string[] };
+  raw?: R;
+}): UtilizeReturnType<() => AiMapImportCategoriesResponse, R> {
+  return makeRequest<AiMapImportCategoriesResponse, R>({
+    method: 'post',
+    url: '/import/ai-map-categories',
     payload,
     raw,
   });

--- a/packages/backend/src/tests/setup-e2e-tests.sh
+++ b/packages/backend/src/tests/setup-e2e-tests.sh
@@ -31,7 +31,7 @@ export TEST_RUNNER_IMAGE="${TEST_RUNNER_IMAGE:-${COMPOSE_PROJECT_NAME}-test-runn
 compose up ${BUILD_FLAG} -d
 
 wait_for() {
-  for _ in $(seq 1 60); do
+  for _ in $(seq 1 120); do
     if "$@" >/dev/null 2>&1; then return 0; fi
     sleep 0.5
   done
@@ -40,7 +40,10 @@ wait_for() {
 }
 
 echo "Waiting for Postgres health check..."
-wait_for compose exec -T test-db pg_isready -U "${APPLICATION_DB_USERNAME}" -d "${APPLICATION_DB_DATABASE}" || exit 1
+# -h 127.0.0.1 is load-bearing: during initdb the postgres image runs a socket-only
+# bootstrap server that answers pg_isready over the socket and then shuts down, so a
+# socket check passes before the real server exists.
+wait_for compose exec -T test-db pg_isready -h 127.0.0.1 -U "${APPLICATION_DB_USERNAME}" -d "${APPLICATION_DB_DATABASE}" || exit 1
 echo "Waiting for Redis health check..."
 wait_for compose exec -T test-redis redis-cli ping || exit 1
 
@@ -50,7 +53,7 @@ recreate_template_db() {
   compose exec -T test-db bash -c "
     psql -U \"${APPLICATION_DB_USERNAME}\" -d postgres -c \"DROP DATABASE IF EXISTS \\\"${TEMPLATE_DB}\\\";\"
     psql -U \"${APPLICATION_DB_USERNAME}\" -d postgres -c \"CREATE DATABASE \\\"${TEMPLATE_DB}\\\";\"
-  "
+  " || { echo "ERROR: could not create template database \"${TEMPLATE_DB}\" — is Postgres up?"; exit 1; }
 }
 
 echo "Creating template database..."

--- a/packages/frontend/src/api/import-export.ts
+++ b/packages/frontend/src/api/import-export.ts
@@ -1,5 +1,6 @@
 import { api } from '@/api/_api';
 import type {
+  AiMapImportCategoriesResponse,
   ColumnMappingConfig,
   CsvImportProgress,
   DetectDuplicatesRequest,
@@ -41,6 +42,13 @@ export const extractUniqueValues = async (
   payload: ExtractUniqueValuesRequest,
 ): Promise<ExtractUniqueValuesResponse> => {
   const result = await api.post('/import/csv/extract-unique-values', payload);
+  return result;
+};
+
+export const aiMapImportCategories = async (payload: {
+  sourceCategories: string[];
+}): Promise<AiMapImportCategoriesResponse> => {
+  const result = await api.post('/import/ai-map-categories', payload);
   return result;
 };
 

--- a/packages/frontend/src/api/user-settings.ts
+++ b/packages/frontend/src/api/user-settings.ts
@@ -1,6 +1,6 @@
 import { api } from '@/api/_api';
 import type { SupportedLocale } from '@bt/shared/i18n/locales';
-import type { endpointsTypes } from '@bt/shared/types';
+import type { CategoryMappingPreset, endpointsTypes } from '@bt/shared/types';
 
 export interface DashboardWidgetConfig {
   widgetId: string;
@@ -82,6 +82,11 @@ export interface UserSettingsSchema {
      * chosen value back, so the next import remembers it. Off when unset.
      */
     recalculateAccountBalance?: boolean;
+    /**
+     * Category mappings remembered from finished imports, keyed by a fingerprint of the
+     * source layout. One preset per fingerprint, newest first.
+     */
+    categoryMappingPresets?: CategoryMappingPreset[];
   };
   includeCreditLimitInStats?: boolean;
   /**

--- a/packages/frontend/src/components/common/dropzone/multi-file-dropzone.vue
+++ b/packages/frontend/src/components/common/dropzone/multi-file-dropzone.vue
@@ -125,7 +125,7 @@ function clearAll() {
         </Button>
       </div>
 
-      <ScrollArea class="max-h-60">
+      <ScrollArea class="max-h-60" viewport-class="max-h-60">
         <ul class="space-y-2">
           <li v-for="(file, index) in files" :key="fileKey(file)">
             <DropzoneFileItem :file="file" :disabled="disabled" @remove="removeAt(index)" />

--- a/packages/frontend/src/composable/use-category-mapping-presets.ts
+++ b/packages/frontend/src/composable/use-category-mapping-presets.ts
@@ -1,0 +1,120 @@
+import { useUserSettings } from '@/composable/data-queries/user-settings';
+import { captureException } from '@/lib/sentry';
+import { useCategoriesStore } from '@/stores/categories/categories';
+import { MAX_CATEGORY_MAPPING_PRESETS, type CategoryMappingConfig, type CategoryMappingPreset } from '@bt/shared/types';
+import { type Ref, computed } from 'vue';
+
+/**
+ * Remembers the category mapping a finished import used, keyed by a fingerprint of the source
+ * layout, so the next import from the same source can re-apply it. Each wizard supplies its own
+ * fingerprint: a header-row hash for CSV, a constant for the fixed-layout sources.
+ *
+ * Naming a preset turns it into a template: it survives cap eviction and can be applied to any
+ * source, not just the layout it was recorded from.
+ */
+export const useCategoryMappingPresets = ({ fingerprint }: { fingerprint: Ref<string | null> }) => {
+  const userSettings = useUserSettings();
+
+  const storedPresets = computed<CategoryMappingPreset[]>(
+    () => userSettings.data.value?.import?.categoryMappingPresets ?? [],
+  );
+
+  const patchPresets = async ({ presets, scope }: { presets: CategoryMappingPreset[]; scope: string }) => {
+    try {
+      await userSettings.patchAsync({ import: { categoryMappingPresets: presets } });
+    } catch (error) {
+      captureException({ error, context: { scope } });
+    }
+  };
+
+  /** The saved category mapping for this source layout, if one exists. */
+  const matchingPreset = computed<CategoryMappingPreset | null>(
+    () => storedPresets.value.find((preset) => preset.fingerprint === fingerprint.value) ?? null,
+  );
+
+  /** Named templates from other source layouts, newest first. */
+  const namedPresets = computed<CategoryMappingPreset[]>(() =>
+    storedPresets.value
+      .filter((preset) => preset.name && preset.fingerprint !== fingerprint.value)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+  );
+
+  /**
+   * Writes the preset's mapping over the current choices, for source names this import
+   * actually contains. Link targets deleted since the preset was saved are dropped rather
+   * than written back as unresolvable ids.
+   */
+  const applyPreset = ({
+    preset,
+    categoryMapping,
+    validSourceNames,
+  }: {
+    preset: CategoryMappingPreset;
+    categoryMapping: Ref<CategoryMappingConfig>;
+    validSourceNames: string[];
+  }) => {
+    const sourceNames = new Set(validSourceNames);
+    const categoriesMap = useCategoriesStore().categoriesMap;
+
+    for (const [name, value] of Object.entries(preset.categoryMapping)) {
+      if (!sourceNames.has(name)) continue;
+      if (value.action === 'link-existing' && !categoriesMap[value.categoryId]) continue;
+      categoryMapping.value[name] = { ...value };
+    }
+  };
+
+  /**
+   * Remembers this run's category mapping against the source fingerprint, newest first,
+   * so the next import from the same source can re-apply it. Over the cap, unnamed presets
+   * are evicted oldest-first; named ones only go once nothing unnamed is left.
+   *
+   * ponytail: silent best-effort save — a failure only reaches Sentry. Add a toast if users
+   * report losing presets.
+   */
+  const persistPreset = ({ mapping }: { mapping: CategoryMappingConfig }) => {
+    if (!fingerprint.value || Object.keys(mapping).length === 0) return;
+
+    const stored = storedPresets.value;
+    const existingName = stored.find((preset) => preset.fingerprint === fingerprint.value)?.name;
+    const presets: CategoryMappingPreset[] = [
+      {
+        fingerprint: fingerprint.value,
+        ...(existingName ? { name: existingName } : {}),
+        categoryMapping: mapping,
+        updatedAt: new Date().toISOString(),
+      },
+      ...stored.filter((preset) => preset.fingerprint !== fingerprint.value),
+    ];
+
+    while (presets.length > MAX_CATEGORY_MAPPING_PRESETS) {
+      const unnamedIndex = presets.findLastIndex((preset) => !preset.name);
+      presets.splice(unnamedIndex === -1 ? presets.length - 1 : unnamedIndex, 1);
+    }
+
+    userSettings.patchAsync({ import: { categoryMappingPresets: presets } }).catch((error) => {
+      captureException({ error, context: { scope: 'import-shared:persist-category-preset' } });
+    });
+  };
+
+  /** Labels a preset in place: the stored order and `updatedAt` stay untouched. */
+  const renamePreset = async ({ fingerprint: target, name }: { fingerprint: string; name: string }) => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+
+    await patchPresets({
+      presets: storedPresets.value.map((preset) =>
+        preset.fingerprint === target ? { ...preset, name: trimmed } : preset,
+      ),
+      scope: 'import-shared:rename-category-preset',
+    });
+  };
+
+  const deletePreset = async ({ fingerprint: target }: { fingerprint: string }) => {
+    await patchPresets({
+      presets: storedPresets.value.filter((preset) => preset.fingerprint !== target),
+      scope: 'import-shared:delete-category-preset',
+    });
+  };
+
+  return { matchingPreset, namedPresets, applyPreset, persistPreset, renamePreset, deletePreset };
+};

--- a/packages/frontend/src/composable/use-resolve-mapping.ts
+++ b/packages/frontend/src/composable/use-resolve-mapping.ts
@@ -1,3 +1,7 @@
+import { aiMapImportCategories } from '@/api/import-export';
+import { i18n } from '@/i18n';
+import { extractApiErrorMessage, isApiErrorWithCode } from '@/js/errors';
+import { captureException } from '@/lib/sentry';
 import {
   type ResolveSource,
   type ResolveTarget,
@@ -5,7 +9,8 @@ import {
   computeCreateForUnresolved,
   computeExactLinkEntries,
 } from '@/pages/import-export/utils/resolve-mapping';
-import { type ComputedRef, type Ref, computed } from 'vue';
+import { API_ERROR_CODES } from '@bt/shared/types';
+import { type ComputedRef, type Ref, computed, ref } from 'vue';
 
 /**
  * Shared "Resolve step" engine for the import wizards (CSV + Wallet). Both
@@ -227,6 +232,99 @@ export function useResolveMapping<
     }
   }
 
+  // ---- AI category mapping ----
+
+  const isAiMappingCategories = ref(false);
+  const aiMappingCategoriesError = ref<string | null>(null);
+
+  /**
+   * Successful AI verdicts from this session, keyed by source name. Null verdicts
+   * are never stored, so an unmatched name is re-asked on the next click (the
+   * user may have created the missing category in between).
+   */
+  const aiCategoryVerdictCache = new Map<string, string>();
+
+  const AI_MAPPING_FLASH_MS = 400;
+
+  /** Cached and no-op paths finish instantly; flash the overlay so the click visibly responds. */
+  function flashAiMappingOverlay(): void {
+    isAiMappingCategories.value = true;
+    setTimeout(() => {
+      isAiMappingCategories.value = false;
+    }, AI_MAPPING_FLASH_MS);
+  }
+
+  /**
+   * Ask the backend AI to link source categories to existing ones. Rows already
+   * linked to a concrete target are skipped; create-new rows (auto-seeded or
+   * user-chosen) are re-decided. Unmatched sources keep their current entry.
+   */
+  async function quickAiMapCategories(): Promise<void> {
+    if (isAiMappingCategories.value) return;
+
+    const names = categorySources.value
+      .filter((source) => {
+        const entry = categories.mapping.value[source.name];
+        return !entry || entry.action !== 'link-existing' || !categories.isResolved(entry);
+      })
+      .map((source) => source.name);
+
+    if (names.length === 0) {
+      flashAiMappingOverlay();
+      return;
+    }
+
+    const validTargetIds = new Set(categoryTargets.value.map((target) => target.id));
+    const applyVerdict = ({ name, categoryId }: { name: string; categoryId: string | null }) => {
+      if (categoryId && validTargetIds.has(categoryId)) {
+        categories.mapping.value[name] = categories.toLink(categoryId, name);
+      }
+    };
+
+    const uncachedNames: string[] = [];
+    for (const name of names) {
+      const cached = aiCategoryVerdictCache.get(name);
+      if (cached) {
+        applyVerdict({ name, categoryId: cached });
+      } else {
+        uncachedNames.push(name);
+      }
+    }
+
+    if (uncachedNames.length === 0) {
+      flashAiMappingOverlay();
+      return;
+    }
+
+    isAiMappingCategories.value = true;
+    aiMappingCategoriesError.value = null;
+    try {
+      const { mappings } = await aiMapImportCategories({ sourceCategories: uncachedNames });
+      for (const [name, categoryId] of Object.entries(mappings)) {
+        if (categoryId) aiCategoryVerdictCache.set(name, categoryId);
+        applyVerdict({ name, categoryId });
+      }
+    } catch (error) {
+      if (isApiErrorWithCode(error, API_ERROR_CODES.validationError)) {
+        // A validation response describes a fixable problem (e.g. AI not
+        // configured); show its message and skip Sentry.
+        aiMappingCategoriesError.value =
+          extractApiErrorMessage(error) ?? i18n.global.t('importShared.aiMapping.failed');
+      } else {
+        aiMappingCategoriesError.value = i18n.global.t('importShared.aiMapping.failed');
+        captureException({ error, context: { scope: 'import-shared:ai-map-categories' } });
+      }
+    } finally {
+      isAiMappingCategories.value = false;
+    }
+  }
+
+  /** Forget this session's AI verdicts and error (wizard restart). */
+  function resetAiMapping(): void {
+    aiCategoryVerdictCache.clear();
+    aiMappingCategoriesError.value = null;
+  }
+
   /** Clear one entity's stored choices, then re-seed via name auto-match. */
   function resetResolveEntity({ entity }: { entity: ResolveEntityKind }): void {
     if (entity === 'accounts') clearEntity({ config: accounts, sources: accountSources });
@@ -291,6 +389,10 @@ export function useResolveMapping<
     quickMapExactMatches,
     quickCreateNewForUnmatched,
     quickSkipAllTags,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
+    resetAiMapping,
     resetResolveEntity,
     toggleDuplicateUnmark,
     accountResolvedCount,

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-budget-bakers-wallet.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-budget-bakers-wallet.json
@@ -63,6 +63,7 @@
           "allFailedDescription": "No rows were imported. Review the errors below and try again.",
           "accountsCreated": "Accounts created",
           "accountsLinked": "Accounts linked",
+          "accountsSkipped": "Accounts skipped",
           "categoriesCreated": "Categories created",
           "tagsCreated": "Tags created",
           "transactionsImported": "Transactions imported",
@@ -91,7 +92,8 @@
             "sectionTitle": "Accounts",
             "currentBalanceLabel": "Current balance (optional)",
             "currentBalancePlaceholder": "Leave blank to use imported total",
-            "willCreateHint": "Will create a new {currency} account"
+            "willCreateHint": "Will create a new {currency} account",
+            "skippedNote": "{count} account(s) will be skipped. Their transactions — and any transfers to or from them — will not be imported."
           },
           "categories": {
             "sectionTitle": "Categories"

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-csv.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-csv.json
@@ -9,7 +9,8 @@
           "steps": {
             "upload": "Upload",
             "map": "Map Columns",
-            "resolve": "Resolve Values",
+            "resolveAccounts": "Accounts",
+            "resolveCategories": "Categories",
             "review": "Review",
             "results": "Done"
           }
@@ -115,6 +116,7 @@
           "imported": "Imported",
           "skippedDuplicates": "Skipped (Duplicates)",
           "accountsCreated": "Accounts Created",
+          "accountsSkipped": "Accounts skipped",
           "categoriesCreated": "Categories Created",
           "tagsCreated": "Tags Created",
           "payeesCreated": "Payees Created",
@@ -255,7 +257,8 @@
           "empty": "No accounts found in CSV",
           "currentBalanceLabel": "Current balance",
           "currentBalancePlaceholder": "0.00",
-          "currentBalanceHint": "The balance this account holds right now — the import will set the account to exactly this value. Leave blank to use the sum of imported transactions."
+          "currentBalanceHint": "The balance this account holds right now — the import will set the account to exactly this value. Leave blank to use the sum of imported transactions.",
+          "skippedNote": "{count} account(s) will be skipped. Their transactions will not be imported."
         },
         "categories": {
           "sectionTitle": "Category Mapping",

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-csv.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-csv.json
@@ -234,7 +234,6 @@
           "createNewForUnmatched": "Create new for unmatched",
           "skipAll": "Skip all",
           "reset": "Reset",
-          "menuLabel": "Quick actions",
           "tooltips": {
             "mapExactMatchesAccounts": "Links each CSV account to an existing account that has the same name and currency. Accounts with no exact match stay unchanged.",
             "mapExactMatchesCategories": "Links each CSV category to an existing category with the same name. Categories with no exact match stay unchanged.",

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-shared.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-shared.json
@@ -15,6 +15,7 @@
     },
     "selectAction": "Select action",
     "resolvedCounterWord": "resolved",
+    "quickActionsMenuLabel": "Bulk actions",
     "columns": {
       "sourceName": "Source name",
       "currency": "Currency",
@@ -71,6 +72,12 @@
         "category": "Category"
       },
       "importAnywayAriaLabel": "Import row {row} anyway"
+    },
+    "aiMapping": {
+      "action": "AI match",
+      "tooltipCategories": "Let AI link each source category to the closest existing category. Rows you already linked to a category are left untouched.",
+      "failed": "AI matching failed. Please try again.",
+      "inProgress": "AI matching in progress…"
     }
   }
 }

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-shared.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-shared.json
@@ -16,6 +16,9 @@
     "selectAction": "Select action",
     "resolvedCounterWord": "resolved",
     "quickActionsMenuLabel": "Bulk actions",
+    "quickActions": {
+      "menu": "Actions"
+    },
     "columns": {
       "sourceName": "Source name",
       "currency": "Currency",
@@ -78,6 +81,16 @@
       "tooltipCategories": "Let AI link each source category to the closest existing category. Rows you already linked to a category are left untouched.",
       "failed": "AI matching failed. Please try again.",
       "inProgress": "AI matching in progress…"
+    },
+    "categoryPreset": {
+      "menuTrigger": "Apply mapping",
+      "currentLayout": "This file's layout",
+      "savedTemplates": "Saved templates",
+      "lastUsed": "Last used mapping",
+      "namePlaceholder": "Name this mapping",
+      "renameAria": "Rename mapping",
+      "deleteAria": "Delete mapping",
+      "confirmRenameAria": "Save name"
     }
   }
 }

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/import-ynab.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/import-ynab.json
@@ -24,9 +24,14 @@
         "preview": {
           "emptyList": "Nothing to import here.",
           "accounts": "Accounts",
+          "categories": "Categories",
+          "payees": "Payees",
+          "tags": "Tags",
           "transactions": "Transactions",
+          "transfers": "Transfers",
           "dateRange": "Range: {from} → {to}",
           "accountsHelper": "For each YNAB account, confirm the currency.",
+          "skippedNote": "{count} account(s) will be skipped. Their transactions — and any transfers to or from them — will not be imported.",
           "warningsTitle": "Warnings",
           "rowPrefix": "Row {rowIndex}:",
           "startOver": "Start over",
@@ -38,7 +43,8 @@
           "currencyPlaceholder": "USD",
           "currencyLabel": "Currency",
           "currencyInvalid": "Enter a 3-letter currency code (e.g. USD)",
-          "autoDetected": "auto-detected: {code}"
+          "autoDetected": "auto-detected: {code}",
+          "undoSkip": "Include in import"
         },
         "execute": {
           "starting": "Starting the import…",
@@ -53,6 +59,7 @@
           "successTitle": "Import complete",
           "successDescription": "Your YNAB data is now in MoneyMatter.",
           "accountsCreated": "Accounts created",
+          "accountsSkipped": "Accounts skipped",
           "categoriesCreated": "Categories created",
           "payeesCreated": "Payees created",
           "tagsCreated": "Tags created",

--- a/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/done-step.vue
+++ b/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/done-step.vue
@@ -31,6 +31,11 @@
         :value="summary.accountsLinked"
       />
       <StatCard
+        v-if="(summary.accountsSkipped ?? 0) > 0"
+        :label="$t('pages.importExport.budgetBakersWalletImport.done.accountsSkipped')"
+        :value="summary.accountsSkipped ?? 0"
+      />
+      <StatCard
         :label="$t('pages.importExport.budgetBakersWalletImport.done.categoriesCreated')"
         :value="summary.categoriesCreated"
       />

--- a/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
+++ b/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
@@ -3,7 +3,7 @@
  * BudgetBakers Wallet resolve step — reconciles every Wallet account + non-transfer category
  * against the user's existing app data using the shared mapping tables. Mirrors
  * the CSV importer's resolve step: each row is either "create new" or
- * "link to existing", with per-entity bulk-action toolbars.
+ * "link to existing", or skipped entirely, with per-entity bulk-action toolbars.
  *
  * Wallet-only addition: each `create-new` account row exposes an optional
  * "current balance" input (the `create-new-cell` slot). Leaving it blank lets
@@ -13,9 +13,7 @@ import InputField from '@/components/fields/input-field.vue';
 import UiButton from '@/components/lib/ui/button/Button.vue';
 import { Callout } from '@/components/lib/ui/callout';
 import RecalculateBalanceToggle from '@/pages/import-export/components/recalculate-balance-toggle.vue';
-import AccountMappingTable, {
-  type AccountAction,
-} from '@/pages/import-export/components/resolve-values-step/account-mapping-table.vue';
+import AccountMappingTable from '@/pages/import-export/components/resolve-values-step/account-mapping-table.vue';
 import CategoryMappingTable from '@/pages/import-export/components/resolve-values-step/category-mapping-table.vue';
 import { type QuickAction } from '@/pages/import-export/components/resolve-values-step/quick-action-toolbar.vue';
 import { useAccountsStore } from '@/stores/accounts';
@@ -57,13 +55,6 @@ const categoryItems = computed(() => {
   }
   return store.resolvableCategoryNames.map((name) => ({ name, transactionCount: countByName.get(name) }));
 });
-
-// ---- Account action bridge ----
-
-function onAccountSetAction({ name, action }: { name: string; action: AccountAction }): void {
-  if (action === 'skip') return;
-  store.setAccountAction({ name, action });
-}
 
 // ---- Current-balance input bridge (Wallet-only) ----
 
@@ -158,7 +149,8 @@ async function handleContinue() {
       :title="$t('pages.importExport.budgetBakersWalletImport.resolve.accounts.sectionTitle')"
       :resolved-label="$t('pages.importExport.budgetBakersWalletImport.resolve.resolvedCounterWord')"
       :quick-actions="accountQuickActions"
-      @set-action="onAccountSetAction"
+      allow-skip
+      @set-action="store.setAccountAction"
       @set-target="store.setAccountTarget"
     >
       <!-- Wallet-only: optional current-balance input for create-new accounts. -->
@@ -181,6 +173,16 @@ async function handleContinue() {
         </div>
       </template>
     </AccountMappingTable>
+
+    <Callout v-if="store.skippedAccountNames.length > 0" variant="warning">
+      <p>
+        {{
+          $t('pages.importExport.budgetBakersWalletImport.resolve.accounts.skippedNote', {
+            count: store.skippedAccountNames.length,
+          })
+        }}
+      </p>
+    </Callout>
 
     <!-- ==================== CATEGORIES SECTION ==================== -->
     <CategoryMappingTable

--- a/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
+++ b/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
@@ -19,7 +19,7 @@ import { type QuickAction } from '@/pages/import-export/components/resolve-value
 import { useAccountsStore } from '@/stores/accounts';
 import { useCategoriesStore } from '@/stores/categories/categories';
 import { useImportBudgetBakersWalletStore } from '@/stores/import-budget-bakers-wallet';
-import { ChevronLeftIcon, ChevronRightIcon, LinkIcon, PlusIcon, RefreshCwIcon } from '@lucide/vue';
+import { ChevronLeftIcon, ChevronRightIcon, LinkIcon, PlusIcon, RefreshCwIcon, SparklesIcon } from '@lucide/vue';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -104,6 +104,13 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     onClick: () => store.quickMapExactMatches({ entity: 'categories' }),
   },
   {
+    icon: SparklesIcon,
+    label: t('importShared.aiMapping.action'),
+    tooltip: t('importShared.aiMapping.tooltipCategories'),
+    onClick: () => store.quickAiMapCategories(),
+    disabled: store.isAiMappingCategories,
+  },
+  {
     icon: PlusIcon,
     label: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.tooltips.createNewForUnmatched'),
@@ -186,6 +193,7 @@ async function handleContinue() {
 
     <!-- ==================== CATEGORIES SECTION ==================== -->
     <CategoryMappingTable
+      :loading="store.isAiMappingCategories"
       :items="categoryItems"
       :mapping="store.categoryMapping"
       :available-categories="formattedCategories"
@@ -195,6 +203,10 @@ async function handleContinue() {
       @set-action="store.setCategoryAction"
       @set-target="store.setCategoryTarget"
     />
+
+    <Callout v-if="store.aiMappingCategoriesError" variant="destructive" role="alert">
+      <p>{{ store.aiMappingCategoriesError }}</p>
+    </Callout>
 
     <!-- ==================== BALANCE RECALCULATION ==================== -->
     <RecalculateBalanceToggle
@@ -216,7 +228,9 @@ async function handleContinue() {
       </UiButton>
 
       <UiButton
-        :disabled="!store.isResolveStepValid || isNavigating || store.isDetectingDuplicates"
+        :disabled="
+          !store.isResolveStepValid || isNavigating || store.isDetectingDuplicates || store.isAiMappingCategories
+        "
         @click="handleContinue"
       >
         {{ $t('pages.importExport.budgetBakersWalletImport.resolve.footer.continue') }}

--- a/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
+++ b/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/resolve-step.vue
@@ -81,12 +81,14 @@ const accountQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.tooltips.mapExactMatchesAccounts'),
     onClick: () => store.quickMapExactMatches({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => store.quickCreateNewForUnmatched({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -102,6 +104,7 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.tooltips.mapExactMatchesCategories'),
     onClick: () => store.quickMapExactMatches({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: SparklesIcon,
@@ -109,12 +112,14 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     tooltip: t('importShared.aiMapping.tooltipCategories'),
     onClick: () => store.quickAiMapCategories(),
     disabled: store.isAiMappingCategories,
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.budgetBakersWalletImport.resolve.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => store.quickCreateNewForUnmatched({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -200,8 +205,13 @@ async function handleContinue() {
       :title="$t('pages.importExport.budgetBakersWalletImport.resolve.categories.sectionTitle')"
       :resolved-label="$t('pages.importExport.budgetBakersWalletImport.resolve.resolvedCounterWord')"
       :quick-actions="categoryQuickActions"
+      :matching-preset="store.matchingCategoryPreset"
+      :named-presets="store.namedCategoryPresets"
       @set-action="store.setCategoryAction"
       @set-target="store.setCategoryTarget"
+      @apply-preset="store.applyCategoryPreset"
+      @rename-preset="store.renameCategoryPreset"
+      @delete-preset="store.deleteCategoryPreset"
     />
 
     <Callout v-if="store.aiMappingCategoriesError" variant="destructive" role="alert">

--- a/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/review-step.vue
+++ b/packages/frontend/src/pages/import-export/budget-bakers-wallet-import/components/review-step.vue
@@ -20,14 +20,26 @@ const store = useImportBudgetBakersWalletStore();
 
 // ---- Derived counts for the stat cards ----
 
-/** Ordinary transaction rows the parser produced (transfers are separate). */
-const transactionsCount = computed(() => store.parsedResult?.transactions.length ?? 0);
+const skippedAccounts = computed(() => new Set(store.skippedAccountNames));
 
-/** Paired transfers detected during parsing. */
-const transfersCount = computed(() => store.parsedResult?.transfers.length ?? 0);
+/** Ordinary transaction rows that will be imported (transfers are separate). */
+const importableTransactions = computed(() =>
+  (store.parsedResult?.transactions ?? []).filter((tx) => !skippedAccounts.value.has(tx.accountName)),
+);
+
+const importableTransfers = computed(() =>
+  (store.parsedResult?.transfers ?? []).filter(
+    (xfer) =>
+      !skippedAccounts.value.has(xfer.sourceAccountName) && !skippedAccounts.value.has(xfer.destinationAccountName),
+  ),
+);
+
+const transactionsCount = computed(() => importableTransactions.value.length);
+
+const transfersCount = computed(() => importableTransfers.value.length);
 
 /** Unpaired transfer legs imported as out-of-wallet transactions. */
-const outOfWalletCount = computed(() => (store.parsedResult?.transactions ?? []).filter((tx) => tx.outOfWallet).length);
+const outOfWalletCount = computed(() => importableTransactions.value.filter((tx) => tx.outOfWallet).length);
 
 /** Detected duplicates the user left marked (will be skipped on import). */
 const duplicatesSkippedCount = computed(() => store.skipDuplicateIndices.length);

--- a/packages/frontend/src/pages/import-export/components/column-mapping-step/date-format-expansion.vue
+++ b/packages/frontend/src/pages/import-export/components/column-mapping-step/date-format-expansion.vue
@@ -104,7 +104,7 @@ const DEFAULT_SEPARATOR = '/';
 const dateColumnValues = computed<string[]>(() => {
   const column = importStore.columnMapping.date;
   if (!column) return [];
-  const index = importStore.csvHeaders.indexOf(column);
+  const index = importStore.csvDataRowHeaders.indexOf(column);
   if (index === -1) return [];
 
   const values: string[] = [];

--- a/packages/frontend/src/pages/import-export/components/column-mapping-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/column-mapping-step/index.vue
@@ -807,9 +807,9 @@ const missingHint = computed(() => {
 });
 
 const handleNext = async () => {
-  // When a per-value method is active the Resolve step handles reconciliation,
+  // When a per-value method is active a Resolve step handles reconciliation,
   // so just advance; otherwise run duplicate detection (which advances to Review).
-  if (importStore.needsResolveStep) {
+  if (importStore.needsAccountResolution || importStore.needsCategoriesResolveStep) {
     importStore.goNext();
     return;
   }

--- a/packages/frontend/src/pages/import-export/components/import-results-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/import-results-step/index.vue
@@ -81,6 +81,12 @@
           variant="neutral"
         />
         <StatCard
+          v-if="(summary.accountsSkipped ?? 0) > 0"
+          :label="$t('pages.importExport.csvImport.results.accountsSkipped')"
+          :value="summary.accountsSkipped ?? 0"
+          variant="neutral"
+        />
+        <StatCard
           v-if="summary.categoriesCreated > 0"
           :label="$t('pages.importExport.csvImport.results.categoriesCreated')"
           :value="summary.categoriesCreated"
@@ -201,6 +207,7 @@ const hasSecondaryStats = computed(() => {
   return (
     s.skippedUnpriceable > 0 ||
     s.accountsCreated > 0 ||
+    (s.accountsSkipped ?? 0) > 0 ||
     s.categoriesCreated > 0 ||
     s.payeesCreated > 0 ||
     s.tagsCreated > 0

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/category-mapping-table.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/category-mapping-table.vue
@@ -19,6 +19,7 @@ import SelectField from '@/components/fields/select-field.vue';
 import { MappingTable, type MappingTableColumn } from '@/components/lib/ui/mapping-table';
 import { StatusIndicator } from '@/components/lib/ui/status-indicator';
 import { buildCategoryMapById } from '@/pages/import-export/utils/flatten-categories';
+import { Loader2Icon } from '@lucide/vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import QuickActionsToolbar, { type QuickAction } from './quick-action-toolbar.vue';
@@ -47,6 +48,8 @@ const props = defineProps<{
   resolvedLabel: string;
   /** Bulk-action buttons the parent builds with i18n labels + store handlers. */
   quickActions: QuickAction[];
+  /** Blocks the whole section behind a spinner overlay (e.g. while AI matching runs). */
+  loading?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -120,9 +123,23 @@ function onTargetChange({ name, category }: { name: string; category: FormattedC
 </script>
 
 <template>
-  <section>
+  <section class="relative isolate" :aria-busy="loading || undefined">
+    <!-- Blocks the section while an async bulk action runs: this overlay stops
+         pointer input, the inert siblings below stop keyboard access. -->
+    <div
+      v-if="loading"
+      class="bg-background/60 absolute inset-0 z-10 flex justify-center rounded-lg pt-24 backdrop-blur-[2px]"
+    >
+      <div
+        class="border-border bg-card sticky top-1/3 flex h-fit items-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium shadow-lg"
+      >
+        <Loader2Icon class="text-primary-text size-5 animate-spin" />
+        {{ $t('importShared.aiMapping.inProgress') }}
+      </div>
+    </div>
+
     <!-- Section header: title + resolved counter on the left, quick actions on the right -->
-    <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
+    <div class="mb-3 flex flex-wrap items-center justify-between gap-2" :inert="loading || undefined">
       <div>
         <h3 class="text-sm font-semibold">{{ title }}</h3>
         <p class="text-muted-foreground text-xs">{{ resolvedCount }} / {{ items.length }} {{ resolvedLabel }}</p>
@@ -132,6 +149,7 @@ function onTargetChange({ name, category }: { name: string; category: FormattedC
     </div>
 
     <MappingTable
+      :inert="loading || undefined"
       :columns="columns"
       :items="items"
       :row-key="(row) => row.name"

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/category-mapping-table.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/category-mapping-table.vue
@@ -19,9 +19,11 @@ import SelectField from '@/components/fields/select-field.vue';
 import { MappingTable, type MappingTableColumn } from '@/components/lib/ui/mapping-table';
 import { StatusIndicator } from '@/components/lib/ui/status-indicator';
 import { buildCategoryMapById } from '@/pages/import-export/utils/flatten-categories';
+import type { CategoryMappingPreset } from '@bt/shared/types';
 import { Loader2Icon } from '@lucide/vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
+import CategoryPresetMenu from './category-preset-menu.vue';
 import QuickActionsToolbar, { type QuickAction } from './quick-action-toolbar.vue';
 
 const { t } = useI18n();
@@ -48,6 +50,10 @@ const props = defineProps<{
   resolvedLabel: string;
   /** Bulk-action buttons the parent builds with i18n labels + store handlers. */
   quickActions: QuickAction[];
+  /** Saved mapping for the current file's layout. Omit to hide the preset menu. */
+  matchingPreset?: CategoryMappingPreset | null;
+  /** Named mapping templates offered by the preset menu. */
+  namedPresets?: CategoryMappingPreset[];
   /** Blocks the whole section behind a spinner overlay (e.g. while AI matching runs). */
   loading?: boolean;
 }>();
@@ -55,6 +61,9 @@ const props = defineProps<{
 const emit = defineEmits<{
   'set-action': [payload: { name: string; action: 'create-new' | 'link-existing' }];
   'set-target': [payload: { name: string; categoryId: string }];
+  'apply-preset': [payload: { preset: CategoryMappingPreset }];
+  'rename-preset': [payload: { fingerprint: string; name: string }];
+  'delete-preset': [payload: { fingerprint: string }];
 }>();
 
 // ---- Option lists ----
@@ -145,7 +154,17 @@ function onTargetChange({ name, category }: { name: string; category: FormattedC
         <p class="text-muted-foreground text-xs">{{ resolvedCount }} / {{ items.length }} {{ resolvedLabel }}</p>
       </div>
 
-      <QuickActionsToolbar :actions="quickActions" />
+      <div class="flex items-center gap-2">
+        <CategoryPresetMenu
+          :matching-preset="matchingPreset ?? null"
+          :named-presets="namedPresets ?? []"
+          @apply="emit('apply-preset', $event)"
+          @rename="emit('rename-preset', $event)"
+          @delete="emit('delete-preset', $event)"
+        />
+
+        <QuickActionsToolbar :actions="quickActions" />
+      </div>
     </div>
 
     <MappingTable

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/category-preset-menu.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/category-preset-menu.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+/**
+ * Picker for the saved category mappings, shown in the category table header.
+ *
+ * Built on Popover rather than the DropdownMenu primitive: menu roving focus and
+ * typeahead swallow the keystrokes the inline rename input needs.
+ */
+import InputField from '@/components/fields/input-field.vue';
+import UiButton from '@/components/lib/ui/button/Button.vue';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/lib/ui/popover';
+import { DesktopOnlyTooltip } from '@/components/lib/ui/tooltip';
+import type { CategoryMappingPreset } from '@bt/shared/types';
+import { CheckIcon, ChevronDownIcon, HistoryIcon, PencilIcon, Trash2Icon } from '@lucide/vue';
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const MAX_PRESET_NAME_LENGTH = 64;
+
+const props = defineProps<{
+  /** Mapping saved for the layout of the file being imported, if any. */
+  matchingPreset: CategoryMappingPreset | null;
+  /** Named templates, excluding the matching one. */
+  namedPresets: CategoryMappingPreset[];
+}>();
+
+const emit = defineEmits<{
+  apply: [payload: { preset: CategoryMappingPreset }];
+  rename: [payload: { fingerprint: string; name: string }];
+  delete: [payload: { fingerprint: string }];
+}>();
+
+const { t } = useI18n();
+
+const isOpen = ref(false);
+
+const sections = computed(() =>
+  [
+    {
+      key: 'matching',
+      label: t('importShared.categoryPreset.currentLayout'),
+      presets: props.matchingPreset ? [props.matchingPreset] : [],
+    },
+    {
+      key: 'named',
+      label: t('importShared.categoryPreset.savedTemplates'),
+      presets: props.namedPresets,
+    },
+  ].filter((section) => section.presets.length > 0),
+);
+
+function displayName({ preset }: { preset: CategoryMappingPreset }): string {
+  return preset.name || t('importShared.categoryPreset.lastUsed');
+}
+
+// ---- Inline rename ----
+
+const renamingFingerprint = ref<string | null>(null);
+const renameValue = ref('');
+
+function startRename({ preset }: { preset: CategoryMappingPreset }) {
+  renamingFingerprint.value = preset.fingerprint;
+  renameValue.value = preset.name ?? '';
+}
+
+function cancelRename() {
+  renamingFingerprint.value = null;
+}
+
+function commitRename() {
+  const fingerprint = renamingFingerprint.value;
+  const name = renameValue.value.trim();
+  if (fingerprint && name) emit('rename', { fingerprint, name });
+  cancelRename();
+}
+
+// ---- Open state ----
+
+function onOpenChange({ open }: { open: boolean }) {
+  isOpen.value = open;
+  if (!open) cancelRename();
+}
+
+function applyPreset({ preset }: { preset: CategoryMappingPreset }) {
+  emit('apply', { preset });
+  onOpenChange({ open: false });
+}
+</script>
+
+<template>
+  <Popover v-if="sections.length > 0" :open="isOpen" @update:open="(open) => onOpenChange({ open })">
+    <PopoverTrigger as-child>
+      <UiButton variant="secondary" size="sm">
+        <HistoryIcon class="size-3.5" />
+        {{ $t('importShared.categoryPreset.menuTrigger') }}
+        <ChevronDownIcon class="size-3.5" />
+      </UiButton>
+    </PopoverTrigger>
+
+    <PopoverContent align="end" class="w-72 p-1">
+      <template v-for="(section, index) in sections" :key="section.key">
+        <div v-if="index > 0" class="bg-muted -mx-1 my-1 h-px" />
+
+        <p class="text-muted-foreground px-2 py-1.5 text-xs font-medium">{{ section.label }}</p>
+
+        <div v-for="preset in section.presets" :key="preset.fingerprint" class="group/preset flex items-center gap-1">
+          <template v-if="renamingFingerprint === preset.fingerprint">
+            <InputField
+              :model-value="renameValue"
+              class="min-w-0 flex-1"
+              non-label-wrapper
+              autofocus
+              :maxlength="MAX_PRESET_NAME_LENGTH"
+              :placeholder="$t('importShared.categoryPreset.namePlaceholder')"
+              @update:model-value="(value) => (renameValue = String(value ?? ''))"
+              @keydown.enter.stop.prevent="commitRename()"
+              @keydown.esc.stop="cancelRename()"
+            />
+
+            <DesktopOnlyTooltip :content="$t('importShared.categoryPreset.confirmRenameAria')">
+              <UiButton
+                variant="ghost"
+                size="icon-sm"
+                :aria-label="$t('importShared.categoryPreset.confirmRenameAria')"
+                @click="commitRename()"
+              >
+                <CheckIcon class="size-4" />
+              </UiButton>
+            </DesktopOnlyTooltip>
+          </template>
+
+          <template v-else>
+            <UiButton
+              variant="ghost"
+              class="h-8 min-w-0 flex-1 justify-start px-2 font-normal"
+              @click="applyPreset({ preset })"
+            >
+              <span v-if="section.key === 'matching'" class="bg-success-text size-1.5 shrink-0 rounded-full" />
+              <span class="truncate">{{ displayName({ preset }) }}</span>
+            </UiButton>
+
+            <DesktopOnlyTooltip :content="$t('importShared.categoryPreset.renameAria')">
+              <UiButton
+                variant="ghost"
+                size="icon-sm"
+                class="opacity-40 transition-opacity group-hover/preset:opacity-100 focus-visible:opacity-100"
+                :aria-label="$t('importShared.categoryPreset.renameAria')"
+                @click="startRename({ preset })"
+              >
+                <PencilIcon class="size-3.5" />
+              </UiButton>
+            </DesktopOnlyTooltip>
+
+            <DesktopOnlyTooltip :content="$t('importShared.categoryPreset.deleteAria')">
+              <UiButton
+                variant="ghost-destructive"
+                size="icon-sm"
+                class="opacity-40 transition-opacity group-hover/preset:opacity-100 focus-visible:opacity-100"
+                :aria-label="$t('importShared.categoryPreset.deleteAria')"
+                @click="emit('delete', { fingerprint: preset.fingerprint })"
+              >
+                <Trash2Icon class="size-3.5" />
+              </UiButton>
+            </DesktopOnlyTooltip>
+          </template>
+        </div>
+      </template>
+    </PopoverContent>
+  </Popover>
+</template>

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
@@ -199,12 +199,14 @@ const accountQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.resolveValues.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.mapExactMatchesAccounts'),
     onClick: () => importStore.quickMapExactMatches({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.resolveValues.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => importStore.quickCreateNewForUnmatched({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -220,6 +222,7 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.resolveValues.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.mapExactMatchesCategories'),
     onClick: () => importStore.quickMapExactMatches({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: SparklesIcon,
@@ -227,12 +230,14 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     tooltip: t('importShared.aiMapping.tooltipCategories'),
     onClick: () => importStore.quickAiMapCategories(),
     disabled: importStore.isAiMappingCategories,
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.resolveValues.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => importStore.quickCreateNewForUnmatched({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -248,18 +253,21 @@ const tagQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.resolveValues.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.mapExactMatchesTags'),
     onClick: () => importStore.quickMapExactMatches({ entity: 'tags' }),
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.resolveValues.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => importStore.quickCreateNewForUnmatched({ entity: 'tags' }),
+    menu: true,
   },
   {
     icon: SkipForwardIcon,
     label: t('pages.importExport.resolveValues.quickActions.skipAll'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.skipAll'),
     onClick: () => importStore.quickSkipAllTags(),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -378,8 +386,13 @@ async function handleNext() {
         :title="t('pages.importExport.resolveValues.categories.sectionTitle')"
         :resolved-label="t('importShared.resolvedCounterWord')"
         :quick-actions="categoryQuickActions"
+        :matching-preset="importStore.matchingCategoryPreset"
+        :named-presets="importStore.namedCategoryPresets"
         @set-action="onCategorySetAction"
         @set-target="onCategorySetTarget"
+        @apply-preset="importStore.applyCategoryPreset"
+        @rename-preset="importStore.renameCategoryPreset"
+        @delete-preset="importStore.deleteCategoryPreset"
       />
 
       <Callout

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
@@ -21,6 +21,10 @@ import { useI18n } from 'vue-i18n';
 
 const { t } = useI18n();
 
+const props = defineProps<{
+  section: 'accounts' | 'categories';
+}>();
+
 // ---- Stores ----
 
 const importStore = useImportExportStore();
@@ -48,11 +52,12 @@ const tagActionOptions = computed<OptionItem<TagMappingValue['action']>[]>(() =>
 // ---- Account mapping (shared table) emit handlers ----
 
 function onAccountSetAction({ name, action }: { name: string; action: AccountAction }) {
-  if (action === 'skip') return;
   if (action === 'create-new') {
     // `currentBalance: null` = leave the created account at the imported rows'
     // net sum; the balance input below overwrites it when the user enters a value.
     importStore.accountMapping[name] = { action: 'create-new', currentBalance: null };
+  } else if (action === 'skip') {
+    importStore.accountMapping[name] = { action: 'skip' };
   } else {
     importStore.accountMapping[name] = { action: 'link-existing', accountId: '' };
   }
@@ -98,7 +103,7 @@ function onCategorySetTarget({ name, categoryId }: { name: string; categoryId: s
 
 // ---- Category items for the shared table (names → { name }) ----
 
-const categoryItems = computed(() => importStore.uniqueCategoriesInCSV.map((name) => ({ name })));
+const categoryItems = computed(() => importStore.visibleCategoriesToResolve.map((name) => ({ name })));
 
 // ---- Tags table (kept inlined — out of scope for the shared extraction) ----
 
@@ -123,7 +128,7 @@ function getTagStatus(name: string): ResolveRowStatus {
 }
 
 const tagResolvedCount = computed(
-  () => importStore.uniqueTagsInCSV.filter((tg) => getTagStatus(tg) !== 'needs-attention').length,
+  () => importStore.visibleTagsToResolve.filter((tg) => getTagStatus(tg) !== 'needs-attention').length,
 );
 
 const tagColumns: MappingTableColumn[] = [
@@ -260,7 +265,18 @@ onMounted(() => {
 const isNavigating = ref(false);
 const navError = ref<string | null>(null);
 
+/** Only the last resolve step runs duplicate detection; earlier ones just advance. */
+const isLastResolveStep = computed(() => props.section === 'categories' || !importStore.needsCategoriesResolveStep);
+
+const isStepValid = computed(() =>
+  props.section === 'accounts' ? importStore.isResolveAccountsStepValid : importStore.isResolveCategoriesStepValid,
+);
+
 async function handleNext() {
+  if (!isLastResolveStep.value) {
+    importStore.goNext();
+    return;
+  }
   isNavigating.value = true;
   navError.value = null;
   try {
@@ -297,13 +313,14 @@ async function handleNext() {
 
       <!-- ==================== ACCOUNTS SECTION ==================== -->
       <AccountMappingTable
-        v-if="importStore.needsAccountResolution && importStore.uniqueAccountsInCSV.length > 0"
+        v-if="section === 'accounts' && importStore.uniqueAccountsInCSV.length > 0"
         :items="importStore.uniqueAccountsInCSV"
         :mapping="importStore.accountMapping"
         :available-accounts="importLinkableAccounts"
         :title="t('pages.importExport.resolveValues.accounts.sectionTitle')"
         :resolved-label="t('importShared.resolvedCounterWord')"
         :quick-actions="accountQuickActions"
+        allow-skip
         @set-action="onAccountSetAction"
         @set-target="onAccountSetTarget"
       >
@@ -326,9 +343,19 @@ async function handleNext() {
         </template>
       </AccountMappingTable>
 
+      <Callout v-if="section === 'accounts' && importStore.skippedAccountNames.length > 0" variant="warning">
+        <p>
+          {{
+            $t('pages.importExport.resolveValues.accounts.skippedNote', {
+              count: importStore.skippedAccountNames.length,
+            })
+          }}
+        </p>
+      </Callout>
+
       <!-- ==================== CATEGORIES SECTION ==================== -->
       <CategoryMappingTable
-        v-if="importStore.needsCategoryResolution && importStore.uniqueCategoriesInCSV.length > 0"
+        v-if="section === 'categories' && importStore.needsCategoryResolution && categoryItems.length > 0"
         :items="categoryItems"
         :mapping="importStore.categoryMapping"
         :available-categories="formattedCategories"
@@ -340,7 +367,9 @@ async function handleNext() {
       />
 
       <!-- ==================== TAGS SECTION ==================== -->
-      <section v-if="importStore.needsTagResolution && importStore.uniqueTagsInCSV.length > 0">
+      <section
+        v-if="section === 'categories' && importStore.needsTagResolution && importStore.visibleTagsToResolve.length > 0"
+      >
         <div class="mb-3 flex flex-wrap items-center justify-between gap-2">
           <div>
             <h3 class="text-sm font-semibold">{{ t('pages.importExport.resolveValues.tags.sectionTitle') }}</h3>
@@ -348,7 +377,7 @@ async function handleNext() {
               {{
                 t('pages.importExport.resolveValues.tags.resolvedCount', {
                   resolved: tagResolvedCount,
-                  total: importStore.uniqueTagsInCSV.length,
+                  total: importStore.visibleTagsToResolve.length,
                 })
               }}
             </p>
@@ -364,7 +393,7 @@ async function handleNext() {
 
         <MappingTable
           :columns="tagColumns"
-          :items="importStore.uniqueTagsInCSV"
+          :items="importStore.visibleTagsToResolve"
           :row-key="(row) => row"
           :get-row-class="(row) => (getTagStatus(row) === 'needs-attention' ? 'bg-warning/5' : '')"
         >
@@ -450,10 +479,7 @@ async function handleNext() {
         {{ t('pages.importExport.resolveValues.footer.back') }}
       </UiButton>
 
-      <UiButton
-        :disabled="!importStore.isResolveStepValid || isNavigating || importStore.isExtracting"
-        @click="handleNext"
-      >
+      <UiButton :disabled="!isStepValid || isNavigating || importStore.isExtracting" @click="handleNext">
         {{ t('pages.importExport.resolveValues.footer.next') }}
         <ChevronRightIcon class="ml-1.5 size-4" />
       </UiButton>

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/index.vue
@@ -14,7 +14,15 @@ import type { TagMappingValue } from '@bt/shared/types';
 import AccountMappingTable, { type AccountAction } from './account-mapping-table.vue';
 import CategoryMappingTable from './category-mapping-table.vue';
 import QuickActionsToolbar, { type QuickAction } from './quick-action-toolbar.vue';
-import { ChevronLeftIcon, ChevronRightIcon, RefreshCwIcon, LinkIcon, PlusIcon, SkipForwardIcon } from '@lucide/vue';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  RefreshCwIcon,
+  LinkIcon,
+  PlusIcon,
+  SkipForwardIcon,
+  SparklesIcon,
+} from '@lucide/vue';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -214,6 +222,13 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     onClick: () => importStore.quickMapExactMatches({ entity: 'categories' }),
   },
   {
+    icon: SparklesIcon,
+    label: t('importShared.aiMapping.action'),
+    tooltip: t('importShared.aiMapping.tooltipCategories'),
+    onClick: () => importStore.quickAiMapCategories(),
+    disabled: importStore.isAiMappingCategories,
+  },
+  {
     icon: PlusIcon,
     label: t('pages.importExport.resolveValues.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.resolveValues.quickActions.tooltips.createNewForUnmatched'),
@@ -356,6 +371,7 @@ async function handleNext() {
       <!-- ==================== CATEGORIES SECTION ==================== -->
       <CategoryMappingTable
         v-if="section === 'categories' && importStore.needsCategoryResolution && categoryItems.length > 0"
+        :loading="importStore.isAiMappingCategories"
         :items="categoryItems"
         :mapping="importStore.categoryMapping"
         :available-categories="formattedCategories"
@@ -365,6 +381,14 @@ async function handleNext() {
         @set-action="onCategorySetAction"
         @set-target="onCategorySetTarget"
       />
+
+      <Callout
+        v-if="section === 'categories' && importStore.aiMappingCategoriesError"
+        variant="destructive"
+        role="alert"
+      >
+        <p>{{ importStore.aiMappingCategoriesError }}</p>
+      </Callout>
 
       <!-- ==================== TAGS SECTION ==================== -->
       <section
@@ -479,7 +503,10 @@ async function handleNext() {
         {{ t('pages.importExport.resolveValues.footer.back') }}
       </UiButton>
 
-      <UiButton :disabled="!isStepValid || isNavigating || importStore.isExtracting" @click="handleNext">
+      <UiButton
+        :disabled="!isStepValid || isNavigating || importStore.isExtracting || importStore.isAiMappingCategories"
+        @click="handleNext"
+      >
         {{ t('pages.importExport.resolveValues.footer.next') }}
         <ChevronRightIcon class="ml-1.5 size-4" />
       </UiButton>

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/quick-action-toolbar.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/quick-action-toolbar.vue
@@ -12,6 +12,8 @@ export interface QuickAction {
   onClick: () => void;
   /** Disables the action in both the inline button and the overflow menu. */
   disabled?: boolean;
+  /** Moves the action into the shared "Actions" dropdown instead of the inline row. */
+  menu?: boolean;
 }
 </script>
 
@@ -24,26 +26,52 @@ import {
 } from '@/components/common/dropdown-menu';
 import UiButton from '@/components/lib/ui/button/Button.vue';
 import { DesktopOnlyTooltip } from '@/components/lib/ui/tooltip';
-import { EllipsisVerticalIcon } from '@lucide/vue';
+import { ChevronDownIcon, EllipsisVerticalIcon } from '@lucide/vue';
+import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 /**
  * Resolve Values quick-action toolbar. Once the wizard container is wide enough
- * (`@2xl/csv-wizard`) it shows inline labelled buttons, each with a hover tooltip.
- * Below that it collapses into a single overflow menu so every action keeps a
- * readable label on touch, where hover tooltips never fire.
+ * (`@2xl/csv-wizard`) it shows a single "Actions" dropdown holding every action
+ * flagged `menu`, followed by the remaining actions as inline labelled buttons
+ * with hover tooltips. Below that it collapses into a single overflow menu so
+ * every action keeps a readable label on touch, where hover tooltips never fire.
  */
-defineProps<{ actions: QuickAction[] }>();
+const props = defineProps<{ actions: QuickAction[] }>();
 
 const { t } = useI18n();
+
+const menuActions = computed(() => props.actions.filter((action) => action.menu));
+const inlineActions = computed(() => props.actions.filter((action) => !action.menu));
 </script>
 
 <template>
   <div class="flex items-center gap-2">
-    <!-- Wide: inline labelled buttons -->
+    <!-- Wide: "Actions" dropdown + inline labelled buttons -->
     <div class="hidden flex-wrap items-center gap-2 @2xl/csv-wizard:flex">
+      <DropdownMenu v-if="menuActions.length > 0">
+        <DropdownMenuTrigger as-child>
+          <UiButton variant="secondary" size="sm">
+            {{ t('importShared.quickActions.menu') }}
+            <ChevronDownIcon class="size-3.5" />
+          </UiButton>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" class="min-w-56">
+          <DropdownMenuItem
+            v-for="action in menuActions"
+            :key="action.label"
+            :disabled="action.disabled"
+            :title="action.tooltip"
+            @select="action.onClick"
+          >
+            <component :is="action.icon" class="size-4" />
+            {{ action.label }}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       <DesktopOnlyTooltip
-        v-for="action in actions"
+        v-for="action in inlineActions"
         :key="action.label"
         content-class-name="max-w-70"
         :content="action.tooltip"

--- a/packages/frontend/src/pages/import-export/components/resolve-values-step/quick-action-toolbar.vue
+++ b/packages/frontend/src/pages/import-export/components/resolve-values-step/quick-action-toolbar.vue
@@ -10,6 +10,8 @@ export interface QuickAction {
   tooltip: string;
   /** Invoked when the action is chosen (button click or menu select). */
   onClick: () => void;
+  /** Disables the action in both the inline button and the overflow menu. */
+  disabled?: boolean;
 }
 </script>
 
@@ -46,7 +48,7 @@ const { t } = useI18n();
         content-class-name="max-w-70"
         :content="action.tooltip"
       >
-        <UiButton variant="secondary" size="sm" @click="action.onClick">
+        <UiButton variant="secondary" size="sm" :disabled="action.disabled" @click="action.onClick">
           <component :is="action.icon" class="size-3.5" />
           {{ action.label }}
         </UiButton>
@@ -60,13 +62,18 @@ const { t } = useI18n();
           variant="secondary"
           size="sm"
           class="@2xl/csv-wizard:hidden"
-          :aria-label="t('pages.importExport.resolveValues.quickActions.menuLabel')"
+          :aria-label="t('importShared.quickActionsMenuLabel')"
         >
           <EllipsisVerticalIcon class="size-4" />
         </UiButton>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" class="min-w-56">
-        <DropdownMenuItem v-for="action in actions" :key="action.label" @select="action.onClick">
+        <DropdownMenuItem
+          v-for="action in actions"
+          :key="action.label"
+          :disabled="action.disabled"
+          @select="action.onClick"
+        >
           <component :is="action.icon" class="size-4" />
           {{ action.label }}
         </DropdownMenuItem>

--- a/packages/frontend/src/pages/import-export/csv-import.vue
+++ b/packages/frontend/src/pages/import-export/csv-import.vue
@@ -31,7 +31,8 @@
     <div class="min-w-0">
       <FileUploadStep v-if="store.currentStepKey === 'upload'" />
       <ColumnMappingStep v-else-if="store.currentStepKey === 'map'" />
-      <ResolveValuesStep v-else-if="store.currentStepKey === 'resolve'" />
+      <ResolveValuesStep v-else-if="store.currentStepKey === 'resolve-accounts'" section="accounts" />
+      <ResolveValuesStep v-else-if="store.currentStepKey === 'resolve-categories'" section="categories" />
       <ReviewDuplicatesStep v-else-if="store.currentStepKey === 'review'" />
       <template v-else-if="store.currentStepKey === 'results'">
         <ImportResultsStep v-if="store.progress?.status === 'completed'" />
@@ -60,7 +61,8 @@ import ReviewDuplicatesStep from './components/review-duplicates-step/index.vue'
 const STEP_LABEL_KEYS: Record<ImportStepKey, string> = {
   upload: 'pages.importExport.csvImport.stepper.steps.upload',
   map: 'pages.importExport.csvImport.stepper.steps.map',
-  resolve: 'pages.importExport.csvImport.stepper.steps.resolve',
+  'resolve-accounts': 'pages.importExport.csvImport.stepper.steps.resolveAccounts',
+  'resolve-categories': 'pages.importExport.csvImport.stepper.steps.resolveCategories',
   review: 'pages.importExport.csvImport.stepper.steps.review',
   results: 'pages.importExport.csvImport.stepper.steps.results',
 };

--- a/packages/frontend/src/pages/import-export/ms-money-import/components/resolve-step.vue
+++ b/packages/frontend/src/pages/import-export/ms-money-import/components/resolve-step.vue
@@ -19,7 +19,7 @@ import { type QuickAction } from '@/pages/import-export/components/resolve-value
 import { useAccountsStore } from '@/stores/accounts';
 import { useCategoriesStore } from '@/stores/categories/categories';
 import { useImportMsMoneyStore } from '@/stores/import-ms-money';
-import { ChevronLeftIcon, ChevronRightIcon, LinkIcon, PlusIcon, RefreshCwIcon } from '@lucide/vue';
+import { ChevronLeftIcon, ChevronRightIcon, LinkIcon, PlusIcon, RefreshCwIcon, SparklesIcon } from '@lucide/vue';
 import { storeToRefs } from 'pinia';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -102,6 +102,13 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.msMoneyImport.resolve.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.msMoneyImport.resolve.quickActions.tooltips.mapExactMatchesCategories'),
     onClick: () => store.quickMapExactMatches({ entity: 'categories' }),
+  },
+  {
+    icon: SparklesIcon,
+    label: t('importShared.aiMapping.action'),
+    tooltip: t('importShared.aiMapping.tooltipCategories'),
+    onClick: () => store.quickAiMapCategories(),
+    disabled: store.isAiMappingCategories,
   },
   {
     icon: PlusIcon,
@@ -198,6 +205,7 @@ async function handleContinue() {
 
     <!-- ==================== CATEGORIES SECTION ==================== -->
     <CategoryMappingTable
+      :loading="store.isAiMappingCategories"
       :items="categoryItems"
       :mapping="store.categoryMapping"
       :available-categories="formattedCategories"
@@ -207,6 +215,10 @@ async function handleContinue() {
       @set-action="store.setCategoryAction"
       @set-target="store.setCategoryTarget"
     />
+
+    <Callout v-if="store.aiMappingCategoriesError" variant="destructive" role="alert">
+      <p>{{ store.aiMappingCategoriesError }}</p>
+    </Callout>
 
     <!-- ==================== BALANCE RECALCULATION ==================== -->
     <RecalculateBalanceToggle
@@ -228,7 +240,9 @@ async function handleContinue() {
       </UiButton>
 
       <UiButton
-        :disabled="!store.isResolveStepValid || isNavigating || store.isDetectingDuplicates"
+        :disabled="
+          !store.isResolveStepValid || isNavigating || store.isDetectingDuplicates || store.isAiMappingCategories
+        "
         @click="handleContinue"
       >
         {{ $t('pages.importExport.msMoneyImport.resolve.footer.continue') }}

--- a/packages/frontend/src/pages/import-export/ms-money-import/components/resolve-step.vue
+++ b/packages/frontend/src/pages/import-export/ms-money-import/components/resolve-step.vue
@@ -81,12 +81,14 @@ const accountQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.msMoneyImport.resolve.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.msMoneyImport.resolve.quickActions.tooltips.mapExactMatchesAccounts'),
     onClick: () => store.quickMapExactMatches({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.msMoneyImport.resolve.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.msMoneyImport.resolve.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => store.quickCreateNewForUnmatched({ entity: 'accounts' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -102,6 +104,7 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     label: t('pages.importExport.msMoneyImport.resolve.quickActions.mapExactMatches'),
     tooltip: t('pages.importExport.msMoneyImport.resolve.quickActions.tooltips.mapExactMatchesCategories'),
     onClick: () => store.quickMapExactMatches({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: SparklesIcon,
@@ -109,12 +112,14 @@ const categoryQuickActions = computed<QuickAction[]>(() => [
     tooltip: t('importShared.aiMapping.tooltipCategories'),
     onClick: () => store.quickAiMapCategories(),
     disabled: store.isAiMappingCategories,
+    menu: true,
   },
   {
     icon: PlusIcon,
     label: t('pages.importExport.msMoneyImport.resolve.quickActions.createNewForUnmatched'),
     tooltip: t('pages.importExport.msMoneyImport.resolve.quickActions.tooltips.createNewForUnmatched'),
     onClick: () => store.quickCreateNewForUnmatched({ entity: 'categories' }),
+    menu: true,
   },
   {
     icon: RefreshCwIcon,
@@ -212,8 +217,13 @@ async function handleContinue() {
       :title="$t('pages.importExport.msMoneyImport.resolve.categories.sectionTitle')"
       :resolved-label="$t('importShared.resolvedCounterWord')"
       :quick-actions="categoryQuickActions"
+      :matching-preset="store.matchingCategoryPreset"
+      :named-presets="store.namedCategoryPresets"
       @set-action="store.setCategoryAction"
       @set-target="store.setCategoryTarget"
+      @apply-preset="store.applyCategoryPreset"
+      @rename-preset="store.renameCategoryPreset"
+      @delete-preset="store.deleteCategoryPreset"
     />
 
     <Callout v-if="store.aiMappingCategoriesError" variant="destructive" role="alert">

--- a/packages/frontend/src/pages/import-export/utils/suggest-date-field-order.spec.ts
+++ b/packages/frontend/src/pages/import-export/utils/suggest-date-field-order.spec.ts
@@ -175,3 +175,46 @@ describe('detectDateSeparator', () => {
     expect(detectDateSeparator({ values: [] })).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Two-digit years and time suffixes (the "01/01/26, 10:58" import report)
+// ---------------------------------------------------------------------------
+
+describe('two-digit years and time suffixes', () => {
+  it('parses DD/MM/YY with a comma-separated time', () => {
+    expect(parseDateCellParts({ value: '01/01/26, 10:58', fieldOrder: 'day-first' })).toEqual({
+      year: 2026,
+      month: 1,
+      day: 1,
+    });
+  });
+
+  it('parses a space-separated time on a four-digit-year date', () => {
+    expect(parseDateCellParts({ value: '15/01/2026 14:30:45', fieldOrder: 'day-first' })).toEqual({
+      year: 2026,
+      month: 1,
+      day: 15,
+    });
+  });
+
+  it('rejects impossible times instead of ignoring them', () => {
+    expect(parseDateCellParts({ value: '01/01/26, 25:00', fieldOrder: 'day-first' })).toBeNull();
+  });
+
+  it('reads order signals through time suffixes and two-digit years', () => {
+    const result = suggestDateFieldOrder({ values: ['13/06/26, 10:00', '08/06/26, 11:30'] });
+
+    expect(result.suggestion).toBe('day-first');
+    expect(result.isAmbiguous).toBe(false);
+  });
+
+  it('detects the separator of a timed two-digit-year cell', () => {
+    expect(detectDateSeparator({ values: ['01/01/26, 10:58'] })).toBe('/');
+  });
+
+  it('counts no mismatches for a column of timed two-digit-year cells', () => {
+    expect(countMismatchedDateCells({ values: ['01/01/26, 10:58', '02/01/26, 09:12'], fieldOrder: 'day-first' })).toBe(
+      0,
+    );
+  });
+});

--- a/packages/frontend/src/pages/import-export/utils/suggest-date-field-order.ts
+++ b/packages/frontend/src/pages/import-export/utils/suggest-date-field-order.ts
@@ -2,33 +2,19 @@
  * Client-side date-field-order suggestion + preview helpers for the Map step's
  * date-format expansion.
  *
- * The shape grammar and the >12-field signal detection mirror the backend's
- * `date-engine` (packages/backend .../core/parse/date-engine.ts), so the
- * suggestion and preview shown in the wizard match what the server will parse.
- * The user always confirms the order explicitly — these helpers only inform
- * the UI (suggested badge, ISO shortcut, live preview, mismatch count).
+ * The shape grammar lives in `@bt/shared/import-export/date-engine` — the same
+ * module the server parses with — so the suggestion and preview shown in the
+ * wizard match what the server will do cell-for-cell. The user always confirms
+ * the order explicitly; these helpers only inform the UI (suggested badge, ISO
+ * shortcut, live preview, mismatch count).
  */
+import {
+  detectAmbiguousDateSeparator,
+  detectDateOrderSignals,
+  isIntrinsicallyOrdered,
+  parseImportDate,
+} from '@bt/shared/import-export/date-engine';
 import type { DateFieldOrder } from '@bt/shared/types';
-
-// ISO datetime carrying an explicit zone (`Z` or `±hh:mm`) — an absolute moment.
-const ISO_ZONED_DATETIME = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:\d{2})$/;
-
-// ISO datetime WITHOUT a zone (T- or space-separated, optional seconds/ms).
-const ISO_LOCAL_DATETIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?$/;
-
-// Year-first date with `-`, `/` or `.` separators (YYYY-MM-DD and variants).
-const ISO_DATE = /^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})$/;
-
-// Compact 8-digit YYYYMMDD with no separators.
-const COMPACT_DATE = /^(\d{4})(\d{2})(\d{2})$/;
-
-// Year-LAST date with two 1-2 digit lead fields (d/d/yyyy, `/ . -` separators).
-// Which lead field is the day vs the month is intrinsically ambiguous — the
-// user's confirmed `DateFieldOrder` resolves it.
-const AMBIGUOUS_DMY = /^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$/;
-
-// First separator character of an ambiguous-family value, for option labels.
-const AMBIGUOUS_SEPARATOR = /^\d{1,2}([/.-])/;
 
 interface DateFieldOrderSuggestion {
   /**
@@ -55,24 +41,9 @@ interface DateCellParts {
   day: number;
 }
 
-function isValidCalendarDate({ year, month, day }: DateCellParts): boolean {
-  if (month < 1 || month > 12) return false;
-  if (day < 1 || day > 31) return false;
-  // `new Date(year, month, 0)` is the last day of `month`, so this rejects
-  // overlong days (e.g. Feb 30) instead of letting them roll into next month.
-  const daysInMonth = new Date(year, month, 0).getDate();
-  return day <= daysInMonth;
-}
-
 /** Trimmed, non-empty cells — the only ones that carry any date information. */
 function meaningfulValues({ values }: { values: string[] }): string[] {
   return values.map((value) => value.trim()).filter((value) => value.length > 0);
-}
-
-function isIntrinsicallyOrdered({ value }: { value: string }): boolean {
-  return (
-    ISO_ZONED_DATETIME.test(value) || ISO_LOCAL_DATETIME.test(value) || ISO_DATE.test(value) || COMPACT_DATE.test(value)
-  );
 }
 
 /**
@@ -93,25 +64,15 @@ export function suggestDateFieldOrder({
 }): DateFieldOrderSuggestion {
   const cells = meaningfulValues({ values });
 
-  let sawDayFirstSignal = false;
-  let sawMonthFirstSignal = false;
+  const { sawDayFirst, sawMonthFirst } = detectDateOrderSignals({ values: cells });
 
-  for (const value of cells) {
-    const match = value.match(AMBIGUOUS_DMY);
-    if (!match) continue;
-    const first = Number(match[1]);
-    const second = Number(match[2]);
-    if (first > 12) sawDayFirstSignal = true;
-    if (second > 12) sawMonthFirstSignal = true;
-  }
-
-  if (sawDayFirstSignal && sawMonthFirstSignal) {
+  if (sawDayFirst && sawMonthFirst) {
     return { suggestion: null, isAmbiguous: false, isIsoOnly: false, conflict: true };
   }
-  if (sawDayFirstSignal) {
+  if (sawDayFirst) {
     return { suggestion: 'day-first', isAmbiguous: false, isIsoOnly: false, conflict: false };
   }
-  if (sawMonthFirstSignal) {
+  if (sawMonthFirst) {
     return { suggestion: 'month-first', isAmbiguous: false, isIsoOnly: false, conflict: false };
   }
 
@@ -154,35 +115,16 @@ export function parseDateCellParts({
   value: string;
   fieldOrder: DateFieldOrder;
 }): DateCellParts | null {
-  if (ISO_ZONED_DATETIME.test(value)) {
-    const instant = new Date(value);
-    return { year: instant.getUTCFullYear(), month: instant.getUTCMonth() + 1, day: instant.getUTCDate() };
-  }
-
-  const localMatch = value.match(ISO_LOCAL_DATETIME);
-  if (localMatch) {
-    return { year: Number(localMatch[1]), month: Number(localMatch[2]), day: Number(localMatch[3]) };
-  }
-
-  const isoMatch = value.match(ISO_DATE) ?? value.match(COMPACT_DATE);
-  if (isoMatch) {
-    const parts = { year: Number(isoMatch[1]), month: Number(isoMatch[2]), day: Number(isoMatch[3]) };
-    return isValidCalendarDate(parts) ? parts : null;
-  }
-
-  const ambiguousMatch = value.match(AMBIGUOUS_DMY);
-  if (ambiguousMatch) {
-    const first = Number(ambiguousMatch[1]);
-    const second = Number(ambiguousMatch[2]);
-    const parts = {
-      year: Number(ambiguousMatch[3]),
-      month: fieldOrder === 'day-first' ? second : first,
-      day: fieldOrder === 'day-first' ? first : second,
+  const parsed = parseImportDate({ value, format: { fieldOrder } });
+  if (!parsed) return null;
+  if (parsed.kind === 'instant') {
+    return {
+      year: parsed.instant.getUTCFullYear(),
+      month: parsed.instant.getUTCMonth() + 1,
+      day: parsed.instant.getUTCDate(),
     };
-    return isValidCalendarDate(parts) ? parts : null;
   }
-
-  return null;
+  return { year: parsed.year, month: parsed.month, day: parsed.day };
 }
 
 /** Number of non-empty cells that won't parse under `fieldOrder` — the wizard
@@ -203,10 +145,5 @@ export function countMismatchedDateCells({
  * when no ambiguous-family cell exists.
  */
 export function detectDateSeparator({ values }: { values: string[] }): string | null {
-  for (const value of meaningfulValues({ values })) {
-    if (!AMBIGUOUS_DMY.test(value)) continue;
-    const match = value.match(AMBIGUOUS_SEPARATOR);
-    if (match?.[1]) return match[1];
-  }
-  return null;
+  return detectAmbiguousDateSeparator({ values: meaningfulValues({ values }) });
 }

--- a/packages/frontend/src/pages/import-export/ynab-import/components/account-pick-row.vue
+++ b/packages/frontend/src/pages/import-export/ynab-import/components/account-pick-row.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-muted/30 rounded-md border px-4 py-3">
+  <div class="bg-muted/30 rounded-md border px-4 py-3" :class="isSkipped ? 'opacity-60' : ''">
     <div class="mb-3 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
       <div class="flex min-w-0 items-baseline gap-2">
         <span class="truncate font-medium">{{ account.originalName }}</span>
@@ -11,11 +11,19 @@
           }}
         </span>
       </div>
-      <div class="text-muted-foreground text-xs whitespace-nowrap">
-        {{ $t('pages.importExport.ynabImport.accountRow.startingBalance') }}:
-        <span class="text-foreground ml-1 text-sm font-semibold">
-          {{ formattedStartingBalance }}
-        </span>
+      <div class="flex items-center gap-2">
+        <div class="text-muted-foreground text-xs whitespace-nowrap">
+          {{ $t('pages.importExport.ynabImport.accountRow.startingBalance') }}:
+          <span class="text-foreground ml-1 text-sm font-semibold">
+            {{ formattedStartingBalance }}
+          </span>
+        </div>
+        <DesktopOnlyTooltip :content="skipToggleLabel">
+          <UiButton variant="ghost" size="icon-sm" :aria-label="skipToggleLabel" @click="emit('toggle-skip')">
+            <Undo2Icon v-if="isSkipped" class="size-4" />
+            <BanIcon v-else class="size-4" />
+          </UiButton>
+        </DesktopOnlyTooltip>
       </div>
     </div>
 
@@ -27,19 +35,27 @@
         value-key="code"
         with-search
         :search-keys="['code', 'currency']"
+        :disabled="isSkipped"
         :label="$t('pages.importExport.ynabImport.accountRow.currencyLabel')"
         :placeholder="$t('pages.importExport.ynabImport.accountRow.currencyPlaceholder')"
         :error-message="currencyErrorMessage"
         @update:model-value="onCurrencySelected"
       />
     </div>
+
+    <p v-if="isSkipped" class="text-muted-foreground mt-2 text-sm">
+      {{ $t('importShared.account.willSkip') }}
+    </p>
   </div>
 </template>
 
 <script setup lang="ts">
 import SelectField from '@/components/fields/select-field.vue';
+import { Button as UiButton } from '@/components/lib/ui/button';
+import { DesktopOnlyTooltip } from '@/components/lib/ui/tooltip';
 import { formatUIAmount } from '@/js/helpers';
 import type { YnabAccountMappingValue, YnabParseAccount } from '@bt/shared/types';
+import { BanIcon, Undo2Icon } from '@lucide/vue';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -55,9 +71,16 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'update', mapping: YnabAccountMappingValue): void;
+  (e: 'toggle-skip'): void;
 }>();
 
 const { t } = useI18n();
+
+const isSkipped = computed(() => props.mapping?.skip === true);
+
+const skipToggleLabel = computed(() =>
+  isSkipped.value ? t('pages.importExport.ynabImport.accountRow.undoSkip') : t('importShared.action.skip'),
+);
 
 const formattedStartingBalance = computed(() =>
   formatUIAmount(props.account.startingBalance, {
@@ -71,12 +94,13 @@ const selectedCurrency = computed<CurrencyOption | null>(() => {
 });
 
 const currencyErrorMessage = computed(() => {
+  if (isSkipped.value) return undefined;
   if (props.mapping?.currencyCode.length === CURRENCY_CODE_LENGTH) return undefined;
   return t('pages.importExport.ynabImport.accountRow.currencyInvalid');
 });
 
 function onCurrencySelected(currency: CurrencyOption | null) {
   if (!currency) return;
-  emit('update', { currencyCode: currency.code });
+  emit('update', { ...props.mapping, currencyCode: currency.code });
 }
 </script>

--- a/packages/frontend/src/pages/import-export/ynab-import/components/accounts-tab.vue
+++ b/packages/frontend/src/pages/import-export/ynab-import/components/accounts-tab.vue
@@ -3,6 +3,17 @@
     <p class="text-muted-foreground text-sm">
       {{ $t('pages.importExport.ynabImport.preview.accountsHelper') }}
     </p>
+
+    <Callout v-if="store.skippedAccountNames.length > 0" variant="warning">
+      <p>
+        {{
+          $t('pages.importExport.ynabImport.preview.skippedNote', {
+            count: store.skippedAccountNames.length,
+          })
+        }}
+      </p>
+    </Callout>
+
     <EmptyList v-if="accounts.length === 0" />
     <VirtualList
       v-else
@@ -19,6 +30,7 @@
             :mapping="store.accountPicks[acc.originalName]"
             :currency-options="currencyOptions"
             @update="(mapping) => (store.accountPicks[acc.originalName] = mapping)"
+            @toggle-skip="store.toggleAccountSkip({ accountName: acc.originalName })"
           />
         </div>
       </template>
@@ -27,6 +39,7 @@
 </template>
 
 <script setup lang="ts">
+import { Callout } from '@/components/lib/ui/callout';
 import { useImportYnabStore } from '@/stores/import-ynab';
 import type { YnabParseAccount } from '@bt/shared/types';
 

--- a/packages/frontend/src/pages/import-export/ynab-import/components/done-step.vue
+++ b/packages/frontend/src/pages/import-export/ynab-import/components/done-step.vue
@@ -9,6 +9,11 @@
     <div class="grid grid-cols-2 gap-3 @sm/ynab-done:grid-cols-3 @lg/ynab-done:grid-cols-4">
       <SummaryStat :label="$t('pages.importExport.ynabImport.done.accountsCreated')" :value="summary.accountsCreated" />
       <SummaryStat
+        v-if="summary.accountsSkipped"
+        :label="$t('pages.importExport.ynabImport.done.accountsSkipped')"
+        :value="summary.accountsSkipped"
+      />
+      <SummaryStat
         :label="$t('pages.importExport.ynabImport.done.categoriesCreated')"
         :value="summary.categoriesCreated"
       />

--- a/packages/frontend/src/stores/import-budget-bakers-wallet.test.ts
+++ b/packages/frontend/src/stores/import-budget-bakers-wallet.test.ts
@@ -94,7 +94,11 @@ vi.mock('@/composable/data-queries/user-settings', () => ({
 // ----- helpers -----
 
 import * as walletApi from '@/api/import-budget-bakers-wallet';
-import type { BudgetBakersWalletParseResult } from '@bt/shared/types';
+import {
+  TRANSACTION_TYPES,
+  type BudgetBakersWalletParseResult,
+  type BudgetBakersWalletParseTransaction,
+} from '@bt/shared/types';
 
 const mockParse = vi.mocked(walletApi.parseBudgetBakersWallet);
 
@@ -114,6 +118,45 @@ const PARSE_RESULT: BudgetBakersWalletParseResult = {
   warnings: [],
   dateRange: null,
   detectedBaseCurrency: null,
+};
+
+const aTransaction = ({
+  rowIndex,
+  accountName,
+  categoryName,
+}: {
+  rowIndex: number;
+  accountName: string;
+  categoryName: string | null;
+}): BudgetBakersWalletParseTransaction => ({
+  rowIndex,
+  date: `2026-01-0${rowIndex}T10:00:00.000Z`,
+  accountName,
+  categoryName,
+  payeeName: null,
+  note: '',
+  amount: -10,
+  type: TRANSACTION_TYPES.expense,
+  paymentType: 'Cash',
+  tags: [],
+  outOfWallet: false,
+});
+
+/**
+ * Two accounts, three rows: `Groceries` is used by both, `Brand New Category`
+ * only by `Savings`, so skipping `Savings` hides exactly one category.
+ */
+const TWO_ACCOUNT_PARSE_RESULT: BudgetBakersWalletParseResult = {
+  ...PARSE_RESULT,
+  accounts: [
+    { originalName: 'Cash', currency: 'USD', transactionCount: 2, netImportedAmount: -20 },
+    { originalName: 'Savings', currency: 'USD', transactionCount: 1, netImportedAmount: -10 },
+  ],
+  transactions: [
+    aTransaction({ rowIndex: 1, accountName: 'Cash', categoryName: 'Groceries' }),
+    aTransaction({ rowIndex: 2, accountName: 'Savings', categoryName: 'Groceries' }),
+    aTransaction({ rowIndex: 3, accountName: 'Savings', categoryName: 'Brand New Category' }),
+  ],
 };
 
 const mountWithPlugins = () => {
@@ -195,5 +238,64 @@ describe('useImportBudgetBakersWalletStore – recalculate-balance toggle wiring
     store.reset();
 
     expect(store.recalculateBalance).toBe(true);
+  });
+});
+
+describe('useImportBudgetBakersWalletStore – skipped accounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+  });
+
+  const mockExecute = vi.mocked(walletApi.executeBudgetBakersWalletImport);
+
+  it('counts a skipped account as resolved and lists it in skippedAccountNames', async () => {
+    mockParse.mockResolvedValue({ result: TWO_ACCOUNT_PARSE_RESULT });
+
+    const store = useImportBudgetBakersWalletStore();
+    await store.parseFiles({ files: [aFile()] });
+
+    // An unselected link target leaves the step invalid; skipping decides the row.
+    store.setAccountTarget({ name: 'Savings', accountId: '' });
+    expect(store.isResolveStepValid).toBe(false);
+
+    store.setAccountAction({ name: 'Savings', action: 'skip' });
+
+    expect(store.accountMapping['Savings']).toEqual({ action: 'skip' });
+    expect(store.skippedAccountNames).toEqual(['Savings']);
+    expect(store.isResolveStepValid).toBe(true);
+  });
+
+  it('hides categories used only by skipped accounts and restores them on unskip', async () => {
+    mockParse.mockResolvedValue({ result: TWO_ACCOUNT_PARSE_RESULT });
+
+    const store = useImportBudgetBakersWalletStore();
+    await store.parseFiles({ files: [aFile()] });
+
+    expect(store.resolvableCategoryNames).toEqual(['Groceries', 'Brand New Category']);
+
+    store.setAccountAction({ name: 'Savings', action: 'skip' });
+
+    // 'Groceries' survives on the Cash row; 'Brand New Category' is Savings-only.
+    expect(store.resolvableCategoryNames).toEqual(['Groceries']);
+
+    store.setAccountAction({ name: 'Savings', action: 'create-new' });
+
+    expect(store.resolvableCategoryNames).toEqual(['Groceries', 'Brand New Category']);
+  });
+
+  it('prunes hidden category mappings from the execute payload but keeps the skipped account', async () => {
+    mockParse.mockResolvedValue({ result: TWO_ACCOUNT_PARSE_RESULT });
+    mockExecute.mockResolvedValue({ jobId: 'job-skip' });
+
+    const store = useImportBudgetBakersWalletStore();
+    await store.parseFiles({ files: [aFile()] });
+    store.setAccountAction({ name: 'Savings', action: 'skip' });
+
+    await store.execute();
+
+    const payload = mockExecute.mock.calls[0]![0];
+    expect(Object.keys(payload.categoryMapping)).toEqual(['Groceries']);
+    expect(payload.accountMapping['Savings']).toEqual({ action: 'skip' });
   });
 });

--- a/packages/frontend/src/stores/import-budget-bakers-wallet.test.ts
+++ b/packages/frontend/src/stores/import-budget-bakers-wallet.test.ts
@@ -69,6 +69,7 @@ vi.mock('@/stores/categories/categories', () => ({
   useCategoriesStore: vi.fn(() => ({
     categories: [{ id: 'cat-groceries', name: 'Groceries', subCategories: [] }],
     formattedCategories: [{ id: 'cat-groceries', name: 'Groceries', subCategories: [] }],
+    categoriesMap: { 'cat-groceries': { id: 'cat-groceries', name: 'Groceries' } },
     loadCategories: vi.fn(),
   })),
 }));
@@ -81,7 +82,9 @@ vi.mock('@/stores/tags', () => ({ useTagsStore: vi.fn(() => ({ loadTags: vi.fn()
 // The store reads the persisted recalculate-balance default from user settings at
 // construction and PATCHes the chosen value back after a successful execute. Mocked
 // so no real settings query fires; tests drive `data` and assert on `patchAsync`.
-let mockUserSettingsData: Ref<{ import?: { recalculateAccountBalance?: boolean } } | undefined>;
+let mockUserSettingsData: Ref<
+  { import?: { recalculateAccountBalance?: boolean; categoryMappingPresets?: CategoryMappingPreset[] } } | undefined
+>;
 let mockPatchUserSettingsAsync: ReturnType<typeof vi.fn>;
 
 vi.mock('@/composable/data-queries/user-settings', () => ({
@@ -98,6 +101,7 @@ import {
   TRANSACTION_TYPES,
   type BudgetBakersWalletParseResult,
   type BudgetBakersWalletParseTransaction,
+  type CategoryMappingPreset,
 } from '@bt/shared/types';
 
 const mockParse = vi.mocked(walletApi.parseBudgetBakersWallet);
@@ -226,7 +230,6 @@ describe('useImportBudgetBakersWalletStore – recalculate-balance toggle wiring
     await store.execute();
 
     expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ recalculateBalance: true }));
-    expect(mockPatchUserSettingsAsync).toHaveBeenCalledTimes(1);
     expect(mockPatchUserSettingsAsync).toHaveBeenCalledWith({ import: { recalculateAccountBalance: true } });
   });
 
@@ -297,5 +300,55 @@ describe('useImportBudgetBakersWalletStore – skipped accounts', () => {
     const payload = mockExecute.mock.calls[0]![0];
     expect(Object.keys(payload.categoryMapping)).toEqual(['Groceries']);
     expect(payload.accountMapping['Savings']).toEqual({ action: 'skip' });
+  });
+});
+
+describe('useImportBudgetBakersWalletStore – remembered category mappings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+  });
+
+  const mockExecute = vi.mocked(walletApi.executeBudgetBakersWalletImport);
+
+  it('applies the wallet preset and re-persists it under the flow fingerprint on execute', async () => {
+    mockUserSettingsData.value = {
+      import: {
+        categoryMappingPresets: [
+          {
+            fingerprint: 'budget-bakers-wallet',
+            categoryMapping: { 'Brand New Category': { action: 'link-existing', categoryId: 'cat-groceries' } },
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    mockParse.mockResolvedValue({ result: PARSE_RESULT });
+    mockExecute.mockResolvedValue({ jobId: 'job-preset' });
+
+    const store = useImportBudgetBakersWalletStore();
+    await store.parseFiles({ files: [aFile()] });
+
+    expect(store.matchingCategoryPreset?.fingerprint).toBe('budget-bakers-wallet');
+
+    store.applyCategoryPreset({ preset: store.matchingCategoryPreset! });
+    expect(store.categoryMapping['Brand New Category']).toEqual({
+      action: 'link-existing',
+      categoryId: 'cat-groceries',
+    });
+
+    await store.execute();
+
+    const presets = mockPatchUserSettingsAsync.mock.calls.at(-1)![0].import.categoryMappingPresets;
+    expect(presets).toHaveLength(1);
+    expect(presets[0]).toEqual(
+      expect.objectContaining({
+        fingerprint: 'budget-bakers-wallet',
+        categoryMapping: {
+          Groceries: { action: 'link-existing', categoryId: 'cat-groceries' },
+          'Brand New Category': { action: 'link-existing', categoryId: 'cat-groceries' },
+        },
+      }),
+    );
   });
 });

--- a/packages/frontend/src/stores/import-budget-bakers-wallet.ts
+++ b/packages/frontend/src/stores/import-budget-bakers-wallet.ts
@@ -57,7 +57,8 @@ const ALL_STEP_KEYS: readonly BudgetBakersWalletImportStepKey[] = ['upload', 're
  */
 type BudgetBakersWalletAccountFormValue =
   | { action: 'create-new'; currencyCode: string; currentBalance: number | null }
-  | { action: 'link-existing'; accountId: string | undefined };
+  | { action: 'link-existing'; accountId: string | undefined }
+  | { action: 'skip' };
 
 /** Form-level account decisions keyed by `WalletParseAccount.originalName`. */
 type BudgetBakersWalletAccountFormMapping = Record<string, BudgetBakersWalletAccountFormValue>;
@@ -99,7 +100,8 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
   /**
    * Per-account decision keyed by `WalletParseAccount.originalName`. Seeded
    * after a successful parse with `create-new` + the detected currency; the
-   * resolve step lets the user switch individual accounts to `link-existing`.
+   * resolve step lets the user switch individual accounts to `link-existing` or
+   * `skip`.
    *
    * Default: `create-new` with `currentBalance: null` (no explicit target —
    * the final balance equals whatever the imported transactions sum to).
@@ -226,14 +228,34 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     currentBalance: null,
   });
 
-  /** Source category names — what the resolve step renders. */
-  const resolvableCategoryNames = computed<string[]>(() =>
-    (parsedResult.value?.categories ?? []).map((category) => category.name),
+  const skippedAccountNames = computed<string[]>(() =>
+    Object.entries(accountMapping.value)
+      .filter(([, value]) => value.action === 'skip')
+      .map(([name]) => name),
   );
 
-  /** True once an account form decision is complete (create-new, or linked with a chosen target). */
+  /**
+   * Source category names used by at least one row of a non-skipped account.
+   * Transfers carry no category and out-of-wallet legs carry a null one, so the
+   * ordinary rows are the whole picture.
+   */
+  const resolvableCategoryNames = computed<string[]>(() => {
+    const names = (parsedResult.value?.categories ?? []).map((category) => category.name);
+    if (skippedAccountNames.value.length === 0) return names;
+
+    const skipped = new Set(skippedAccountNames.value);
+    const stillReferenced = new Set<string>();
+    for (const tx of parsedResult.value?.transactions ?? []) {
+      if (tx.categoryName && !skipped.has(tx.accountName)) stillReferenced.add(tx.categoryName);
+    }
+    return names.filter((name) => stillReferenced.has(name));
+  });
+
+  /** True once an account form decision is complete (create-new, skip, or linked with a chosen target). */
   const isAccountResolved = (mapping: BudgetBakersWalletAccountFormValue | undefined): boolean =>
-    mapping?.action === 'create-new' || (mapping?.action === 'link-existing' && mapping.accountId !== undefined);
+    mapping?.action === 'create-new' ||
+    mapping?.action === 'skip' ||
+    (mapping?.action === 'link-existing' && mapping.accountId !== undefined);
 
   /** True once a category decision is complete (create-new, or linked with a chosen target). */
   const isCategoryResolved = (mapping: CategoryMappingValue | undefined): boolean =>
@@ -276,7 +298,7 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     },
     categories: {
       isActive: () => true,
-      getSources: () => (parsedResult.value?.categories ?? []).map((category) => ({ name: category.name })),
+      getSources: () => resolvableCategoryNames.value.map((name) => ({ name })),
       getTargets: () =>
         flattenCategories({ categories: useCategoriesStore().formattedCategories }).map((category) => ({
           id: category.id,
@@ -301,13 +323,15 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
   /**
    * Switches one account's action. `create-new` carries the account's detected
    * currency + a null balance; `link-existing` starts unselected (no target id)
-   * until the user picks one.
+   * until the user picks one; `skip` stores no payload.
    */
-  function setAccountAction({ name, action }: { name: string; action: 'create-new' | 'link-existing' }): void {
+  function setAccountAction({ name, action }: { name: string; action: 'create-new' | 'link-existing' | 'skip' }): void {
     if (action === 'create-new') {
       accountMapping.value[name] = buildAccountCreateNew({ currency: accountCurrencyByName.value.get(name) });
-    } else {
+    } else if (action === 'link-existing') {
       accountMapping.value[name] = { action: 'link-existing', accountId: undefined };
+    } else {
+      accountMapping.value[name] = { action: 'skip' };
     }
   }
 
@@ -505,12 +529,19 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     }
     jobProgress.setExecuteError(null);
 
+    // Stored decisions for categories hidden by an account skip must not reach the
+    // backend: it would create categories no imported row references.
+    const visibleCategories = new Set(resolvableCategoryNames.value);
+    const categoryMappingPayload = Object.fromEntries(
+      Object.entries(categoryMapping.value).filter(([name]) => visibleCategories.has(name)),
+    );
+
     let response: Awaited<ReturnType<typeof executeBudgetBakersWalletImport>>;
     try {
       response = await executeBudgetBakersWalletImport({
         fileContent,
         accountMapping: toWireAccountMapping(),
-        categoryMapping: categoryMapping.value,
+        categoryMapping: categoryMappingPayload,
         skipDuplicateIndices: skipDuplicateIndices.value,
         recalculateBalance: recalculateBalance.value,
       });
@@ -575,6 +606,7 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     accountResolvedCount,
     categoryResolvedCount,
     resolvableCategoryNames,
+    skippedAccountNames,
     isResolveStepValid,
     hasAnyLinkExisting,
     skipDuplicateIndices,

--- a/packages/frontend/src/stores/import-budget-bakers-wallet.ts
+++ b/packages/frontend/src/stores/import-budget-bakers-wallet.ts
@@ -272,6 +272,10 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
+    resetAiMapping,
     resetResolveEntity,
     toggleDuplicateUnmark,
     accountResolvedCount,
@@ -580,6 +584,7 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     parseError.value = null;
     isDetectingDuplicates.value = false;
     detectError.value = null;
+    resetAiMapping();
     jobProgress.setExecuteError(null);
     fileContent = null;
     jobProgress.stop();
@@ -632,6 +637,9 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
     resetResolveEntity,
 
     // Duplicate helpers

--- a/packages/frontend/src/stores/import-budget-bakers-wallet.ts
+++ b/packages/frontend/src/stores/import-budget-bakers-wallet.ts
@@ -4,6 +4,7 @@ import {
   getBudgetBakersWalletImportStatus,
   parseBudgetBakersWallet,
 } from '@/api/import-budget-bakers-wallet';
+import { useCategoryMappingPresets } from '@/composable/use-category-mapping-presets';
 import { useImportJobProgress } from '@/composable/use-import-job-progress';
 import { useRecalculateBalanceToggle } from '@/composable/use-recalculate-balance-toggle';
 import { useResolveMapping } from '@/composable/use-resolve-mapping';
@@ -19,6 +20,7 @@ import {
   BUDGET_BAKERS_WALLET_MAX_ROWS,
   SSE_EVENT_TYPES,
   type CategoryMappingConfig,
+  type CategoryMappingPreset,
   type CategoryMappingValue,
   type DuplicateMatch,
   type BudgetBakersWalletAccountMapping,
@@ -43,6 +45,9 @@ export type BudgetBakersWalletImportStepKey = 'upload' | 'resolve' | 'review' | 
 
 /** Every step in canonical order. All are always visible. */
 const ALL_STEP_KEYS: readonly BudgetBakersWalletImportStepKey[] = ['upload', 'resolve', 'review', 'results'];
+
+/** The Wallet export layout is fixed, so every import shares one remembered-preset key. */
+const CATEGORY_PRESET_FINGERPRINT = 'budget-bakers-wallet';
 
 /**
  * Store-internal form shape for one account decision. Wider than the wire type
@@ -316,6 +321,20 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     unmarkedDuplicateIndices,
   });
 
+  // ---- Remembered category mappings ----
+
+  const {
+    matchingPreset: matchingCategoryPreset,
+    namedPresets: namedCategoryPresets,
+    applyPreset,
+    persistPreset: persistCategoryPreset,
+    renamePreset: renameCategoryPreset,
+    deletePreset: deleteCategoryPreset,
+  } = useCategoryMappingPresets({ fingerprint: ref(CATEGORY_PRESET_FINGERPRINT) });
+
+  const applyCategoryPreset = ({ preset }: { preset: CategoryMappingPreset }) =>
+    applyPreset({ preset, categoryMapping, validSourceNames: resolvableCategoryNames.value });
+
   /** True when at least one account is mapped to an existing app account.
    *  Determines whether duplicate detection is meaningful. */
   const hasAnyLinkExisting = computed(() =>
@@ -559,6 +578,7 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     // Job accepted: remember the balance-recalculation choice for the next
     // import (fire-and-forget), then advance the wizard and arm the watchdog.
     persistRecalculateBalanceSetting();
+    persistCategoryPreset({ mapping: categoryMappingPayload });
     markStepCompleted('review');
     goToStep('results');
     jobProgress.start({
@@ -612,6 +632,8 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     categoryResolvedCount,
     resolvableCategoryNames,
     skippedAccountNames,
+    matchingCategoryPreset,
+    namedCategoryPresets,
     isResolveStepValid,
     hasAnyLinkExisting,
     skipDuplicateIndices,
@@ -641,6 +663,9 @@ export const useImportBudgetBakersWalletStore = defineStore('import-budget-baker
     isAiMappingCategories,
     aiMappingCategoriesError,
     resetResolveEntity,
+    applyCategoryPreset,
+    renameCategoryPreset,
+    deleteCategoryPreset,
 
     // Duplicate helpers
     toggleDuplicateUnmark,

--- a/packages/frontend/src/stores/import-export.test.ts
+++ b/packages/frontend/src/stores/import-export.test.ts
@@ -66,6 +66,12 @@ vi.mock('./onboarding', () => ({
   useOnboardingStore: vi.fn(() => ({ completeTask: vi.fn() })),
 }));
 
+// Only reached through the resolve engine's account link targets; mocked so the
+// real store's accounts query never fires.
+vi.mock('./accounts', () => ({
+  useAccountsStore: vi.fn(() => ({ importLinkableAccounts: [] })),
+}));
+
 vi.mock('./categories/categories', () => ({
   useCategoriesStore: vi.fn(() => ({ loadCategories: vi.fn() })),
 }));
@@ -99,6 +105,7 @@ import {
   CurrencyOptionValue,
   type DetectDuplicatesResponse,
   type ExecuteImportResponse,
+  type ParsedTransactionRow,
   type SourceAccount,
   TagOptionValue,
   TransactionTypeOptionValue,
@@ -229,25 +236,25 @@ describe('useImportExportStore – detectDuplicates', () => {
     const store = useImportExportStore();
     seedStore(store);
     store.columnMapping.dateFieldOrder = null;
-    store.currentStep = 2;
+    store.currentStepKey = 'map';
 
     await store.detectDuplicates();
 
     expect(mockDetectDuplicatesApi).not.toHaveBeenCalled();
     expect(store.detectError).not.toBeNull();
-    expect(store.currentStep).toBe(2);
+    expect(store.currentStepKey).toBe('map');
   });
 
-  it('advances to step 3 on a successful detection', async () => {
+  it('advances to the review step on a successful detection', async () => {
     mockDetectDuplicatesApi.mockResolvedValue(BASE_RESPONSE);
 
     const store = useImportExportStore();
     seedStore(store);
-    store.currentStep = 2;
+    store.currentStepKey = 'map';
 
     await store.detectDuplicates();
 
-    expect(store.currentStep).toBe(3);
+    expect(store.currentStepKey).toBe('review');
   });
 
   // N-5: network error — loading resets, detect-error state set, step does not advance
@@ -257,13 +264,13 @@ describe('useImportExportStore – detectDuplicates', () => {
 
     const store = useImportExportStore();
     seedStore(store);
-    store.currentStep = 2;
+    store.currentStepKey = 'map';
 
     await expect(store.detectDuplicates()).rejects.toThrow('Network failure');
 
     expect(store.isDetectingDuplicates).toBe(false);
     expect(store.detectError).not.toBeNull();
-    expect(store.currentStep).toBe(2);
+    expect(store.currentStepKey).toBe('map');
   });
 
   // N-5: after error→success the step advances and validRows is populated
@@ -279,18 +286,18 @@ describe('useImportExportStore – detectDuplicates', () => {
 
     const store = useImportExportStore();
     seedStore(store);
-    store.currentStep = 2;
+    store.currentStepKey = 'map';
 
     // First call: network error
     await expect(store.detectDuplicates()).rejects.toThrow('Network failure');
     expect(store.detectError).not.toBeNull();
-    expect(store.currentStep).toBe(2);
+    expect(store.currentStepKey).toBe('map');
 
     // Second call: success
     await store.detectDuplicates();
 
     expect(store.detectError).toBeNull();
-    expect(store.currentStep).toBe(3);
+    expect(store.currentStepKey).toBe('review');
     expect(store.validRows).toHaveLength(1);
   });
 });
@@ -598,6 +605,7 @@ describe('useImportExportStore – executeImport tagMapping inclusion', () => {
     const store = useImportExportStore();
     seedStore(store);
     store.columnMapping.tags = { option: 'map-data-source-column' as never, columnName: 'labels' };
+    store.uniqueTagsInCSV = ['Food'];
     store.tagMapping = { Food: { action: 'create-new' } };
     await store.detectDuplicates();
 
@@ -786,13 +794,13 @@ describe('useImportExportStore – isMapStepValid', () => {
   });
 });
 
-describe('useImportExportStore – isResolveStepValid', () => {
+describe('useImportExportStore – per-step resolve validity', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mountWithPlugins();
   });
 
-  it('accounts (from-column): true when all resolved, false when a link row has an empty id', () => {
+  it('accounts step: true when all resolved, false when a link row has an empty id', () => {
     const store = useImportExportStore();
     store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
     store.uniqueAccountsInCSV = [
@@ -804,17 +812,32 @@ describe('useImportExportStore – isResolveStepValid', () => {
       Checking: { action: 'link-existing', accountId: 'acc-1' },
       Savings: { action: 'create-new', currentBalance: null },
     };
-    expect(store.isResolveStepValid).toBe(true);
+    expect(store.isResolveAccountsStepValid).toBe(true);
 
     // A link-existing row with an empty target id is not fully resolved.
     store.accountMapping = {
       Checking: { action: 'link-existing', accountId: '' },
       Savings: { action: 'create-new', currentBalance: null },
     };
-    expect(store.isResolveStepValid).toBe(false);
+    expect(store.isResolveAccountsStepValid).toBe(false);
   });
 
-  it('categories (map-from-column): true when all resolved, false when a link row has an empty id', () => {
+  it('accounts step: skip counts as a complete decision', () => {
+    const store = useImportExportStore();
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.uniqueAccountsInCSV = [
+      { name: 'Checking', currency: 'USD' },
+      { name: 'Savings', currency: 'USD' },
+    ] as SourceAccount[];
+
+    store.accountMapping = {
+      Checking: { action: 'link-existing', accountId: 'acc-1' },
+      Savings: { action: 'skip' },
+    };
+    expect(store.isResolveAccountsStepValid).toBe(true);
+  });
+
+  it('categories step: true when all resolved, false when a link row has an empty id', () => {
     const store = useImportExportStore();
     store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
     store.uniqueCategoriesInCSV = ['Food', 'Travel'];
@@ -823,16 +846,16 @@ describe('useImportExportStore – isResolveStepValid', () => {
       Food: { action: 'link-existing', categoryId: 'cat-1' },
       Travel: { action: 'create-new' },
     };
-    expect(store.isResolveStepValid).toBe(true);
+    expect(store.isResolveCategoriesStepValid).toBe(true);
 
     store.categoryMapping = {
       Food: { action: 'link-existing', categoryId: '' },
       Travel: { action: 'create-new' },
     };
-    expect(store.isResolveStepValid).toBe(false);
+    expect(store.isResolveCategoriesStepValid).toBe(false);
   });
 
-  it('tags (map-from-column): skip counts as resolved; a link row with an empty id does not', () => {
+  it('categories step: tag skip counts as resolved; a link row with an empty id does not', () => {
     const store = useImportExportStore();
     store.columnMapping.tags = { option: TagOptionValue.mapDataSourceColumn, columnName: 'labels' };
     store.uniqueTagsInCSV = ['urgent', 'work'];
@@ -842,17 +865,29 @@ describe('useImportExportStore – isResolveStepValid', () => {
       urgent: { action: 'skip' },
       work: { action: 'link-existing', tagId: 'tag-1' },
     };
-    expect(store.isResolveStepValid).toBe(true);
+    expect(store.isResolveCategoriesStepValid).toBe(true);
 
     store.tagMapping = {
       urgent: { action: 'skip' },
       work: { action: 'link-existing', tagId: '' },
     };
-    expect(store.isResolveStepValid).toBe(false);
+    expect(store.isResolveCategoriesStepValid).toBe(false);
+  });
+
+  it('the two steps gate independently: unresolved categories never block the accounts step', () => {
+    const store = useImportExportStore();
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+    store.uniqueAccountsInCSV = [{ name: 'Checking', currency: 'USD' }] as SourceAccount[];
+    store.uniqueCategoriesInCSV = ['Food'];
+    store.accountMapping = { Checking: { action: 'create-new', currentBalance: null } };
+
+    expect(store.isResolveAccountsStepValid).toBe(true);
+    expect(store.isResolveCategoriesStepValid).toBe(false);
   });
 });
 
-describe('useImportExportStore – needsResolveStep & visibleSteps', () => {
+describe('useImportExportStore – resolve-step flags & visibleSteps', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mountWithPlugins();
@@ -860,48 +895,60 @@ describe('useImportExportStore – needsResolveStep & visibleSteps', () => {
 
   const stepKeys = (store: ReturnType<typeof useImportExportStore>) => store.visibleSteps.map((s) => s.key);
 
-  it('category map-from-column requires the resolve step', () => {
+  it('category map-from-column adds only the categories resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
 
-    expect(store.needsResolveStep).toBe(true);
-    expect(stepKeys(store)).toContain('resolve');
+    expect(store.needsCategoriesResolveStep).toBe(true);
+    expect(store.needsAccountResolution).toBe(false);
+    expect(stepKeys(store)).toEqual(['upload', 'map', 'resolve-categories', 'review', 'results']);
   });
 
-  it('category create-new requires the resolve step', () => {
+  it('category create-new adds only the categories resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.category = { option: CategoryOptionValue.createNewCategories, columnName: 'category' };
 
-    expect(store.needsResolveStep).toBe(true);
-    expect(stepKeys(store)).toContain('resolve');
+    expect(store.needsCategoriesResolveStep).toBe(true);
+    expect(stepKeys(store)).toContain('resolve-categories');
+    expect(stepKeys(store)).not.toContain('resolve-accounts');
   });
 
-  it('account from-column requires the resolve step', () => {
+  it('account from-column adds only the accounts resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
 
-    expect(store.needsResolveStep).toBe(true);
-    expect(stepKeys(store)).toContain('resolve');
+    expect(store.needsAccountResolution).toBe(true);
+    expect(store.needsCategoriesResolveStep).toBe(false);
+    expect(stepKeys(store)).toEqual(['upload', 'map', 'resolve-accounts', 'review', 'results']);
   });
 
-  it('tags map-from-column requires the resolve step', () => {
+  it('tags map-from-column adds only the categories resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.tags = { option: TagOptionValue.mapDataSourceColumn, columnName: 'labels' };
 
-    expect(store.needsResolveStep).toBe(true);
-    expect(stepKeys(store)).toContain('resolve');
+    expect(store.needsCategoriesResolveStep).toBe(true);
+    expect(stepKeys(store)).toContain('resolve-categories');
+    expect(stepKeys(store)).not.toContain('resolve-accounts');
   });
 
-  it('currency from-column does NOT add the resolve step', () => {
+  it('accounts and categories from columns show both resolve steps, accounts first', () => {
+    const store = useImportExportStore();
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+
+    expect(stepKeys(store)).toEqual(['upload', 'map', 'resolve-accounts', 'resolve-categories', 'review', 'results']);
+  });
+
+  it('currency from-column does NOT add a resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.currency = { option: CurrencyOptionValue.dataSourceColumn, columnName: 'currency' };
 
-    expect(store.needsResolveStep).toBe(false);
-    expect(stepKeys(store)).not.toContain('resolve');
+    expect(store.needsAccountResolution).toBe(false);
+    expect(store.needsCategoriesResolveStep).toBe(false);
     expect(stepKeys(store)).toEqual(['upload', 'map', 'review', 'results']);
   });
 
-  it('transaction-type from-column does NOT add the resolve step', () => {
+  it('transaction-type from-column does NOT add a resolve step', () => {
     const store = useImportExportStore();
     store.columnMapping.transactionType = {
       option: TransactionTypeOptionValue.dataSourceColumn,
@@ -910,8 +957,197 @@ describe('useImportExportStore – needsResolveStep & visibleSteps', () => {
       expenseValues: ['Gasto'],
     };
 
-    expect(store.needsResolveStep).toBe(false);
-    expect(stepKeys(store)).not.toContain('resolve');
+    expect(store.needsAccountResolution).toBe(false);
+    expect(store.needsCategoriesResolveStep).toBe(false);
+    expect(stepKeys(store)).toEqual(['upload', 'map', 'review', 'results']);
+  });
+});
+
+describe('useImportExportStore – skipped accounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+  });
+
+  /**
+   * Both account and category read from CSV columns, over four rows:
+   * `Shared` is used by both accounts, `Food` only by Checking, `Travel` only by Savings.
+   */
+  const seedAccountAndCategoryColumns = (store: ReturnType<typeof useImportExportStore>) => {
+    seedStore(store);
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+    store.csvDataRowHeaders = ['date', 'amount', 'account', 'category'];
+    store.csvDataRows = [
+      ['2026-01-01', '10', 'Checking', 'Food'],
+      ['2026-01-02', '20', 'Checking', ' Shared '],
+      ['2026-01-03', '30', 'Savings', 'Travel'],
+      ['2026-01-04', '40', 'Savings', 'Shared'],
+    ];
+    store.uniqueAccountsInCSV = [
+      { name: 'Checking', currency: 'USD' },
+      { name: 'Savings', currency: 'USD' },
+    ] as SourceAccount[];
+    store.uniqueCategoriesInCSV = ['Food', 'Shared', 'Travel'];
+  };
+
+  it('drops rows of a skipped account from importSummary.willImport', () => {
+    const store = useImportExportStore();
+    seedAccountAndCategoryColumns(store);
+    store.totalRows = 3;
+    store.validRows = [
+      { rowIndex: 0, accountName: 'Checking' },
+      { rowIndex: 1, accountName: 'Savings' },
+      { rowIndex: 2, accountName: 'Savings' },
+    ] as ParsedTransactionRow[];
+
+    expect(store.importSummary.willImport).toBe(3);
+
+    store.accountMapping = {
+      Checking: { action: 'create-new', currentBalance: null },
+      Savings: { action: 'skip' },
+    };
+
+    expect(store.importSummary.willImport).toBe(1);
+    // The parse-level counters describe the file, not the user's skip choices.
+    expect(store.importSummary.validRows).toBe(3);
+  });
+
+  it('hides categories used only by skipped accounts and restores them on unskip', () => {
+    const store = useImportExportStore();
+    seedAccountAndCategoryColumns(store);
+
+    expect(store.visibleCategoriesToResolve).toEqual(['Food', 'Shared', 'Travel']);
+
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.skippedAccountNames).toEqual(['Savings']);
+    expect(store.visibleCategoriesToResolve).toEqual(['Food', 'Shared']);
+
+    store.accountMapping = { Savings: { action: 'create-new', currentBalance: null } };
+
+    expect(store.visibleCategoriesToResolve).toEqual(['Food', 'Shared', 'Travel']);
+  });
+
+  it('keeps the full category list when the account column is not a data-source column', () => {
+    const store = useImportExportStore();
+    seedAccountAndCategoryColumns(store);
+    store.columnMapping.account = { option: AccountOptionValue.existingAccount, accountId: 'acc-1' };
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.visibleCategoriesToResolve).toEqual(['Food', 'Shared', 'Travel']);
+  });
+
+  it('categories step validity ignores categories hidden by a skipped account', () => {
+    const store = useImportExportStore();
+    seedAccountAndCategoryColumns(store);
+    store.categoryMapping = { Food: { action: 'create-new' }, Shared: { action: 'create-new' } };
+
+    expect(store.isResolveCategoriesStepValid).toBe(false);
+
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.isResolveCategoriesStepValid).toBe(true);
+  });
+
+  it('prunes hidden category mappings from the execute payload but keeps skipped accounts', async () => {
+    mockExecuteImportApi.mockResolvedValue(EXECUTE_RESPONSE);
+
+    const store = useImportExportStore();
+    seedAccountAndCategoryColumns(store);
+    store.accountMapping = {
+      Checking: { action: 'create-new', currentBalance: null },
+      Savings: { action: 'skip' },
+    };
+    store.categoryMapping = {
+      Food: { action: 'create-new' },
+      Shared: { action: 'create-new' },
+      Travel: { action: 'create-new' },
+    };
+
+    await store.executeImport();
+
+    const payload = mockExecuteImportApi.mock.calls[0]![0];
+    expect(payload.categoryMapping).toEqual({
+      Food: { action: 'create-new' },
+      Shared: { action: 'create-new' },
+    });
+    expect(payload.accountMapping).toEqual({
+      Checking: { action: 'create-new', currentBalance: null },
+      Savings: { action: 'skip' },
+    });
+  });
+
+  /**
+   * Account and tags read from CSV columns, over three rows: `shared` is used by
+   * both accounts, `travel` only by Savings. One cell carries two names so the
+   * comma split matches the backend's `splitTagCell`.
+   */
+  const seedAccountAndTagColumns = (store: ReturnType<typeof useImportExportStore>) => {
+    seedStore(store);
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.tags = { option: TagOptionValue.mapDataSourceColumn, columnName: 'labels' };
+    store.csvDataRowHeaders = ['date', 'amount', 'account', 'labels'];
+    store.csvDataRows = [
+      ['2026-01-01', '10', 'Checking', 'food, shared'],
+      ['2026-01-02', '20', 'Savings', 'travel'],
+      ['2026-01-03', '30', 'Savings', 'shared'],
+    ];
+    store.uniqueAccountsInCSV = [
+      { name: 'Checking', currency: 'USD' },
+      { name: 'Savings', currency: 'USD' },
+    ] as SourceAccount[];
+    store.uniqueTagsInCSV = ['food', 'shared', 'travel'];
+  };
+
+  it('hides tags used only by skipped accounts and restores them on unskip', () => {
+    const store = useImportExportStore();
+    seedAccountAndTagColumns(store);
+
+    expect(store.visibleTagsToResolve).toEqual(['food', 'shared', 'travel']);
+
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.visibleTagsToResolve).toEqual(['food', 'shared']);
+
+    store.accountMapping = { Savings: { action: 'create-new', currentBalance: null } };
+
+    expect(store.visibleTagsToResolve).toEqual(['food', 'shared', 'travel']);
+  });
+
+  it('categories step validity ignores tags hidden by a skipped account', () => {
+    const store = useImportExportStore();
+    seedAccountAndTagColumns(store);
+    store.tagMapping = { food: { action: 'create-new' }, shared: { action: 'skip' } };
+
+    expect(store.isResolveCategoriesStepValid).toBe(false);
+
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.isResolveCategoriesStepValid).toBe(true);
+  });
+
+  it('prunes hidden tag mappings from the execute payload', async () => {
+    mockExecuteImportApi.mockResolvedValue(EXECUTE_RESPONSE);
+
+    const store = useImportExportStore();
+    seedAccountAndTagColumns(store);
+    store.accountMapping = {
+      Checking: { action: 'create-new', currentBalance: null },
+      Savings: { action: 'skip' },
+    };
+    store.tagMapping = {
+      food: { action: 'create-new' },
+      shared: { action: 'create-new' },
+      travel: { action: 'create-new' },
+    };
+
+    await store.executeImport();
+
+    expect(mockExecuteImportApi.mock.calls[0]![0].tagMapping).toEqual({
+      food: { action: 'create-new' },
+      shared: { action: 'create-new' },
+    });
   });
 });
 
@@ -1041,6 +1277,38 @@ describe('useImportExportStore – parseFiles', () => {
     expect(store.uncoveredTransactionTypeValues).toEqual(['ZZZ', 'QQQ']);
     expect(store.isMapStepValid).toBe(false);
   });
+
+  // Regression: `csvHeaders` drops an empty header name (a pandas-style index
+  // column), shifting every column after it. Row scans must index against
+  // `csvDataRowHeaders`.
+  it('keeps row scans aligned when the first column has an empty header name', async () => {
+    mockParseCsvApi.mockResolvedValue({
+      headers: ['', 'date', 'amount', 'account', 'category'],
+      preview: [{ '': '0', date: '2026-01-01', amount: '10', account: 'Checking', category: 'Food' }],
+      detectedDelimiter: ',',
+      totalRows: 3,
+    });
+
+    const store = useImportExportStore();
+
+    await store.parseFiles({
+      files: [
+        fakeFile(
+          ',date,amount,account,category\n0,2026-01-01,10,Checking,Food\n1,2026-01-02,20,Savings,Travel\n2,2026-01-03,30,Savings,Food',
+          'indexed.csv',
+        ),
+      ],
+    });
+
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+    store.uniqueCategoriesInCSV = ['Food', 'Travel'];
+    store.accountMapping = { Savings: { action: 'skip' } };
+
+    expect(store.csvHeaders).toEqual(['date', 'amount', 'account', 'category']);
+    // Travel appears only on Savings rows, so skipping that account hides it.
+    expect(store.visibleCategoriesToResolve).toEqual(['Food']);
+  });
 });
 
 // Integration wiring only — the toggle's behavior matrix (persisted default,
@@ -1073,5 +1341,45 @@ describe('useImportExportStore – recalculate-balance toggle wiring', () => {
     store.reset();
 
     expect(store.recalculateBalance).toBe(true);
+  });
+});
+
+describe('useImportExportStore – resolve-step extraction cache', () => {
+  const mockExtractUniqueValuesApi = vi.mocked(apiModule.extractUniqueValues);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+    mockExtractUniqueValuesApi.mockResolvedValue({
+      sourceAccounts: [{ name: 'Checking', currency: 'USD' }],
+      sourceCategories: [],
+      sourceTags: [],
+    });
+  });
+
+  const seedAccountColumn = (store: ReturnType<typeof useImportExportStore>) => {
+    seedStore(store);
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+  };
+
+  it('extracts once when both resolve steps run on unchanged column choices', async () => {
+    const store = useImportExportStore();
+    seedAccountColumn(store);
+
+    await store.prepareResolveStep();
+    await store.prepareResolveStep();
+
+    expect(mockExtractUniqueValuesApi).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-extracts once a mapped column changes', async () => {
+    const store = useImportExportStore();
+    seedAccountColumn(store);
+
+    await store.prepareResolveStep();
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account_name' };
+    await store.prepareResolveStep();
+
+    expect(mockExtractUniqueValuesApi).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/frontend/src/stores/import-export.test.ts
+++ b/packages/frontend/src/stores/import-export.test.ts
@@ -85,7 +85,9 @@ vi.mock('./tags', () => ({
 // The store reads the persisted recalculate-balance default from user settings at
 // construction and PATCHes the chosen value back after a successful execute. Mocked
 // so no real settings query fires; tests drive `data` and assert on `patchAsync`.
-let mockUserSettingsData: Ref<{ import?: { recalculateAccountBalance?: boolean } } | undefined>;
+let mockUserSettingsData: Ref<
+  { import?: { recalculateAccountBalance?: boolean; categoryMappingPresets?: CategoryMappingPreset[] } } | undefined
+>;
 let mockPatchUserSettingsAsync: ReturnType<typeof vi.fn>;
 
 vi.mock('@/composable/data-queries/user-settings', () => ({
@@ -100,11 +102,13 @@ vi.mock('@/composable/data-queries/user-settings', () => ({
 import * as apiModule from '@/api/import-export';
 import {
   AccountOptionValue,
+  type CategoryMappingPreset,
   CategoryOptionValue,
   type CsvImportSummary,
   CurrencyOptionValue,
   type DetectDuplicatesResponse,
   type ExecuteImportResponse,
+  MAX_CATEGORY_MAPPING_PRESETS,
   type ParsedTransactionRow,
   type SourceAccount,
   TagOptionValue,
@@ -874,6 +878,22 @@ describe('useImportExportStore – per-step resolve validity', () => {
     expect(store.isResolveCategoriesStepValid).toBe(false);
   });
 
+  it('extraction failure blocks both resolve steps even when the unique lists are empty', () => {
+    const store = useImportExportStore();
+    store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+
+    // A failed extraction leaves the unique lists empty; `.every()` over an empty
+    // list must not read as "all resolved" while the error is showing.
+    store.extractError = 'Account "Monobank" has transactions with multiple currencies';
+    expect(store.isResolveAccountsStepValid).toBe(false);
+    expect(store.isResolveCategoriesStepValid).toBe(false);
+
+    store.extractError = null;
+    expect(store.isResolveAccountsStepValid).toBe(true);
+    expect(store.isResolveCategoriesStepValid).toBe(true);
+  });
+
   it('the two steps gate independently: unresolved categories never block the accounts step', () => {
     const store = useImportExportStore();
     store.columnMapping.account = { option: AccountOptionValue.dataSourceColumn, columnName: 'account' };
@@ -1381,5 +1401,195 @@ describe('useImportExportStore – resolve-step extraction cache', () => {
     await store.prepareResolveStep();
 
     expect(mockExtractUniqueValuesApi).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('useImportExportStore – remembered category mappings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+  });
+
+  /** Runs one import that maps a single category, and returns the preset list it persisted. */
+  const persistViaImport = async ({
+    stored,
+    fingerprint,
+  }: {
+    stored: CategoryMappingPreset[];
+    fingerprint: string;
+  }): Promise<CategoryMappingPreset[]> => {
+    mockDetectDuplicatesApi.mockResolvedValue(BASE_RESPONSE);
+    mockExecuteImportApi.mockResolvedValue(EXECUTE_RESPONSE);
+    mockUserSettingsData.value = { import: { categoryMappingPresets: stored } };
+
+    const store = useImportExportStore();
+    seedStore(store);
+    store.columnMapping.category = { option: CategoryOptionValue.mapDataSourceColumn, columnName: 'category' };
+    store.uniqueCategoriesInCSV = ['Groceries'];
+    store.categoryMapping = { Groceries: { action: 'create-new' } };
+    store.headersFingerprint = fingerprint;
+    await store.detectDuplicates();
+
+    await store.executeImport();
+
+    return mockPatchUserSettingsAsync.mock.calls.at(-1)![0].import.categoryMappingPresets;
+  };
+
+  const unnamedPreset = (fingerprint: string): CategoryMappingPreset => ({
+    fingerprint,
+    categoryMapping: {},
+    updatedAt: '2025-01-01T00:00:00.000Z',
+  });
+
+  it('applies the preset to present source names, skips deleted link targets, and overwrites current choices', () => {
+    mockUserSettingsData.value = {
+      import: {
+        categoryMappingPresets: [
+          {
+            fingerprint: 'fp-1',
+            categoryMapping: {
+              Groceries: { action: 'link-existing', categoryId: 'cat-1' },
+              Fuel: { action: 'link-existing', categoryId: 'deleted-cat' },
+              Rent: { action: 'create-new' },
+              NotInThisFile: { action: 'create-new' },
+            },
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    vi.mocked(useCategoriesStore).mockReturnValue({
+      loadCategories: vi.fn(),
+      categoriesMap: { 'cat-1': { id: 'cat-1' } },
+    } as never);
+
+    const store = useImportExportStore();
+    store.headersFingerprint = 'fp-1';
+    store.uniqueCategoriesInCSV = ['Groceries', 'Fuel', 'Rent'];
+    store.categoryMapping = { Rent: { action: 'link-existing', categoryId: 'cat-1' } };
+
+    store.applyCategoryPreset({ preset: store.matchingCategoryPreset! });
+
+    expect(store.categoryMapping).toEqual({
+      Groceries: { action: 'link-existing', categoryId: 'cat-1' },
+      Rent: { action: 'create-new' },
+    });
+  });
+
+  it('replaces the same-fingerprint preset on execute instead of appending, and caps the stored list', async () => {
+    const presets = await persistViaImport({
+      stored: [
+        { ...unnamedPreset('fp-1'), categoryMapping: { Old: { action: 'create-new' } } },
+        ...Array.from({ length: MAX_CATEGORY_MAPPING_PRESETS }, (_, index) => unnamedPreset(`fp-other-${index}`)),
+      ],
+      fingerprint: 'fp-1',
+    });
+
+    expect(presets).toHaveLength(MAX_CATEGORY_MAPPING_PRESETS);
+    expect(presets[0]).toEqual(
+      expect.objectContaining({ fingerprint: 'fp-1', categoryMapping: { Groceries: { action: 'create-new' } } }),
+    );
+    expect(presets.filter((preset: CategoryMappingPreset) => preset.fingerprint === 'fp-1')).toHaveLength(1);
+  });
+
+  it('keeps the name when re-persisting the same fingerprint', async () => {
+    const presets = await persistViaImport({
+      stored: [{ ...unnamedPreset('fp-1'), name: 'PKO Bank' }],
+      fingerprint: 'fp-1',
+    });
+
+    expect(presets).toEqual([
+      expect.objectContaining({
+        fingerprint: 'fp-1',
+        name: 'PKO Bank',
+        categoryMapping: { Groceries: { action: 'create-new' } },
+      }),
+    ]);
+  });
+
+  it('evicts the oldest unnamed preset over the cap and keeps the named ones', async () => {
+    const stored = [
+      ...Array.from({ length: MAX_CATEGORY_MAPPING_PRESETS - 1 }, (_, index) => unnamedPreset(`fp-other-${index}`)),
+      { ...unnamedPreset('fp-template'), name: 'Template' },
+    ];
+
+    const presets = await persistViaImport({ stored, fingerprint: 'fp-new' });
+
+    expect(presets).toHaveLength(MAX_CATEGORY_MAPPING_PRESETS);
+    expect(presets.map((preset) => preset.fingerprint)).toContain('fp-template');
+    expect(presets.map((preset) => preset.fingerprint)).not.toContain(`fp-other-${MAX_CATEGORY_MAPPING_PRESETS - 2}`);
+  });
+
+  it('renames a preset in place without reordering or bumping updatedAt', async () => {
+    const stored = [unnamedPreset('fp-1'), { ...unnamedPreset('fp-2'), updatedAt: '2024-01-01T00:00:00.000Z' }];
+    mockUserSettingsData.value = { import: { categoryMappingPresets: stored } };
+
+    const store = useImportExportStore();
+    await store.renameCategoryPreset({ fingerprint: 'fp-2', name: '  Template  ' });
+
+    expect(mockPatchUserSettingsAsync.mock.calls.at(-1)![0].import.categoryMappingPresets).toEqual([
+      stored[0],
+      { ...stored[1], name: 'Template' },
+    ]);
+  });
+
+  it('ignores a rename that trims to nothing', async () => {
+    mockUserSettingsData.value = { import: { categoryMappingPresets: [unnamedPreset('fp-1')] } };
+
+    const store = useImportExportStore();
+    await store.renameCategoryPreset({ fingerprint: 'fp-1', name: '   ' });
+
+    expect(mockPatchUserSettingsAsync).not.toHaveBeenCalled();
+  });
+
+  it('deletes a preset by fingerprint', async () => {
+    const kept = unnamedPreset('fp-1');
+    mockUserSettingsData.value = { import: { categoryMappingPresets: [kept, unnamedPreset('fp-2')] } };
+
+    const store = useImportExportStore();
+    await store.deleteCategoryPreset({ fingerprint: 'fp-2' });
+
+    expect(mockPatchUserSettingsAsync.mock.calls.at(-1)![0].import.categoryMappingPresets).toEqual([kept]);
+  });
+
+  it('lists named presets newest first and excludes the current layout', () => {
+    mockUserSettingsData.value = {
+      import: {
+        categoryMappingPresets: [
+          { ...unnamedPreset('fp-1'), name: 'Current' },
+          { ...unnamedPreset('fp-2'), name: 'Older', updatedAt: '2024-01-01T00:00:00.000Z' },
+          { ...unnamedPreset('fp-3'), name: 'Newer', updatedAt: '2026-01-01T00:00:00.000Z' },
+          unnamedPreset('fp-4'),
+        ],
+      },
+    };
+
+    const store = useImportExportStore();
+    store.headersFingerprint = 'fp-1';
+
+    expect(store.namedCategoryPresets.map((preset) => preset.name)).toEqual(['Newer', 'Older']);
+  });
+
+  it('derives a different fingerprint for a different header row', async () => {
+    const parseCsvMock = vi.mocked(apiModule.parseCsv);
+    const parseResponse = (headers: string[]) =>
+      ({ headers, preview: [], detectedDelimiter: ',', totalRows: 0 }) as never;
+
+    const csvFile = {
+      name: 'test.csv',
+      text: () => Promise.resolve('date,amount\n2026-01-01,100'),
+    } as unknown as File;
+
+    const store = useImportExportStore();
+
+    parseCsvMock.mockResolvedValue(parseResponse(['date', 'amount']));
+    await store.parseFiles({ files: [csvFile] });
+    const firstFingerprint = store.headersFingerprint;
+
+    parseCsvMock.mockResolvedValue(parseResponse(['date', 'amount', 'category']));
+    await store.parseFiles({ files: [csvFile] });
+
+    expect(firstFingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(store.headersFingerprint).not.toBe(firstFingerprint);
   });
 });

--- a/packages/frontend/src/stores/import-export.ts
+++ b/packages/frontend/src/stores/import-export.ts
@@ -510,6 +510,10 @@ export const useImportExportStore = defineStore('importExport', () => {
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
+    resetAiMapping,
     quickSkipAllTags,
     resetResolveEntity,
   } = resolveEngine;
@@ -882,6 +886,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     isDetectingDuplicates.value = false;
     detectError.value = null;
     isEnqueuing.value = false;
+    resetAiMapping();
     resetRecalculateBalanceOverride();
     jobProgress.stop();
     jobProgress.setExecuteError(null);
@@ -954,6 +959,9 @@ export const useImportExportStore = defineStore('importExport', () => {
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
     quickSkipAllTags,
     resetResolveEntity,
     prepareResolveStep,

--- a/packages/frontend/src/stores/import-export.ts
+++ b/packages/frontend/src/stores/import-export.ts
@@ -54,26 +54,20 @@ import { useOnboardingStore } from './onboarding';
 import { useTagsStore } from './tags';
 
 /**
- * Wizard step identifiers, in canonical order. `'resolve'` is conditional —
- * `visibleSteps` omits it when `needsResolveStep` is false. Keys are the single
- * source of truth for navigation; the numeric `currentStep` / `completedSteps`
- * the store still exposes are projected from the key via STEP_KEY_TO_NUMBER.
+ * Wizard step identifiers, in canonical order. Both resolve steps are
+ * conditional: `visibleSteps` drops each one when its entities need no mapping.
  */
-export type ImportStepKey = 'upload' | 'map' | 'resolve' | 'review' | 'results';
+export type ImportStepKey = 'upload' | 'map' | 'resolve-accounts' | 'resolve-categories' | 'review' | 'results';
 
 /** Every step in canonical order, before conditional filtering. */
-const ALL_STEP_KEYS: readonly ImportStepKey[] = ['upload', 'map', 'resolve', 'review', 'results'];
-
-/** Maps a step key to its 1-based number for the numeric step view. */
-const STEP_KEY_TO_NUMBER: Record<ImportStepKey, number> = {
-  upload: 1,
-  map: 2,
-  // Resolve shares the Map step's number so the numeric view keeps detect/review
-  // at 3+ whether or not the conditional Resolve step is shown.
-  resolve: 2,
-  review: 3,
-  results: 4,
-};
+const ALL_STEP_KEYS: readonly ImportStepKey[] = [
+  'upload',
+  'map',
+  'resolve-accounts',
+  'resolve-categories',
+  'review',
+  'results',
+];
 
 const emptyColumnMapping = (): ColumnMapping => ({
   date: null,
@@ -97,12 +91,17 @@ export const useImportExportStore = defineStore('importExport', () => {
   const fileContent = ref<string | null>(null);
 
   // Step 2: Parsing
+  // Column names the mapping UI offers: the parsed headers minus the empty ones.
   const csvHeaders = ref<string[]>([]);
   const csvPreview = ref<Record<string, string>[]>([]);
-  // All data rows of the combined CSV (no header), aligned to `csvHeaders`. The
-  // backend preview is capped at 50 rows, so the Map step scans these for the full
-  // set of transaction-type values (which can appear past the preview window).
+  // All data rows of the combined CSV (no header). The backend preview is capped
+  // at 50 rows, so the Map step scans these for the full set of transaction-type
+  // values (which can appear past the preview window).
   const csvDataRows = ref<string[][]>([]);
+  // Row lookups must index against this list, never `csvHeaders`: `csvHeaders`
+  // drops empty header names, which shifts every column that follows one. Holds
+  // every parsed header, positionally aligned with `csvDataRows`.
+  const csvDataRowHeaders = ref<string[]>([]);
   const detectedDelimiter = ref<string>(',');
   const totalRows = ref<number>(0);
 
@@ -126,6 +125,17 @@ export const useImportExportStore = defineStore('importExport', () => {
   // Resolve step: extraction + entity-list loading state.
   const isExtracting = ref<boolean>(false);
   const extractError = ref<string | null>(null);
+  // Column choices the unique account/category/tag lists were extracted from.
+  // Re-extraction runs only when they change, so both Resolve steps share one fetch.
+  const resolveExtractionKey = computed(() =>
+    JSON.stringify([
+      columnMapping.value.account,
+      columnMapping.value.category,
+      columnMapping.value.tags,
+      columnMapping.value.currency,
+    ]),
+  );
+  const extractedForColumns = ref<string | null>(null);
   // Set when loading the existing tags list fails, so the Resolve step can warn
   // that link-to-existing targets may be missing while still letting create/skip through.
   const tagsLoadFailed = ref<boolean>(false);
@@ -262,18 +272,9 @@ export const useImportExportStore = defineStore('importExport', () => {
   /** Tags assignment maps per-row values from a CSV column → Resolve must map them. */
   const needsTagResolution = computed(() => columnMapping.value.tags?.option === TagOptionValue.mapDataSourceColumn);
 
-  /**
-   * True when at least one assignment uses a per-value method that the Resolve
-   * step must reconcile: category (map-to-column or create-new), account
-   * (from-column), or tags (map-to-column). Currency / transaction-type
-   * "from column" do NOT need Resolve — they read straight from the row.
-   */
-  const needsResolveStep = computed(
-    () => needsCategoryResolution.value || needsAccountResolution.value || needsTagResolution.value,
-  );
+  const needsCategoriesResolveStep = computed(() => needsCategoryResolution.value || needsTagResolution.value);
 
-  // UI state — key-based step model (the single source of truth). `'resolve'` is
-  // omitted from `visibleSteps` when `needsResolveStep` is false.
+  // UI state — key-based step model (the single source of truth).
   const {
     currentStepKey,
     completedStepKeys,
@@ -285,32 +286,11 @@ export const useImportExportStore = defineStore('importExport', () => {
     reset: resetSteps,
   } = useWizardSteps<ImportStepKey>({
     stepKeys: ALL_STEP_KEYS,
-    isStepVisible: (key) => key !== 'resolve' || needsResolveStep.value,
-  });
-
-  // Numeric step view derived from the key model. A numeric step API is part of
-  // this store's public surface (template consumers reference step numbers), so
-  // it is projected through STEP_KEY_TO_NUMBER rather than tracked separately.
-  // `currentStep` is writable: setting a number jumps to the first key that maps
-  // to it (Resolve and Map share number 2; Map is canonical).
-  const NUMBER_TO_STEP_KEY = ALL_STEP_KEYS.reduce<Record<number, ImportStepKey>>((acc, key) => {
-    const num = STEP_KEY_TO_NUMBER[key];
-    if (!(num in acc)) acc[num] = key;
-    return acc;
-  }, {});
-
-  const currentStep = computed<number>({
-    get: () => STEP_KEY_TO_NUMBER[currentStepKey.value],
-    set: (value) => {
-      const key = NUMBER_TO_STEP_KEY[value];
-      if (key) goToStep(key);
+    isStepVisible: (key) => {
+      if (key === 'resolve-accounts') return needsAccountResolution.value;
+      if (key === 'resolve-categories') return needsCategoriesResolveStep.value;
+      return true;
     },
-  });
-
-  const completedSteps = computed<number[]>(() => {
-    const numbers = new Set<number>();
-    for (const key of completedStepKeys.value) numbers.add(STEP_KEY_TO_NUMBER[key]);
-    return [...numbers];
   });
 
   /**
@@ -324,7 +304,7 @@ export const useImportExportStore = defineStore('importExport', () => {
       return [];
     }
     return distinctColumnValues({
-      headers: csvHeaders.value,
+      headers: csvDataRowHeaders.value,
       dataRows: csvDataRows.value,
       columnName: transactionType.columnName,
     });
@@ -383,13 +363,93 @@ export const useImportExportStore = defineStore('importExport', () => {
    * so the backend receives a valid reference rather than an empty string.
    */
   const isAccountResolved = (mapping: AccountMappingValue | undefined): boolean =>
-    mapping?.action === 'create-new' || (mapping?.action === 'link-existing' && !!mapping.accountId);
+    mapping?.action === 'create-new' ||
+    mapping?.action === 'skip' ||
+    (mapping?.action === 'link-existing' && !!mapping.accountId);
   const isCategoryResolved = (mapping: CategoryMappingValue | undefined): boolean =>
     mapping?.action === 'create-new' || (mapping?.action === 'link-existing' && !!mapping.categoryId);
   const isTagResolved = (mapping: TagMappingValue | undefined): boolean =>
     mapping?.action === 'create-new' ||
     mapping?.action === 'skip' ||
     (mapping?.action === 'link-existing' && !!mapping.tagId);
+
+  const skippedAccountNames = computed<string[]>(() =>
+    Object.entries(accountMapping.value)
+      .filter(([, value]) => value.action === 'skip')
+      .map(([name]) => name),
+  );
+
+  /**
+   * Values of `columnName` on rows whose account is not skipped. Returns null when
+   * the caller must keep its full list: nothing is skipped, the account is not read
+   * from a column, or a column is absent from the data rows.
+   */
+  const valuesInKeptRows = ({
+    columnName,
+    splitCell,
+  }: {
+    columnName: string;
+    splitCell: (cell: string | undefined) => string[];
+  }): Set<string> | null => {
+    const account = columnMapping.value.account;
+    if (skippedAccountNames.value.length === 0 || account?.option !== AccountOptionValue.dataSourceColumn) return null;
+
+    const accountIndex = csvDataRowHeaders.value.indexOf(account.columnName);
+    const valueIndex = csvDataRowHeaders.value.indexOf(columnName);
+    if (accountIndex === -1 || valueIndex === -1) return null;
+
+    const skipped = new Set(skippedAccountNames.value);
+    const referenced = new Set<string>();
+    for (const row of csvDataRows.value) {
+      const accountName = row[accountIndex]?.trim();
+      if (accountName && skipped.has(accountName)) continue;
+      for (const value of splitCell(row[valueIndex])) referenced.add(value);
+    }
+    return referenced;
+  };
+
+  /** Must match the backend's `extract-categories` split: one trimmed name per cell. */
+  const categoryNameInCell = (cell: string | undefined): string[] => {
+    const name = cell?.trim();
+    return name ? [name] : [];
+  };
+
+  /** Must match the backend's `splitTagCell`: comma-separated names in one cell. */
+  const tagNamesInCell = (cell: string | undefined): string[] =>
+    (cell ?? '')
+      .split(',')
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+  /**
+   * Categories used by at least one row of a non-skipped account. Falls back to
+   * the full `uniqueCategoriesInCSV` when the account or category column is not
+   * a data-source column.
+   */
+  const visibleCategoriesToResolve = computed<string[]>(() => {
+    const category = columnMapping.value.category;
+    const columnName =
+      category?.option === CategoryOptionValue.mapDataSourceColumn ||
+      category?.option === CategoryOptionValue.createNewCategories
+        ? category.columnName
+        : null;
+    if (!columnName) return uniqueCategoriesInCSV.value;
+
+    const referenced = valuesInKeptRows({ columnName, splitCell: categoryNameInCell });
+    if (!referenced) return uniqueCategoriesInCSV.value;
+    return uniqueCategoriesInCSV.value.filter((name) => referenced.has(name));
+  });
+
+  /** Same rule for tags, whose cell holds several comma-separated names. */
+  const visibleTagsToResolve = computed<string[]>(() => {
+    const tags = columnMapping.value.tags;
+    const columnName = tags?.option === TagOptionValue.mapDataSourceColumn ? tags.columnName : null;
+    if (!columnName) return uniqueTagsInCSV.value;
+
+    const referenced = valuesInKeptRows({ columnName, splitCell: tagNamesInCell });
+    if (!referenced) return uniqueTagsInCSV.value;
+    return uniqueTagsInCSV.value.filter((name) => referenced.has(name));
+  });
 
   /**
    * Shared resolve engine (bulk actions, step validity, duplicate-unmark toggle).
@@ -422,7 +482,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     },
     categories: {
       isActive: () => needsCategoryResolution.value,
-      getSources: () => uniqueCategoriesInCSV.value.map((name) => ({ name })),
+      getSources: () => visibleCategoriesToResolve.value.map((name) => ({ name })),
       getTargets: () =>
         flattenCategories({ categories: useCategoriesStore().formattedCategories }).map((category) => ({
           id: category.id,
@@ -435,7 +495,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     },
     tags: {
       isActive: () => needsTagResolution.value,
-      getSources: () => uniqueTagsInCSV.value.map((name) => ({ name })),
+      getSources: () => visibleTagsToResolve.value.map((name) => ({ name })),
       getTargets: () => useTagsStore().tags.map((tag) => ({ id: String(tag.id), name: tag.name })),
       mapping: tagMapping,
       toLink: (id) => ({ action: 'link-existing', tagId: id }),
@@ -452,8 +512,29 @@ export const useImportExportStore = defineStore('importExport', () => {
     quickCreateNewForUnmatched,
     quickSkipAllTags,
     resetResolveEntity,
-    isResolveStepValid,
   } = resolveEngine;
+
+  const isResolveAccountsStepValid = computed(
+    () =>
+      !needsAccountResolution.value ||
+      uniqueAccountsInCSV.value.every((account) => isAccountResolved(accountMapping.value[account.name])),
+  );
+
+  const isResolveCategoriesStepValid = computed(() => {
+    if (
+      needsCategoryResolution.value &&
+      !visibleCategoriesToResolve.value.every((name) => isCategoryResolved(categoryMapping.value[name]))
+    ) {
+      return false;
+    }
+    if (
+      needsTagResolution.value &&
+      !visibleTagsToResolve.value.every((name) => isTagResolved(tagMapping.value[name]))
+    ) {
+      return false;
+    }
+    return true;
+  });
 
   // ---- Other getters ----
 
@@ -462,8 +543,11 @@ export const useImportExportStore = defineStore('importExport', () => {
     const duplicateIndicesToSkip = new Set(
       duplicates.value.filter((d) => !unmarkedDuplicateIndices.value.has(d.rowIndex)).map((d) => d.rowIndex),
     );
+    const skippedAccounts = new Set(skippedAccountNames.value);
 
-    return validRows.value.filter((row) => !duplicateIndicesToSkip.has(row.rowIndex));
+    return validRows.value.filter(
+      (row) => !duplicateIndicesToSkip.has(row.rowIndex) && !skippedAccounts.has(row.accountName),
+    );
   });
 
   const importSummary = computed(() => ({
@@ -491,6 +575,7 @@ export const useImportExportStore = defineStore('importExport', () => {
       fileContent: fileContent.value,
     });
 
+    csvDataRowHeaders.value = response.headers;
     csvHeaders.value = response.headers.filter((h) => h !== '');
     csvPreview.value = response.preview;
     detectedDelimiter.value = response.detectedDelimiter;
@@ -559,12 +644,9 @@ export const useImportExportStore = defineStore('importExport', () => {
       unmarkedDuplicateIndices.value = new Set();
       unpriceableRows.value = response.unpriceableRows ?? [];
 
-      // Mapping (and Resolve, if it was shown) are done once detection succeeds;
-      // advance the wizard to the Review step.
       markStepCompleted('map');
-      if (needsResolveStep.value) {
-        markStepCompleted('resolve');
-      }
+      if (needsAccountResolution.value) markStepCompleted('resolve-accounts');
+      if (needsCategoriesResolveStep.value) markStepCompleted('resolve-categories');
       goToStep('review');
     } catch (error) {
       // Surface the error message so the UI can render it; re-throw so callers
@@ -608,11 +690,21 @@ export const useImportExportStore = defineStore('importExport', () => {
       .filter((d) => !unmarkedDuplicateIndices.value.has(d.rowIndex))
       .map((d) => d.rowIndex);
 
+    // Stored decisions for categories and tags hidden by an account skip must not
+    // reach the backend: it would create entities no imported row references.
+    const visibleCategories = new Set(visibleCategoriesToResolve.value);
+    const categoryMappingPayload = Object.fromEntries(
+      Object.entries(categoryMapping.value).filter(([name]) => visibleCategories.has(name)),
+    );
+
     // Only send tagMapping when a tags column is actually mapped. When the user
     // deselects the tags column, tagMapping may still hold stale entries; sending
     // them would make the backend create tags the user opted out of. The backend
     // treats an omitted tagMapping as "no tags" (see execute-import service).
-    const tagMappingPayload = columnMapping.value.tags ? tagMapping.value : undefined;
+    const visibleTags = new Set(visibleTagsToResolve.value);
+    const tagMappingPayload = columnMapping.value.tags
+      ? Object.fromEntries(Object.entries(tagMapping.value).filter(([name]) => visibleTags.has(name)))
+      : undefined;
 
     isEnqueuing.value = true;
     let response: Awaited<ReturnType<typeof executeImportApi>>;
@@ -622,7 +714,7 @@ export const useImportExportStore = defineStore('importExport', () => {
         delimiter: detectedDelimiter.value,
         columnMapping: config,
         accountMapping: accountMapping.value,
-        categoryMapping: categoryMapping.value,
+        categoryMapping: categoryMappingPayload,
         tagMapping: tagMappingPayload,
         skipDuplicateIndices,
         skipUnpriceableIndices,
@@ -710,6 +802,8 @@ export const useImportExportStore = defineStore('importExport', () => {
       Object.keys(accountMapping.value).forEach((name) => {
         if (!sourceAccountNames.has(name)) delete accountMapping.value[name];
       });
+
+      extractedForColumns.value = resolveExtractionKey.value;
     } catch (error) {
       if (
         error instanceof ApiErrorResponseError &&
@@ -728,18 +822,13 @@ export const useImportExportStore = defineStore('importExport', () => {
   };
 
   /**
-   * Readies the Resolve step: extracts the unique source values when missing,
-   * loads the existing category/tag lists that link targets need, then runs a
-   * non-destructive auto-match. Each fetch is independently guarded so a single
-   * failure neither aborts the rest nor rejects the caller.
+   * Readies either Resolve step: re-extracts unique source values when the column
+   * choices changed, loads the category/tag lists that link targets need, then
+   * auto-matches non-destructively. Each fetch is guarded, so one failure neither
+   * aborts the rest nor rejects the caller.
    */
   const prepareResolveStep = async (): Promise<void> => {
-    const needsExtraction =
-      (needsAccountResolution.value && uniqueAccountsInCSV.value.length === 0) ||
-      (needsCategoryResolution.value && uniqueCategoriesInCSV.value.length === 0) ||
-      (needsTagResolution.value && uniqueTagsInCSV.value.length === 0);
-
-    if (needsExtraction) {
+    if (extractedForColumns.value !== resolveExtractionKey.value) {
       await extractUniqueValues();
     }
 
@@ -769,6 +858,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     csvHeaders.value = [];
     csvPreview.value = [];
     csvDataRows.value = [];
+    csvDataRowHeaders.value = [];
     detectedDelimiter.value = ',';
     totalRows.value = 0;
     columnMapping.value = emptyColumnMapping();
@@ -782,6 +872,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     currencyMismatchWarning.value = null;
     isExtracting.value = false;
     extractError.value = null;
+    extractedForColumns.value = null;
     tagsLoadFailed.value = false;
     validRows.value = [];
     invalidRows.value = [];
@@ -805,6 +896,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     csvHeaders,
     csvPreview,
     csvDataRows,
+    csvDataRowHeaders,
     detectedDelimiter,
     totalRows,
     columnMapping,
@@ -834,18 +926,20 @@ export const useImportExportStore = defineStore('importExport', () => {
     recalculateBalanceSettingLoadFailed,
     currentStepKey,
     completedStepKeys,
-    currentStep,
-    completedSteps,
 
     // Getters
-    needsResolveStep,
     needsAccountResolution,
     needsCategoryResolution,
     needsTagResolution,
+    needsCategoriesResolveStep,
     visibleSteps,
     isMapStepValid,
     uncoveredTransactionTypeValues,
-    isResolveStepValid,
+    isResolveAccountsStepValid,
+    isResolveCategoriesStepValid,
+    skippedAccountNames,
+    visibleCategoriesToResolve,
+    visibleTagsToResolve,
     importSummary,
 
     // Actions

--- a/packages/frontend/src/stores/import-export.ts
+++ b/packages/frontend/src/stores/import-export.ts
@@ -3,6 +3,7 @@ import {
   type AccountMappingValue,
   AccountOptionValue,
   type CategoryMappingConfig,
+  type CategoryMappingPreset,
   type CategoryMappingValue,
   CategoryOptionValue,
   type CsvImportProgress,
@@ -22,6 +23,7 @@ import type { AccountMappingConfig } from '@bt/shared/types';
 type UnpriceableRow = NonNullable<DetectDuplicatesResponse['unpriceableRows']>[number];
 import { executeImport as executeImportApi, getCsvImportStatus } from '@/api/import-export';
 import { VUE_QUERY_CACHE_KEYS, VUE_QUERY_GLOBAL_PREFIXES } from '@/common/const/vue-query';
+import { useCategoryMappingPresets } from '@/composable/use-category-mapping-presets';
 import { useImportJobProgress } from '@/composable/use-import-job-progress';
 import { useRecalculateBalanceToggle } from '@/composable/use-recalculate-balance-toggle';
 import { useResolveMapping } from '@/composable/use-resolve-mapping';
@@ -82,6 +84,11 @@ const emptyColumnMapping = (): ColumnMapping => ({
   transactionType: { option: TransactionTypeOptionValue.amountSign },
 });
 
+const sha256Hex = async ({ value }: { value: string }): Promise<string> => {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+
 export const useImportExportStore = defineStore('importExport', () => {
   const queryClient = useQueryClient();
 
@@ -102,6 +109,9 @@ export const useImportExportStore = defineStore('importExport', () => {
   // drops empty header names, which shifts every column that follows one. Holds
   // every parsed header, positionally aligned with `csvDataRows`.
   const csvDataRowHeaders = ref<string[]>([]);
+  // Identifies the file's column layout, so a category mapping saved by an earlier import of a
+  // same-layout file can be offered again. Null until a file is parsed.
+  const headersFingerprint = ref<string | null>(null);
   const detectedDelimiter = ref<string>(',');
   const totalRows = ref<number>(0);
 
@@ -518,13 +528,18 @@ export const useImportExportStore = defineStore('importExport', () => {
     resetResolveEntity,
   } = resolveEngine;
 
+  // A failed extraction leaves the unique lists empty, and `.every()` over an
+  // empty list reads as "all resolved" — so both resolve steps must hard-block
+  // on the error itself, or Next would walk past the failure to Review.
   const isResolveAccountsStepValid = computed(
     () =>
       !needsAccountResolution.value ||
-      uniqueAccountsInCSV.value.every((account) => isAccountResolved(accountMapping.value[account.name])),
+      (!extractError.value &&
+        uniqueAccountsInCSV.value.every((account) => isAccountResolved(accountMapping.value[account.name]))),
   );
 
   const isResolveCategoriesStepValid = computed(() => {
+    if (needsCategoriesResolveStep.value && extractError.value) return false;
     if (
       needsCategoryResolution.value &&
       !visibleCategoriesToResolve.value.every((name) => isCategoryResolved(categoryMapping.value[name]))
@@ -539,6 +554,20 @@ export const useImportExportStore = defineStore('importExport', () => {
     }
     return true;
   });
+
+  // ---- Remembered category mappings ----
+
+  const {
+    matchingPreset: matchingCategoryPreset,
+    namedPresets: namedCategoryPresets,
+    applyPreset,
+    persistPreset: persistCategoryPreset,
+    renamePreset: renameCategoryPreset,
+    deletePreset: deleteCategoryPreset,
+  } = useCategoryMappingPresets({ fingerprint: headersFingerprint });
+
+  const applyCategoryPreset = ({ preset }: { preset: CategoryMappingPreset }) =>
+    applyPreset({ preset, categoryMapping, validSourceNames: uniqueCategoriesInCSV.value });
 
   // ---- Other getters ----
 
@@ -580,6 +609,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     });
 
     csvDataRowHeaders.value = response.headers;
+    headersFingerprint.value = await sha256Hex({ value: JSON.stringify(response.headers) });
     csvHeaders.value = response.headers.filter((h) => h !== '');
     csvPreview.value = response.preview;
     detectedDelimiter.value = response.detectedDelimiter;
@@ -741,6 +771,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     // Job accepted: remember the balance-recalculation choice for the next
     // import (fire-and-forget), then advance the wizard and arm the watchdog.
     persistRecalculateBalanceSetting();
+    if (needsCategoryResolution.value) persistCategoryPreset({ mapping: categoryMappingPayload });
     markStepCompleted('review');
     goToStep('results');
     jobProgress.start({
@@ -863,6 +894,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     csvPreview.value = [];
     csvDataRows.value = [];
     csvDataRowHeaders.value = [];
+    headersFingerprint.value = null;
     detectedDelimiter.value = ',';
     totalRows.value = 0;
     columnMapping.value = emptyColumnMapping();
@@ -902,6 +934,7 @@ export const useImportExportStore = defineStore('importExport', () => {
     csvPreview,
     csvDataRows,
     csvDataRowHeaders,
+    headersFingerprint,
     detectedDelimiter,
     totalRows,
     columnMapping,
@@ -945,6 +978,8 @@ export const useImportExportStore = defineStore('importExport', () => {
     skippedAccountNames,
     visibleCategoriesToResolve,
     visibleTagsToResolve,
+    matchingCategoryPreset,
+    namedCategoryPresets,
     importSummary,
 
     // Actions
@@ -964,6 +999,9 @@ export const useImportExportStore = defineStore('importExport', () => {
     aiMappingCategoriesError,
     quickSkipAllTags,
     resetResolveEntity,
+    applyCategoryPreset,
+    renameCategoryPreset,
+    deleteCategoryPreset,
     prepareResolveStep,
     reset,
   };

--- a/packages/frontend/src/stores/import-ms-money.test.ts
+++ b/packages/frontend/src/stores/import-ms-money.test.ts
@@ -62,6 +62,7 @@ vi.mock('@/stores/categories/categories', () => ({
   useCategoriesStore: vi.fn(() => ({
     categories: [{ id: 'cat-groceries', name: 'Groceries', subCategories: [] }],
     formattedCategories: [{ id: 'cat-groceries', name: 'Groceries', subCategories: [] }],
+    categoriesMap: { 'cat-groceries': { id: 'cat-groceries', name: 'Groceries' } },
     loadCategories: vi.fn(),
   })),
 }));
@@ -77,7 +78,9 @@ vi.mock('@/i18n', () => ({ i18n: { global: { t: (key: string) => key } } }));
 
 // The store reads the persisted recalculate-balance default from user settings at
 // construction and PATCHes the chosen value back after a successful execute.
-let mockUserSettingsData: Ref<{ import?: { recalculateAccountBalance?: boolean } } | undefined>;
+let mockUserSettingsData: Ref<
+  { import?: { recalculateAccountBalance?: boolean; categoryMappingPresets?: CategoryMappingPreset[] } } | undefined
+>;
 let mockPatchUserSettingsAsync: ReturnType<typeof vi.fn>;
 
 vi.mock('@/composable/data-queries/user-settings', () => ({
@@ -92,6 +95,7 @@ vi.mock('@/composable/data-queries/user-settings', () => ({
 import * as msMoneyApi from '@/api/import-ms-money';
 import {
   MsMoneyAccountType,
+  type CategoryMappingPreset,
   type MsMoneyParseResult,
   type MsMoneyUploadResponse,
   type ResourceLease,
@@ -327,5 +331,48 @@ describe('useImportMsMoneyStore – bounce messages', () => {
 
     await expect(store.uploadFile({ file: aFile() })).rejects.toBe('boom');
     expect(store.uploadError).toBe('errors.api.unexpectedError');
+  });
+});
+
+describe('useImportMsMoneyStore – remembered category mappings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mountWithPlugins();
+  });
+
+  it('applies the ms-money preset and re-persists it under the flow fingerprint on execute', async () => {
+    mockUserSettingsData.value = {
+      import: {
+        categoryMappingPresets: [
+          {
+            fingerprint: 'ms-money',
+            categoryMapping: { 'Auto:Gas': { action: 'link-existing', categoryId: 'cat-groceries' } },
+            updatedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    };
+    mockExecute.mockResolvedValue({ jobId: 'job-preset' });
+
+    const store = await uploadedStore();
+
+    expect(store.matchingCategoryPreset?.fingerprint).toBe('ms-money');
+
+    store.applyCategoryPreset({ preset: store.matchingCategoryPreset! });
+    expect(store.categoryMapping['Auto:Gas']).toEqual({ action: 'link-existing', categoryId: 'cat-groceries' });
+
+    await store.execute();
+
+    const presets = mockPatchUserSettingsAsync.mock.calls.at(-1)![0].import.categoryMappingPresets;
+    expect(presets).toHaveLength(1);
+    expect(presets[0]).toEqual(
+      expect.objectContaining({
+        fingerprint: 'ms-money',
+        categoryMapping: {
+          Groceries: { action: 'link-existing', categoryId: 'cat-groceries' },
+          'Auto:Gas': { action: 'link-existing', categoryId: 'cat-groceries' },
+        },
+      }),
+    );
   });
 });

--- a/packages/frontend/src/stores/import-ms-money.ts
+++ b/packages/frontend/src/stores/import-ms-money.ts
@@ -6,6 +6,7 @@ import {
 } from '@/api/import-ms-money';
 import { refreshResourceLease } from '@/api/resource-leases';
 import { getErrorMessage } from '@/common/utils/error-message';
+import { useCategoryMappingPresets } from '@/composable/use-category-mapping-presets';
 import { useImportJobProgress } from '@/composable/use-import-job-progress';
 import { useRecalculateBalanceToggle } from '@/composable/use-recalculate-balance-toggle';
 import { useResolveMapping } from '@/composable/use-resolve-mapping';
@@ -21,6 +22,7 @@ import {
   ResourceLeaseType,
   SSE_EVENT_TYPES,
   type CategoryMappingConfig,
+  type CategoryMappingPreset,
   type CategoryMappingValue,
   type DuplicateMatch,
   type MsMoneyAccountMapping,
@@ -46,6 +48,9 @@ type MsMoneyImportStepKey = 'upload' | 'resolve' | 'review' | 'execute' | 'done'
 
 /** Every step in canonical order. All are always visible. */
 const MS_MONEY_STEP_KEYS: readonly MsMoneyImportStepKey[] = ['upload', 'resolve', 'review', 'execute', 'done'];
+
+/** The Money category layout is fixed, so every import shares one remembered-preset key. */
+const CATEGORY_PRESET_FINGERPRINT = 'ms-money';
 
 /** i18n key rendering each step's label in the stepper. */
 export const MS_MONEY_STEP_LABEL_KEYS: Record<MsMoneyImportStepKey, string> = {
@@ -333,6 +338,20 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     unmarkedDuplicateIndices,
   });
 
+  // ---- Remembered category mappings ----
+
+  const {
+    matchingPreset: matchingCategoryPreset,
+    namedPresets: namedCategoryPresets,
+    applyPreset,
+    persistPreset: persistCategoryPreset,
+    renamePreset: renameCategoryPreset,
+    deletePreset: deleteCategoryPreset,
+  } = useCategoryMappingPresets({ fingerprint: ref(CATEGORY_PRESET_FINGERPRINT) });
+
+  const applyCategoryPreset = ({ preset }: { preset: CategoryMappingPreset }) =>
+    applyPreset({ preset, categoryMapping, validSourceNames: resolvableCategoryNames.value });
+
   /** True when at least one account is mapped to an existing app account.
    *  Determines whether duplicate detection is meaningful. */
   const hasAnyLinkExisting = computed(() =>
@@ -581,12 +600,14 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     jobProgress.setExecuteError(null);
 
     isEnqueuing.value = true;
+    let categoryMappingPayload: CategoryMappingConfig;
     let response: Awaited<ReturnType<typeof executeMsMoneyImport>>;
     try {
+      categoryMappingPayload = toWireCategoryMapping();
       response = await executeMsMoneyImport({
         uploadId: uploadId.value,
         accountMapping: toWireAccountMapping(),
-        categoryMapping: toWireCategoryMapping(),
+        categoryMapping: categoryMappingPayload,
         skipDuplicateIndices: skipDuplicateIndices.value,
         includeVoidedTransactions: includeVoidedTransactions.value,
         recalculateBalance: recalculateBalance.value,
@@ -603,6 +624,7 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     // Job accepted: remember the balance-recalculation choice for the next
     // import (fire-and-forget), then advance the wizard and arm the watchdog.
     persistRecalculateBalanceSetting();
+    persistCategoryPreset({ mapping: categoryMappingPayload });
     markStepCompleted('review');
     goToStep('execute');
     jobProgress.start({
@@ -663,6 +685,8 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     accountResolvedCount,
     categoryResolvedCount,
     resolvableCategoryNames,
+    matchingCategoryPreset,
+    namedCategoryPresets,
     isResolveStepValid,
     hasAnyLinkExisting,
     skippedAccountNames,
@@ -693,6 +717,9 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     isAiMappingCategories,
     aiMappingCategoriesError,
     resetResolveEntity,
+    applyCategoryPreset,
+    renameCategoryPreset,
+    deleteCategoryPreset,
 
     // Duplicate helpers
     toggleDuplicateUnmark,

--- a/packages/frontend/src/stores/import-ms-money.ts
+++ b/packages/frontend/src/stores/import-ms-money.ts
@@ -289,6 +289,10 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
+    resetAiMapping,
     resetResolveEntity,
     toggleDuplicateUnmark,
     accountResolvedCount,
@@ -628,6 +632,7 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     isDetectingDuplicates.value = false;
     detectError.value = null;
     isEnqueuing.value = false;
+    resetAiMapping();
     jobProgress.setExecuteError(null);
     jobProgress.stop();
   }
@@ -684,6 +689,9 @@ export const useImportMsMoneyStore = defineStore('import-ms-money', () => {
     autoMatchResolveValues,
     quickMapExactMatches,
     quickCreateNewForUnmatched,
+    quickAiMapCategories,
+    isAiMappingCategories,
+    aiMappingCategoriesError,
     resetResolveEntity,
 
     // Duplicate helpers

--- a/packages/frontend/src/stores/import-ynab.test.ts
+++ b/packages/frontend/src/stores/import-ynab.test.ts
@@ -1,0 +1,152 @@
+import { QueryClient } from '@tanstack/vue-query';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Ref, ref } from 'vue';
+
+import { useImportYnabStore } from './import-ynab';
+
+// ----- module mocks -----
+
+vi.mock('@/api/import-ynab', () => ({
+  parseYnab: vi.fn(),
+  executeYnabImport: vi.fn(),
+  getYnabImportStatus: vi.fn(),
+}));
+
+// The store arms a `useImportJobProgress` watchdog at construction time. Mock it
+// so the store builds without real SSE or timers.
+let mockJobProgress: Ref<unknown>;
+let mockJobExecuteError: Ref<string | null>;
+
+vi.mock('@/composable/use-import-job-progress', () => ({
+  useImportJobProgress: vi.fn(() => ({
+    progress: mockJobProgress,
+    executeError: mockJobExecuteError,
+    start: vi.fn(),
+    stop: vi.fn(),
+  })),
+}));
+
+// useQueryClient is called at store construction time; hand back a shared client.
+let sharedQueryClient: QueryClient;
+vi.mock('@tanstack/vue-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/vue-query')>();
+  return { ...actual, useQueryClient: vi.fn(() => sharedQueryClient) };
+});
+
+// Only referenced inside the (never-fired) onComplete callback; stubbed so the
+// real modules aren't pulled in.
+vi.mock('@/stores/accounts', () => ({ useAccountsStore: vi.fn(() => ({ refetchAccounts: vi.fn() })) }));
+vi.mock('@/stores/categories/categories', () => ({ useCategoriesStore: vi.fn(() => ({ loadCategories: vi.fn() })) }));
+vi.mock('@/stores/currencies', () => ({ useCurrenciesStore: vi.fn(() => ({ loadCurrencies: vi.fn() })) }));
+vi.mock('@/stores/tags', () => ({ useTagsStore: vi.fn(() => ({ loadTags: vi.fn() })) }));
+
+// ----- helpers -----
+
+import * as ynabApi from '@/api/import-ynab';
+import type { YnabParseAccount, YnabParseResult } from '@bt/shared/types';
+
+const mockParse = vi.mocked(ynabApi.parseYnab);
+
+const anAccount = ({
+  originalName,
+  detectedCurrency,
+}: {
+  originalName: string;
+  detectedCurrency: string | null;
+}): YnabParseAccount => ({
+  originalName,
+  detectedCurrency,
+  startingBalance: 0,
+  transactionCount: 1,
+});
+
+const aParseResult = ({ accounts }: { accounts: YnabParseAccount[] }): YnabParseResult => ({
+  accounts,
+  categories: [],
+  payees: [],
+  tagsUsed: [],
+  transactions: [],
+  transfers: [],
+  detectedSplitCount: 0,
+  warnings: [],
+  dateRange: null,
+});
+
+const aFile = () => new File(['csv'], 'register.csv', { type: 'text/csv' });
+
+/** Parses a file so `accountPicks` is seeded from the parser's currency guesses. */
+const parsedStore = async ({ accounts }: { accounts: YnabParseAccount[] }) => {
+  mockParse.mockResolvedValue({ result: aParseResult({ accounts }) });
+  const store = useImportYnabStore();
+  await store.parseFile(aFile());
+  return store;
+};
+
+// ----- tests -----
+
+describe('useImportYnabStore – skipped accounts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sharedQueryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    mockJobProgress = ref(null);
+    mockJobExecuteError = ref<string | null>(null);
+    setActivePinia(createPinia());
+  });
+
+  it('allows executing once every account resolved to a 3-letter currency', async () => {
+    const store = await parsedStore({
+      accounts: [
+        anAccount({ originalName: 'Cash', detectedCurrency: 'USD' }),
+        anAccount({ originalName: 'Savings', detectedCurrency: 'EUR' }),
+      ],
+    });
+
+    expect(store.canExecute).toBe(true);
+  });
+
+  it('blocks execute on an unresolved currency and waives it once the account is skipped', async () => {
+    const store = await parsedStore({
+      accounts: [
+        anAccount({ originalName: 'Cash', detectedCurrency: 'USD' }),
+        anAccount({ originalName: 'Mystery', detectedCurrency: null }),
+      ],
+    });
+
+    expect(store.canExecute).toBe(false);
+
+    store.toggleAccountSkip({ accountName: 'Mystery' });
+
+    expect(store.canExecute).toBe(true);
+  });
+
+  it('keeps currencyCode across a skip/unskip round trip', async () => {
+    const store = await parsedStore({
+      accounts: [anAccount({ originalName: 'Cash', detectedCurrency: 'EUR' })],
+    });
+
+    store.toggleAccountSkip({ accountName: 'Cash' });
+    expect(store.accountPicks['Cash']).toEqual({ currencyCode: 'EUR', skip: true });
+
+    store.toggleAccountSkip({ accountName: 'Cash' });
+    expect(store.accountPicks['Cash']).toEqual({ currencyCode: 'EUR', skip: false });
+    expect(store.canExecute).toBe(true);
+  });
+
+  it('lists exactly the skipped accounts in skippedAccountNames', async () => {
+    const store = await parsedStore({
+      accounts: [
+        anAccount({ originalName: 'Cash', detectedCurrency: 'USD' }),
+        anAccount({ originalName: 'Savings', detectedCurrency: 'EUR' }),
+      ],
+    });
+
+    expect(store.skippedAccountNames).toEqual([]);
+
+    store.toggleAccountSkip({ accountName: 'Savings' });
+    expect(store.skippedAccountNames).toEqual(['Savings']);
+
+    store.toggleAccountSkip({ accountName: 'Savings' });
+    expect(store.skippedAccountNames).toEqual([]);
+  });
+});

--- a/packages/frontend/src/stores/import-ynab.ts
+++ b/packages/frontend/src/stores/import-ynab.ts
@@ -91,16 +91,31 @@ export const useImportYnabStore = defineStore('importYnab', () => {
   // Internal execute machinery — components never read these.
   let fileContent: string | null = null;
 
+  const skippedAccountNames = computed<string[]>(() =>
+    Object.entries(accountPicks.value)
+      .filter(([, value]) => value.skip)
+      .map(([name]) => name),
+  );
+
   const canExecute = computed(() => {
     if (!parsedResult.value) return false;
-    // Every YNAB account must have resolved to a valid 3-letter ISO currency
-    // code before the worker can boot user currencies and create the row.
+    // Every account the user keeps must have resolved to a valid 3-letter ISO
+    // currency code before the worker can boot user currencies and create the
+    // row. Skipped accounts are never created, so their currency is irrelevant.
     for (const acc of parsedResult.value.accounts) {
       const mapping = accountPicks.value[acc.originalName];
-      if (!mapping || mapping.currencyCode.length !== 3) return false;
+      if (!mapping) return false;
+      if (!mapping.skip && mapping.currencyCode.length !== 3) return false;
     }
     return true;
   });
+
+  /** Keeps `currencyCode` so unskipping restores the picker's previous value. */
+  function toggleAccountSkip({ accountName }: { accountName: string }) {
+    const mapping = accountPicks.value[accountName];
+    if (!mapping) return;
+    accountPicks.value[accountName] = { ...mapping, skip: !mapping.skip };
+  }
 
   async function parseFile(file: File) {
     uploadedFile.value = file;
@@ -183,6 +198,8 @@ export const useImportYnabStore = defineStore('importYnab', () => {
     parseError,
     executeError,
     canExecute,
+    skippedAccountNames,
+    toggleAccountSkip,
     parseFile,
     execute,
     reset,

--- a/packages/shared/src/import-export/date-engine.ts
+++ b/packages/shared/src/import-export/date-engine.ts
@@ -1,5 +1,5 @@
-import { type SupportedLocale } from '@bt/shared/i18n/locales';
-import { type DateFieldOrder } from '@bt/shared/types';
+import { type SupportedLocale } from '../i18n/locales';
+import { type DateFieldOrder } from '../types/import-export';
 
 /**
  * Timezone-agnostic normalized result of parsing a single raw date cell.
@@ -7,6 +7,10 @@ import { type DateFieldOrder } from '@bt/shared/types';
  * The engine never applies a timezone. A later piece anchors `dateOnly` /
  * `localDateTime` values to the user's browser timezone to decide the stored
  * instant; `instant` already carries an absolute moment and is preserved as-is.
+ *
+ * Lives in `shared` because the import wizard's client-side preview and the
+ * server's actual parse MUST agree cell-for-cell — a second hand-mirrored
+ * grammar is how they drift apart.
  */
 export type ParsedImportDate =
   | { kind: 'instant'; instant: Date }
@@ -65,10 +69,16 @@ const ISO_DATE = /^(\d{4})[/.-](\d{1,2})[/.-](\d{1,2})$/;
 // Compact 8-digit YYYYMMDD with no separators.
 const COMPACT_DATE = /^(\d{4})(\d{2})(\d{2})$/;
 
-// Year-LAST date with two 1-2 digit lead fields (d/d/yyyy, `/ . -` separators).
-// Which lead field is the day vs the month is intrinsically ambiguous, so it is
-// resolved at the column level via `DateColumnFormat.fieldOrder`.
-const AMBIGUOUS_DMY = /^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4})$/;
+// Year-LAST date with two 1-2 digit lead fields and a 4- or 2-digit year
+// (d/d/yyyy, d/d/yy, `/ . -` separators), optionally followed by a time —
+// comma- or space-separated `hh:mm`, with optional seconds (e.g.
+// "01/01/26, 10:58" as exported by some money apps). Which lead field is the
+// day vs the month is intrinsically ambiguous, so it is resolved at the
+// column level via `DateColumnFormat.fieldOrder`.
+const AMBIGUOUS_DMY = /^(\d{1,2})[/.-](\d{1,2})[/.-](\d{4}|\d{2})(?:(?:,\s*|\s+)(\d{1,2}):(\d{2})(?::(\d{2}))?)?$/;
+
+// First separator character of an ambiguous-family value, for option labels.
+const AMBIGUOUS_SEPARATOR = /^\d{1,2}([/.-])/;
 
 function isValidCalendarDate({ year, month, day }: { year: number; month: number; day: number }): boolean {
   if (month < 1 || month > 12) return false;
@@ -79,6 +89,22 @@ function isValidCalendarDate({ year, month, day }: { year: number; month: number
   return day <= daysInMonth;
 }
 
+// POSIX-style pivot: bank/app exports realistically span 1970–2069, so `26`
+// reads as 2026 and `99` as 1999.
+function resolveAmbiguousYear(yearStr: string): number {
+  const year = Number(yearStr);
+  if (yearStr.length === 4) return year;
+  return year >= 70 ? 1900 + year : 2000 + year;
+}
+
+/** True when the value is an ISO date/datetime or compact YYYYMMDD — shapes
+ *  that carry their field order intrinsically and ignore `fieldOrder`. */
+export function isIntrinsicallyOrdered({ value }: { value: string }): boolean {
+  return (
+    ISO_ZONED_DATETIME.test(value) || ISO_LOCAL_DATETIME.test(value) || ISO_DATE.test(value) || COMPACT_DATE.test(value)
+  );
+}
+
 export function parseImportDate({ value, format }: ParseImportDateParams): ParsedImportDate | null {
   if (ISO_ZONED_DATETIME.test(value)) {
     return { kind: 'instant', instant: new Date(value) };
@@ -87,6 +113,7 @@ export function parseImportDate({ value, format }: ParseImportDateParams): Parse
   const localMatch = value.match(ISO_LOCAL_DATETIME);
   if (localMatch) {
     const [, year, month, day, hour, minute, second, fraction] = localMatch;
+    if (!isValidCalendarDate({ year: Number(year), month: Number(month), day: Number(day) })) return null;
     return {
       kind: 'localDateTime',
       year: Number(year),
@@ -123,53 +150,73 @@ export function parseImportDate({ value, format }: ParseImportDateParams): Parse
 
   const ambiguousMatch = value.match(AMBIGUOUS_DMY);
   if (ambiguousMatch) {
-    const [, firstStr, secondStr, yearStr] = ambiguousMatch;
+    const [, firstStr, secondStr, yearStr, hourStr, minuteStr, secondsStr] = ambiguousMatch;
     const first = Number(firstStr);
     const second = Number(secondStr);
-    const year = Number(yearStr);
+    const year = resolveAmbiguousYear(yearStr!);
     // The whole column shares one order, so a leading field is the day or the
     // month consistently — never re-guessed per value.
     const day = format.fieldOrder === 'day-first' ? first : second;
     const month = format.fieldOrder === 'day-first' ? second : first;
-    if (isValidCalendarDate({ year, month, day })) {
+    if (!isValidCalendarDate({ year, month, day })) return null;
+
+    if (hourStr === undefined) {
       return { kind: 'dateOnly', year, month, day };
     }
+    const hour = Number(hourStr);
+    const minute = Number(minuteStr);
+    const seconds = secondsStr === undefined ? 0 : Number(secondsStr);
+    // Same no-rollover rule as dates: an impossible time fails loudly instead
+    // of snapping into the next hour/day.
+    if (hour > 23 || minute > 59 || seconds > 59) return null;
+    return { kind: 'localDateTime', year, month, day, hour, minute, second: seconds, ms: 0 };
   }
 
   return null;
 }
 
 /**
- * Suggests a day/month order for a whole date column. This is a SUGGESTION
- * algorithm, not the authority: the CSV import path parses with the
- * `dateFieldOrder` the user explicitly confirmed in the wizard (the frontend
- * mirrors this detection to pre-suggest an option there). Kept canonical here
- * so client and server infer signals identically.
+ * Day/month-order signals carried by a column's cells. Only the ambiguous
+ * d/d/yyyy family is informative: a lead field above 12 can only be a day
+ * (→ day-first); a second field above 12 can only be a month-position day
+ * (→ month-first). All other shapes are intrinsically ordered and contribute
+ * nothing.
  */
-export function detectDateColumnFormat({ values, locale }: DetectDateColumnFormatParams): DetectDateColumnFormatResult {
-  let sawDayFirstSignal = false;
-  let sawMonthFirstSignal = false;
+export function detectDateOrderSignals({ values }: { values: string[] }): {
+  sawDayFirst: boolean;
+  sawMonthFirst: boolean;
+} {
+  let sawDayFirst = false;
+  let sawMonthFirst = false;
 
-  // Only the ambiguous d/d/yyyy family carries order ambiguity. A lead field
-  // above 12 can only be a day (→ day-first); a second field above 12 can only
-  // be a month-position day (→ month-first). All other shapes are intrinsically
-  // ordered and contribute no signal.
   for (const value of values) {
     const match = value.match(AMBIGUOUS_DMY);
     if (!match) continue;
     const first = Number(match[1]);
     const second = Number(match[2]);
-    if (first > 12) sawDayFirstSignal = true;
-    if (second > 12) sawMonthFirstSignal = true;
+    if (first > 12) sawDayFirst = true;
+    if (second > 12) sawMonthFirst = true;
   }
 
-  if (sawDayFirstSignal && sawMonthFirstSignal) {
+  return { sawDayFirst, sawMonthFirst };
+}
+
+/**
+ * Suggests a day/month order for a whole date column. This is a SUGGESTION
+ * algorithm, not the authority: the CSV import path parses with the
+ * `dateFieldOrder` the user explicitly confirmed in the wizard (the frontend
+ * builds its pre-suggestion on the same signals via `detectDateOrderSignals`).
+ */
+export function detectDateColumnFormat({ values, locale }: DetectDateColumnFormatParams): DetectDateColumnFormatResult {
+  const { sawDayFirst, sawMonthFirst } = detectDateOrderSignals({ values });
+
+  if (sawDayFirst && sawMonthFirst) {
     return { ok: false, reason: 'mixed' };
   }
-  if (sawDayFirstSignal) {
+  if (sawDayFirst) {
     return { ok: true, format: { fieldOrder: 'day-first' } };
   }
-  if (sawMonthFirstSignal) {
+  if (sawMonthFirst) {
     return { ok: true, format: { fieldOrder: 'month-first' } };
   }
 
@@ -178,4 +225,18 @@ export function detectDateColumnFormat({ values, locale }: DetectDateColumnForma
   // writes day-first (DD/MM). Only a suggestion — the user still confirms.
   const fieldOrder = locale === 'en' ? 'month-first' : 'day-first';
   return { ok: true, format: { fieldOrder } };
+}
+
+/**
+ * Separator of the first ambiguous-family cell (`.`, `/` or `-`), used to
+ * render wizard option examples with the column's actual separator. `null`
+ * when no ambiguous-family cell exists.
+ */
+export function detectAmbiguousDateSeparator({ values }: { values: string[] }): string | null {
+  for (const value of values) {
+    if (!AMBIGUOUS_DMY.test(value)) continue;
+    const match = value.match(AMBIGUOUS_SEPARATOR);
+    if (match?.[1]) return match[1];
+  }
+  return null;
 }

--- a/packages/shared/src/types/budget-bakers-wallet-import.ts
+++ b/packages/shared/src/types/budget-bakers-wallet-import.ts
@@ -202,10 +202,13 @@ export interface ParseBudgetBakersWalletResponse {
  *    (captured before importing, restored via `updateAccount` afterwards).
  *    Only accounts with the same currency as the CSV account are selectable
  *    in the UI.
+ *  - `skip` — the account and all its rows are left out of the import, along
+ *    with every transfer that touches it.
  */
 export type BudgetBakersWalletAccountMappingValue =
   | { action: 'create-new'; currencyCode: string; currentBalance: number | null }
-  | { action: 'link-existing'; accountId: string };
+  | { action: 'link-existing'; accountId: string }
+  | { action: 'skip' };
 
 /** Keyed by `BudgetBakersWalletParseAccount.originalName`. */
 export type BudgetBakersWalletAccountMapping = Record<string, BudgetBakersWalletAccountMappingValue>;
@@ -281,6 +284,8 @@ export type BudgetBakersWalletImportError = ImportError;
 export interface BudgetBakersWalletImportSummary extends ImportSummaryBase {
   accountsCreated: number;
   accountsLinked: number;
+  /** Number of source accounts mapped to skip. Optional: retained results predate the field. */
+  accountsSkipped?: number;
   categoriesCreated: number;
   payeesCreated: number;
   tagsCreated: number;

--- a/packages/shared/src/types/import-export.ts
+++ b/packages/shared/src/types/import-export.ts
@@ -200,10 +200,12 @@ export interface ExtractUniqueValuesResponse {
  * imported rows sum to. Required-but-nullable (not optional) so every
  * create-new mapping states the balance explicitly, matching the Wallet
  * importer's `BudgetBakersWalletAccountMappingValue.currentBalance`.
+ * `skip` excludes the source account and all of its rows from the import.
  */
 export type AccountMappingValue =
   | { action: 'create-new'; currentBalance: number | null }
-  | { action: 'link-existing'; accountId: string };
+  | { action: 'link-existing'; accountId: string }
+  | { action: 'skip' };
 
 export type AccountMappingConfig = Record<string, AccountMappingValue>;
 
@@ -460,6 +462,8 @@ export interface CsvImportSummary extends ImportSummaryBase {
   /** Number of unpriceable rows skipped (from skipUnpriceableIndices) */
   skippedUnpriceable: number;
   accountsCreated: number;
+  /** Number of source accounts mapped to skip. Optional: retained results predate the field. */
+  accountsSkipped?: number;
   categoriesCreated: number;
   tagsCreated: number;
   /** Number of Payees inserted by this import. Reused/linked Payees don't count. */

--- a/packages/shared/src/types/import-export.ts
+++ b/packages/shared/src/types/import-export.ts
@@ -224,6 +224,26 @@ export type CategoryMappingValue = { action: 'create-new' } | { action: 'link-ex
 
 export type CategoryMappingConfig = Record<string, CategoryMappingValue>;
 
+/** Cap on remembered category presets per user — they all live in one settings row. */
+export const MAX_CATEGORY_MAPPING_PRESETS = 20;
+
+/**
+ * A category mapping remembered from a finished import, so a later import from the
+ * same source can re-apply it. One preset per fingerprint, newest wins.
+ */
+export interface CategoryMappingPreset {
+  /**
+   * Identifies a source layout: sha256 of the header row for CSV, a constant per
+   * fixed-layout source otherwise.
+   */
+  fingerprint: string;
+  /** User-given label. Named presets survive cap eviction and can be applied to any source. */
+  name?: string;
+  categoryMapping: CategoryMappingConfig;
+  /** ISO timestamp of the import that wrote this preset. */
+  updatedAt: string;
+}
+
 /** A single row that cannot be priced by the exchange-rate layer. */
 export interface UnpriceableRow {
   rowIndex: number;

--- a/packages/shared/src/types/import-export.ts
+++ b/packages/shared/src/types/import-export.ts
@@ -210,6 +210,14 @@ export type AccountMappingValue =
 export type AccountMappingConfig = Record<string, AccountMappingValue>;
 
 /**
+ * Keyed by source category name; the value is the matched existing category id,
+ * or null when the AI found no reasonable match.
+ */
+export interface AiMapImportCategoriesResponse {
+  mappings: Record<string, string | null>;
+}
+
+/**
  * Category mapping for import - maps CSV category name to action
  */
 export type CategoryMappingValue = { action: 'create-new' } | { action: 'link-existing'; categoryId: string };

--- a/packages/shared/src/types/ynab-import.ts
+++ b/packages/shared/src/types/ynab-import.ts
@@ -149,10 +149,11 @@ export interface ParseYnabResponse {
   result: YnabParseResult;
 }
 
-/** Per-account currency override the user confirms in the preview step.
- *  The wizard always creates fresh accounts — no opt-in to merge into an
- *  existing app account — so currency is the only decision left to make. */
-export type YnabAccountMappingValue = { currencyCode: string };
+/** Per-account decision the user confirms in the preview step. The wizard always
+ *  creates fresh accounts, with no opt-in to merge into an existing app account.
+ *  A skipped account keeps its `currencyCode` so unskipping restores the picker's
+ *  value; the executor ignores it. */
+export type YnabAccountMappingValue = { currencyCode: string; skip?: boolean };
 
 /** Keyed by `YnabParseAccount.originalName`. */
 export type YnabAccountMapping = Record<string, YnabAccountMappingValue>;
@@ -174,6 +175,8 @@ export type YnabImportJobStatus = ImportJobStatus;
 /** Cumulative numbers reported once the worker finishes. */
 export interface YnabImportSummary {
   accountsCreated: number;
+  /** Number of source accounts mapped to skip. Optional: retained results predate the field. */
+  accountsSkipped?: number;
   categoriesCreated: number;
   payeesCreated: number;
   tagsCreated: number;


### PR DESCRIPTION
- allows to skip accounts upon import
- adds AI category mapping action
- fixes issues related to DB on CI
- stores previous categoris mappings as templates, so user can simply reuse them next time
- fixes parsing CSV files with date format of /yy instead of /yyyy