### PR TITLE
fix(oauth): delete OAuth tokens when a connected app is revoked

### DIFF
--- a/packages/backend/src/services/mcp/connected-apps.e2e.ts
+++ b/packages/backend/src/services/mcp/connected-apps.e2e.ts
@@ -38,7 +38,7 @@ describe('MCP Connected Apps API', () => {
     it('returns each connected app with its fields, and a null lastUsedAt when it has no access tokens', async () => {
       const withToken = await mcpHelpers.createTestOAuthClient();
       await mcpHelpers.createTestOAuthConsent({ clientId: withToken.clientId });
-      await mcpHelpers.createTestOAuthAccessToken({ clientId: withToken.id });
+      await mcpHelpers.createTestOAuthAccessToken({ clientId: withToken.clientId });
 
       const withoutToken = await mcpHelpers.createTestOAuthClient({
         id: 'test-internal-client-id-2',
@@ -75,14 +75,17 @@ describe('MCP Connected Apps API', () => {
     it('revokes a connected app, removing it from the list and deleting its auth-DB records', async () => {
       const client = await mcpHelpers.createTestOAuthClient();
       await mcpHelpers.createTestOAuthConsent({ clientId: client.clientId });
-      await mcpHelpers.createTestOAuthAccessToken({ clientId: client.id });
+      // Tokens key off the public clientId, exactly as better-auth writes them.
+      await mcpHelpers.createTestOAuthAccessToken({ clientId: client.clientId });
+      await mcpHelpers.createTestOAuthRefreshToken({ clientId: client.clientId });
 
       const appsBefore = await mcpHelpers.getConnectedApps({ raw: true });
       expect(appsBefore).toHaveLength(1);
       const countsBefore = await mcpHelpers.getTestOAuthRecordCounts({
-        internalClientId: client.id,
+        clientId: client.clientId,
       });
       expect(countsBefore.accessTokens).toBe(1);
+      expect(countsBefore.refreshTokens).toBe(1);
       expect(countsBefore.consents).toBe(1);
 
       const res: CustomResponse<{ success: boolean }> = await mcpHelpers.revokeConnectedApp({
@@ -96,9 +99,12 @@ describe('MCP Connected Apps API', () => {
       const appsAfter = await mcpHelpers.getConnectedApps({ raw: true });
       expect(appsAfter).toEqual([]);
       const countsAfter = await mcpHelpers.getTestOAuthRecordCounts({
-        internalClientId: client.id,
+        clientId: client.clientId,
       });
+      // The access token (72h TTL) and refresh token (60d TTL) must both be gone —
+      // otherwise the integration keeps authenticating after the user revokes it.
       expect(countsAfter.accessTokens).toBe(0);
+      expect(countsAfter.refreshTokens).toBe(0);
       expect(countsAfter.consents).toBe(0);
     });
   });

--- a/packages/backend/src/services/mcp/connected-apps.ts
+++ b/packages/backend/src/services/mcp/connected-apps.ts
@@ -20,8 +20,8 @@ interface ConnectedAppRow {
   lastUsedAt: string | null;
 }
 
-interface ClientIdRow {
-  id: string;
+interface ClientExistsRow {
+  clientId: string;
 }
 
 /**
@@ -38,7 +38,7 @@ export async function getConnectedApps({ authUserId }: { authUserId: string }): 
        (
          SELECT MAX(at."createdAt")
          FROM "ba_oauth_access_token" at
-         WHERE at."clientId" = c."id" AND at."userId" = $1
+         WHERE at."clientId" = c."clientId" AND at."userId" = $1
        ) AS "lastUsedAt"
      FROM "ba_oauth_consent" con
      JOIN "ba_oauth_client" c ON con."clientId" = c."clientId"
@@ -67,9 +67,10 @@ export async function revokeConnectedApp({
   authUserId: string;
   clientId: string;
 }): Promise<void> {
-  // Get the internal client ID from the public clientId
-  const clientResult = await authPool.query<ClientIdRow>(
-    `SELECT "id" FROM "ba_oauth_client" WHERE "clientId" = $1 LIMIT 1`,
+  // Confirm the client exists so an unknown clientId is a 404 rather than a
+  // silent no-op.
+  const clientResult = await authPool.query<ClientExistsRow>(
+    `SELECT "clientId" FROM "ba_oauth_client" WHERE "clientId" = $1 LIMIT 1`,
     [clientId],
   );
 
@@ -77,18 +78,21 @@ export async function revokeConnectedApp({
     throw new NotFoundError({ message: 'Client not found' });
   }
 
-  const internalClientId = clientResult.rows[0]!.id;
-
-  // Delete all tokens and consent in a transaction
+  // The token and consent rows all key off the *public* clientId: the
+  // oauth-provider schema declares ba_oauth_access_token.clientId and
+  // ba_oauth_refresh_token.clientId as references to ba_oauth_client.clientId
+  // (not .id), and better-auth writes `client.clientId` into them on issue.
+  // Filtering by the internal ba_oauth_client.id matches zero token rows, which
+  // left the access token (72h) and refresh token (60d) usable after "revoke".
   const client = await authPool.connect();
   try {
     await client.query('BEGIN');
     await client.query(`DELETE FROM "ba_oauth_access_token" WHERE "clientId" = $1 AND "userId" = $2`, [
-      internalClientId,
+      clientId,
       authUserId,
     ]);
     await client.query(`DELETE FROM "ba_oauth_refresh_token" WHERE "clientId" = $1 AND "userId" = $2`, [
-      internalClientId,
+      clientId,
       authUserId,
     ]);
     await client.query(`DELETE FROM "ba_oauth_consent" WHERE "clientId" = $1 AND "userId" = $2`, [

--- a/packages/backend/src/tests/helpers/mcp.ts
+++ b/packages/backend/src/tests/helpers/mcp.ts
@@ -125,12 +125,13 @@ export async function createTestOAuthConsent({
 
 /**
  * Insert a test OAuth access token into `ba_oauth_access_token`.
- * Note: `clientId` here stores the **internal id** (from `ba_oauth_client.id`).
+ * Note: `clientId` here stores the **public clientId** (from `ba_oauth_client.clientId`),
+ * matching what better-auth's oauth-provider writes on token issue.
  */
 export async function createTestOAuthAccessToken({
   id = 'test-access-token-id',
   token = 'test-access-token-value',
-  clientId = 'test-internal-client-id',
+  clientId = 'test-public-client-id',
   userId = TEST_AUTH_USER_ID,
   scopes = '["finance:read","profile:read"]',
 }: {
@@ -149,6 +150,32 @@ export async function createTestOAuthAccessToken({
 }
 
 /**
+ * Insert a test OAuth refresh token into `ba_oauth_refresh_token`.
+ * Note: `clientId` here stores the **public clientId** (from `ba_oauth_client.clientId`),
+ * matching what better-auth's oauth-provider writes on token issue.
+ */
+export async function createTestOAuthRefreshToken({
+  id = 'test-refresh-token-id',
+  token = 'test-refresh-token-value',
+  clientId = 'test-public-client-id',
+  userId = TEST_AUTH_USER_ID,
+  scopes = '["finance:read","profile:read"]',
+}: {
+  id?: string;
+  token?: string;
+  clientId?: string;
+  userId?: string;
+  scopes?: string;
+} = {}): Promise<void> {
+  await authPool.query(
+    `INSERT INTO "ba_oauth_refresh_token" (id, token, "clientId", "userId", scopes, "expiresAt", "createdAt")
+     VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '60 days', NOW())
+     ON CONFLICT DO NOTHING`,
+    [id, token, clientId, userId, scopes],
+  );
+}
+
+/**
  * Clean up all test OAuth data from auth tables.
  * Deletes in dependency order to avoid FK constraint errors.
  */
@@ -160,16 +187,22 @@ export async function cleanupTestOAuthData(): Promise<void> {
 }
 
 /**
- * Query the auth DB to count remaining OAuth records for the test user.
+ * Query the auth DB to count remaining OAuth records for the test user, keyed on
+ * the **public clientId** (the value the token/consent rows actually store).
  * Useful for asserting that revocation cleaned up all records.
  */
-export async function getTestOAuthRecordCounts({ internalClientId }: { internalClientId: string }): Promise<{
+export async function getTestOAuthRecordCounts({ clientId }: { clientId: string }): Promise<{
   accessTokens: number;
+  refreshTokens: number;
   consents: number;
 }> {
   const accessTokenResult = await authPool.query(
     `SELECT COUNT(*)::int AS count FROM "ba_oauth_access_token" WHERE "clientId" = $1 AND "userId" = $2`,
-    [internalClientId, TEST_AUTH_USER_ID],
+    [clientId, TEST_AUTH_USER_ID],
+  );
+  const refreshTokenResult = await authPool.query(
+    `SELECT COUNT(*)::int AS count FROM "ba_oauth_refresh_token" WHERE "clientId" = $1 AND "userId" = $2`,
+    [clientId, TEST_AUTH_USER_ID],
   );
   const consentResult = await authPool.query(
     `SELECT COUNT(*)::int AS count FROM "ba_oauth_consent" WHERE "userId" = $1`,
@@ -178,6 +211,7 @@ export async function getTestOAuthRecordCounts({ internalClientId }: { internalC
 
   return {
     accessTokens: accessTokenResult.rows[0]?.count ?? 0,
+    refreshTokens: refreshTokenResult.rows[0]?.count ?? 0,
     consents: consentResult.rows[0]?.count ?? 0,
   };
 }


### PR DESCRIPTION
Revoking a connected MCP app (Settings → AI Integrations → "Revoke") returns
`200` and removes the app from the list, but **the OAuth tokens stay valid** —
the access token for its full 72h TTL, the refresh token for 60 days. The
integration keeps working, and can still refresh itself, after being revoked.

## Cause

`revokeConnectedApp()` deletes tokens filtered by the internal
`ba_oauth_client.id`:

```js
const internalClientId = clientResult.rows[0].id;
DELETE FROM "ba_oauth_access_token"  WHERE "clientId" = $1   // $1 = internalClientId
DELETE FROM "ba_oauth_refresh_token" WHERE "clientId" = $1   // $1 = internalClientId
DELETE FROM "ba_oauth_consent"       WHERE "clientId" = $1   // $1 = public clientId ✅
```

But those token columns store the **public** clientId (better-auth's schema
references `oauthClient.clientId`, and it writes `client.clientId` on issue).
So the two token deletes match zero rows; only the consent delete works —
which is why the app disappears from the UI while the tokens live on.

Verified on a live instance: the token row's `clientId` equals the public id,
never the internal one, so the delete predicate can't match.

## Why the test didn't catch it

`connected-apps.e2e.ts` seeded the token with `clientId: client.id` (internal)
and counted by the same value — the fixture shared the bug's wrong assumption,
so the broken `DELETE` matched it and the test passed.

## Fix

- `revokeConnectedApp`: filter all three deletes by the public `clientId`.
- `getConnectedApps`: same bug in the `lastUsedAt` subquery (`at.clientId =
  c.id`) — it was always `null`. Now joins on `c.clientId`.
- Tests: fixtures now use the public `clientId` like better-auth does; the
  revoke test also seeds and asserts a refresh token. Fails on `dev`, passes
  here.

## Follow-up (separate)

`verifyAccessToken` doesn't check `client.disabled`, the audience, or an
existing consent row — weaker than better-auth's own `validateOpaqueAccessToken`.
A consent check there would make revocation robust against a missed delete.
