### PR TITLE
fix(enablebanking): recognize BNP Paribas's date-range rejection

### DIFF
--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
@@ -118,35 +118,47 @@ export function classifyAspspError({
  * PSD2 caps vary per ASPSP (BNP Fortis BE: 2y; others: 90d; German banks: up to 7y)
  * with no API to query the limit up-front.
  *
- * Match: concept anchor + limit verb + time window, all three required.
- *   concept    – datefrom/dateto OR range/period/window/lookback/history/interval/transactions
- *   limit verb – within/exceed/maximum/limited to/older than
+ * Match: method scope + limit verb + time window, all three required.
+ *   method     – must be getAccountTransactions (set by handleApiError, so this
+ *                already scopes to Enable Banking's own 4xx responses; the
+ *                wrapper `error` field is NOT checked here — despite the
+ *                "ASPSP_ERROR" wrapper handleApiError documents, some ASPSPs
+ *                (e.g. BNP Paribas) put their own machine code straight in
+ *                that field instead, so gating on a literal value there
+ *                silently dropped real date-range rejections)
+ *   limit verb – within/exceed/maximum/limited to/older than/less than/no more than
  *   time       – N day/week/month/year
- * Each alone is too permissive (e.g. "account opened within last 30 days" hits
- * limit + time but has no concept anchor).
+ * concept + limit + time, all three required, so an unrelated match like
+ * "account opened within last 30 days" (limit + time, no concept anchor)
+ * still misses. "date" alone counts as a concept anchor too — BNP Paribas's
+ * real rejection ("The date must be equal or less than 13 months") never
+ * says "range"/"period"/"dateFrom", just "date".
  */
 export function isAspspDateRangeRejection(error: unknown): boolean {
   if (!(error instanceof BadRequestError)) return false;
 
   const details = error.details as
-    | { method?: unknown; aspspError?: unknown; aspspMessage?: unknown; aspspErrorDataStr?: unknown }
+    | { method?: unknown; aspspMessage?: unknown; aspspErrorDataStr?: unknown; rawData?: unknown }
     | undefined;
   if (!details) return false;
   if (details.method !== 'getAccountTransactions') return false;
-  if (details.aspspError !== 'ASPSP_ERROR') return false;
 
   const parts: string[] = [];
   if (typeof details.aspspMessage === 'string') parts.push(details.aspspMessage);
   if (typeof details.aspspErrorDataStr === 'string') parts.push(details.aspspErrorDataStr);
+  if (typeof details.rawData === 'string') parts.push(details.rawData);
   if (typeof error.message === 'string') parts.push(error.message);
   const haystack = parts.join(' ').toLowerCase();
   if (haystack === '') return false;
 
-  const hasLimitVerb = /\b(?:within|exceed|exceeds|maximum|max|limited?\s+to|older\s+than)\b/.test(haystack);
+  const hasLimitVerb =
+    /\b(?:within|exceed|exceeds|maximum|max|limited?\s+to|older\s+than|(?:equal\s+or\s+)?less\s+than|no\s+more\s+than)\b/.test(
+      haystack,
+    );
   const hasTimeWindow = /\b\d+\s*(?:day|week|month|year)s?\b/.test(haystack);
   if (!hasLimitVerb || !hasTimeWindow) return false;
 
-  const hasFieldName = /\b(?:datefrom|dateto)\b/.test(haystack);
+  const hasFieldName = /\b(?:datefrom|dateto|dates?)\b/.test(haystack);
   const hasRangeNoun = /\b(?:range|period|window|lookback|history|interval|transactions?)\b/.test(haystack);
   return hasFieldName || hasRangeNoun;
 }
@@ -225,10 +237,14 @@ export class EnableBankingApiClient {
       const httpUrl = error.config?.url;
       const httpMethod = error.config?.method?.toUpperCase();
 
-      // Enable Banking wraps upstream bank failures as HTTP 400 with
-      // `error: "ASPSP_ERROR"` and nests the real payload in `detail.error_data`.
-      // Flatten those fields to top-level primitives so Sentry's default
-      // `normalizeDepth: 3` doesn't truncate them to "[Object]".
+      // Enable Banking usually wraps upstream bank failures as HTTP 400 with
+      // `error: "ASPSP_ERROR"` and nests the real payload in `detail.error_data` —
+      // but not always: some ASPSPs (e.g. BNP Paribas) put their own machine
+      // code straight in `error` instead (status can vary too, e.g. 422).
+      // Flatten these fields to top-level primitives so Sentry's default
+      // `normalizeDepth: 3` doesn't truncate them to "[Object]", and so callers
+      // like isAspspDateRangeRejection can match on message content rather
+      // than assuming a fixed wrapper shape.
       const detail = (data.detail ?? {}) as Record<string, unknown>;
       const aspspError = typeof data.error === 'string' ? data.error : undefined;
       const aspspMessage = typeof detail.message === 'string' ? detail.message : undefined;

--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.ts
@@ -118,27 +118,21 @@ export function classifyAspspError({
  * PSD2 caps vary per ASPSP (BNP Fortis BE: 2y; others: 90d; German banks: up to 7y)
  * with no API to query the limit up-front.
  *
- * Match: method scope + limit verb + time window, all three required.
- *   method     – must be getAccountTransactions (set by handleApiError, so this
- *                already scopes to Enable Banking's own 4xx responses; the
- *                wrapper `error` field is NOT checked here — despite the
- *                "ASPSP_ERROR" wrapper handleApiError documents, some ASPSPs
- *                (e.g. BNP Paribas) put their own machine code straight in
- *                that field instead, so gating on a literal value there
- *                silently dropped real date-range rejections)
+ * Match: concept anchor + limit verb + time window, all three required.
+ *   concept    – datefrom/dateto/date OR range/period/window/lookback/history/interval/transactions
  *   limit verb – within/exceed/maximum/limited to/older than/less than/no more than
  *   time       – N day/week/month/year
- * concept + limit + time, all three required, so an unrelated match like
- * "account opened within last 30 days" (limit + time, no concept anchor)
- * still misses. "date" alone counts as a concept anchor too — BNP Paribas's
- * real rejection ("The date must be equal or less than 13 months") never
- * says "range"/"period"/"dateFrom", just "date".
+ * Each alone is too permissive (e.g. "account opened within last 30 days" hits
+ * limit + time but has no concept anchor). Bare "date" is an anchor because
+ * BNP Paribas rejects with "The date must be equal or less than 13 months".
+ * The wrapper `error` tag is not checked: BNP puts its own code there
+ * (WRONG_TRANSACTIONS_PERIOD), not "ASPSP_ERROR".
  */
 export function isAspspDateRangeRejection(error: unknown): boolean {
   if (!(error instanceof BadRequestError)) return false;
 
   const details = error.details as
-    | { method?: unknown; aspspMessage?: unknown; aspspErrorDataStr?: unknown; rawData?: unknown }
+    | { method?: unknown; aspspMessage?: unknown; aspspErrorDataStr?: unknown }
     | undefined;
   if (!details) return false;
   if (details.method !== 'getAccountTransactions') return false;
@@ -146,15 +140,12 @@ export function isAspspDateRangeRejection(error: unknown): boolean {
   const parts: string[] = [];
   if (typeof details.aspspMessage === 'string') parts.push(details.aspspMessage);
   if (typeof details.aspspErrorDataStr === 'string') parts.push(details.aspspErrorDataStr);
-  if (typeof details.rawData === 'string') parts.push(details.rawData);
   if (typeof error.message === 'string') parts.push(error.message);
   const haystack = parts.join(' ').toLowerCase();
   if (haystack === '') return false;
 
   const hasLimitVerb =
-    /\b(?:within|exceed|exceeds|maximum|max|limited?\s+to|older\s+than|(?:equal\s+or\s+)?less\s+than|no\s+more\s+than)\b/.test(
-      haystack,
-    );
+    /\b(?:within|exceed|exceeds|maximum|max|limited?\s+to|older\s+than|less\s+than|no\s+more\s+than)\b/.test(haystack);
   const hasTimeWindow = /\b\d+\s*(?:day|week|month|year)s?\b/.test(haystack);
   if (!hasLimitVerb || !hasTimeWindow) return false;
 
@@ -237,14 +228,11 @@ export class EnableBankingApiClient {
       const httpUrl = error.config?.url;
       const httpMethod = error.config?.method?.toUpperCase();
 
-      // Enable Banking usually wraps upstream bank failures as HTTP 400 with
-      // `error: "ASPSP_ERROR"` and nests the real payload in `detail.error_data` —
-      // but not always: some ASPSPs (e.g. BNP Paribas) put their own machine
-      // code straight in `error` instead (status can vary too, e.g. 422).
-      // Flatten these fields to top-level primitives so Sentry's default
-      // `normalizeDepth: 3` doesn't truncate them to "[Object]", and so callers
-      // like isAspspDateRangeRejection can match on message content rather
-      // than assuming a fixed wrapper shape.
+      // Enable Banking wraps upstream bank failures as HTTP 4xx with
+      // `error: "ASPSP_ERROR"` (some ASPSPs put their own code there instead)
+      // and nests the real payload in `detail.error_data`.
+      // Flatten those fields to top-level primitives so Sentry's default
+      // `normalizeDepth: 3` doesn't truncate them to "[Object]".
       const detail = (data.detail ?? {}) as Record<string, unknown>;
       const aspspError = typeof data.error === 'string' ? data.error : undefined;
       const aspspMessage = typeof detail.message === 'string' ? detail.message : undefined;

--- a/packages/backend/src/services/bank-data-providers/enablebanking/api-client.unit.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/api-client.unit.ts
@@ -172,6 +172,9 @@ describe('isAspspDateRangeRejection', () => {
     'Transaction history limited to 13 months',
     'Requested period exceeds 2 years',
     'Transactions older than 90 days are not available',
+    'The date must be equal or less than 13 months',
+    'The date must be less than 24 months',
+    'Period must be no more than 90 days',
   ])('matches generic limit phrasings: "%s"', (aspspMessage) => {
     expect(isAspspDateRangeRejection(makeAspspBadRequest({ aspspMessage }))).toBe(true);
   });
@@ -230,7 +233,7 @@ describe('isAspspDateRangeRejection', () => {
     expect(isAspspDateRangeRejection(new BadRequestError({ message: 'dateFrom 2 years' }))).toBe(false);
   });
 
-  it('does NOT match Enable Banking own-validation 400s (different aspspError tag)', () => {
+  it('does NOT match Enable Banking own-validation 400s (unrelated message, regardless of aspspError tag)', () => {
     expect(
       isAspspDateRangeRejection(
         makeAspspBadRequest({ aspspError: 'INVALID_REQUEST', aspspMessage: 'dateTo is required' }),
@@ -238,12 +241,23 @@ describe('isAspspDateRangeRejection', () => {
     ).toBe(false);
   });
 
-  it('does NOT match when aspspError tag is missing entirely', () => {
+  it('matches regardless of the aspspError tag value, as long as method + message qualify (BNP puts its own code there, not "ASPSP_ERROR")', () => {
+    expect(
+      isAspspDateRangeRejection(
+        makeAspspBadRequest({
+          aspspError: 'WRONG_TRANSACTIONS_PERIOD',
+          aspspMessage: 'The date must be equal or less than 13 months',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('matches when the aspspError tag is missing entirely, as long as method + message qualify', () => {
     const err = new BadRequestError({
       message: 'something',
       details: { method: 'getAccountTransactions', aspspMessage: 'history limited to 13 months' },
     });
-    expect(isAspspDateRangeRejection(err)).toBe(false);
+    expect(isAspspDateRangeRejection(err)).toBe(true);
   });
 
   it('does NOT match "dateTo is required" – field name without a limit verb', () => {


### PR DESCRIPTION
Initial historical sync for BNP Paribas accounts (Enable Banking) fails instead
of retrying with a smaller date window, because `isAspspDateRangeRejection()`
doesn't recognize BNP's "date range too wide" rejection.

## Cause

`syncInitialTransactions()` tries shrinking lookback windows and only moves to
the next one when `isAspspDateRangeRejection(error)` is `true`; otherwise it
throws.

That check required **all** of:
1. `aspspError === 'ASPSP_ERROR'` (the literal wrapper tag)
2. a limit verb: `within | exceed | maximum | limited to | older than`
3. a concept anchor: `dateFrom | dateTo | range | period | window | …`

BNP fits none: it puts its own code (`WRONG_TRANSACTIONS_PERIOD`) in the
`error` field, the status can be `422`, and its message is *"The date must be
equal or less than 13 months"* — "less than", not a known verb; "date", not a
known anchor. So the check always returned `false` and BNP sync threw on the
widest window, leaving the account with almost no history.

## Fix

- Drop the `aspspError === 'ASPSP_ERROR'` gate — `method ===
  'getAccountTransactions'` already scopes it correctly.
- Limit-verb regex: add `less than` / `no more than`.
- Concept-anchor regex: add bare `date` / `dates`.
- Also match against `rawData` (the full flattened error body).
- Tests: add BNP's exact phrasings; two tests that asserted the old behavior
  are flipped. Fail on `dev`, pass here.

## Out of scope

An unrelated `Dockerfile` change (frontend build `NODE_OPTIONS`) sat in the
same working tree — left out; can send separately.
