### PR TITLE
fix: vehicle value override failed error fix

### DIFF
--- a/packages/frontend/src/api/vehicles.ts
+++ b/packages/frontend/src/api/vehicles.ts
@@ -1,5 +1,5 @@
 import { api } from '@/api/_api';
-import type { AccountModel, DEPRECIATION_PRESET, RecordId, VEHICLE_CLASS } from '@bt/shared/types';
+import type { AccountModel, DEPRECIATION_PRESET, RecordId, TransactionModel, VEHICLE_CLASS } from '@bt/shared/types';
 
 export interface VehicleModel {
   id: RecordId;
@@ -80,3 +80,25 @@ export const updateVehicle = async ({
 export const deleteVehicle = async ({ id }: { id: string }) => {
   return api.delete(`/vehicles/${id}`);
 };
+
+/**
+ * Manual override. This is the ONLY sanctioned way to move a vehicle account's
+ * balance — the generic `POST /accounts/:id/balance-adjustment` path is rejected
+ * server-side because it would leave `valueAnchor` stale.
+ */
+export const overrideVehicleValue = async ({
+  id,
+  targetValue,
+  note,
+  time,
+}: {
+  id: string;
+  targetValue: number;
+  note?: string;
+  time?: Date;
+}): Promise<{
+  vehicle: VehicleModel | null;
+  transaction: TransactionModel | null;
+  previousBalance: number;
+  newBalance: number;
+}> => api.post(`/vehicles/${id}/value`, { targetValue, note, time });

--- a/packages/frontend/src/pages/account/components/balance-adjustment-dialog.test.ts
+++ b/packages/frontend/src/pages/account/components/balance-adjustment-dialog.test.ts
@@ -1,20 +1,26 @@
 import formsEn from '@/i18n/locales/chunks/en/forms.json';
 import accountEn from '@/i18n/locales/chunks/en/pages/account.json';
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import { createI18n } from 'vue-i18n';
 
 import BalanceAdjustmentDialog from './balance-adjustment-dialog.vue';
 
-/* ────────────────────────────── Hoisted mocks ────────────────────────── */
+/* ──────────────────────── Hoisted mocks ────────────────── */
 
-const { mockMutateAsync, mockAddSuccess, mockAddError } = vi.hoisted(() => ({
+const { mockMutateAsync, mockOverrideVehicleValue, mockAddSuccess, mockAddError } = vi.hoisted(() => ({
   mockMutateAsync: vi.fn(),
+  mockOverrideVehicleValue: vi.fn(),
   mockAddSuccess: vi.fn(),
   mockAddError: vi.fn(),
 }));
 
-/* ────────────────────────────── Module mocks ─────────────────────────── */
+/* ──────────────────────── Module mocks ─────────────────── */
+
+vi.mock('@/api/vehicles', () => ({
+  overrideVehicleValue: mockOverrideVehicleValue,
+}));
 
 vi.mock('@/composable/use-account-display-balance', async () => {
   const { computed } = await import('vue');
@@ -102,16 +108,35 @@ const ACCOUNT = {
   type: 'system',
 };
 
+const VEHICLE_ACCOUNT = {
+  id: 99,
+  name: 'Test Vehicle',
+  currentBalance: 20000,
+  currencyCode: 'USD',
+  type: 'system',
+  accountCategory: 'vehicle',
+};
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const mountDialog = (overrides: Record<string, unknown> = {}) =>
+const mountDialog = (overrides: Record<string, unknown> = {}, props: Record<string, unknown> = {}) =>
   mount(BalanceAdjustmentDialog, {
-    props: { account: { ...ACCOUNT, ...overrides } as any },
-    global: { plugins: [i18n] },
+    props: { account: { ...ACCOUNT, ...overrides } as any, ...props },
+    global: {
+      plugins: [
+        i18n,
+        [VueQueryPlugin, { queryClient: new QueryClient({ defaultOptions: { queries: { retry: false } } }) }],
+      ],
+    },
   });
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
 const confirmBtn = (w: VueWrapper) =>
   w.findAll('button').find((b) => b.text().trim() === t('pages.account.balanceAdjustmentDialog.confirm'))!;
+
+// A vehicle account swaps the whole dialog's copy for `pages.vehicleDetails.valueOverrideDialog`
+// (see `label()` in the component), so its confirm button reads "Save value", not "Confirm".
+const vehicleConfirmBtn = (w: VueWrapper) =>
+  w.findAll('button').find((b) => b.text().trim() === t('pages.vehicleDetails.valueOverrideDialog.confirm'))!;
 
 const amountInput = (w: VueWrapper) => w.find('input[type="number"]');
 
@@ -121,6 +146,13 @@ const enterAmountAndSubmit = async (w: VueWrapper, amount: number | string) => {
   await amountInput(w).setValue(String(amount));
   await nextTick();
   await confirmBtn(w).trigger('click');
+  await flushPromises();
+};
+
+const enterAmountAndSubmitVehicle = async (w: VueWrapper, amount: number | string) => {
+  await amountInput(w).setValue(String(amount));
+  await nextTick();
+  await vehicleConfirmBtn(w).trigger('click');
   await flushPromises();
 };
 
@@ -141,6 +173,12 @@ describe('BalanceAdjustmentDialog', () => {
       transaction: { id: 1 },
       previousBalance: 1000,
       newBalance: 1500,
+    });
+    mockOverrideVehicleValue.mockResolvedValue({
+      vehicle: { id: 7 },
+      transaction: { id: 2 },
+      previousBalance: 20000,
+      newBalance: 25000,
     });
   });
 
@@ -317,6 +355,41 @@ describe('BalanceAdjustmentDialog', () => {
       // Amount cleared, confirm disabled again
       expect((amountInput(w).element as HTMLInputElement).value).toBe('');
       expect(confirmBtn(w).attributes('disabled')).toBeDefined();
+    });
+  });
+
+  describe('vehicle override', () => {
+    // Regression test: a vehicle account must never go through the generic
+    // POST /accounts/:id/balance-adjustment path — the backend rejects it with
+    // 422 (`balanceAdjustment.vehicleUseOverride`), because only the dedicated
+    // POST /vehicles/:id/value endpoint keeps `Vehicle.valueAnchor` in sync.
+    it('calls overrideVehicleValue with the vehicle id, not the generic balance-adjustment mutation', async () => {
+      const w = mountDialog(VEHICLE_ACCOUNT, { vehicleId: '7' });
+      await enterAmountAndSubmitVehicle(w, 25000);
+
+      expect(mockOverrideVehicleValue).toHaveBeenCalledWith(
+        expect.objectContaining({ id: '7', targetValue: 25000, note: undefined }),
+        expect.anything(),
+      );
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('shows success notification and closes on successful override', async () => {
+      const w = mountDialog(VEHICLE_ACCOUNT, { vehicleId: '7' });
+      await enterAmountAndSubmitVehicle(w, 25000);
+
+      expect(mockAddSuccess).toHaveBeenCalledWith(t('pages.vehicleDetails.valueOverrideDialog.successNotification'));
+      expect(w.emitted('close')).toHaveLength(1);
+    });
+
+    it('shows error notification when the override mutation rejects', async () => {
+      mockOverrideVehicleValue.mockRejectedValueOnce(new Error('Server error'));
+
+      const w = mountDialog(VEHICLE_ACCOUNT, { vehicleId: '7' });
+      await enterAmountAndSubmitVehicle(w, 25000);
+
+      expect(mockAddError).toHaveBeenCalledWith(t('pages.vehicleDetails.valueOverrideDialog.errorNotification'));
+      expect(w.emitted('close')).toBeUndefined();
     });
   });
 });

--- a/packages/frontend/src/pages/account/components/balance-adjustment-dialog.vue
+++ b/packages/frontend/src/pages/account/components/balance-adjustment-dialog.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { overrideVehicleValue } from '@/api/vehicles';
+import { VUE_QUERY_GLOBAL_PREFIXES } from '@/common/const';
 import ResponsiveDialog from '@/components/common/responsive-dialog.vue';
 import DateField from '@/components/fields/date-field.vue';
 import { InputField } from '@/components/fields';
@@ -13,13 +15,23 @@ import * as validators from '@/js/helpers/validators';
 import { captureException } from '@/lib/sentry';
 import { cn } from '@/lib/utils';
 import { ACCOUNT_CATEGORIES, AccountModel } from '@bt/shared/types';
+import { useMutation, useQueryClient } from '@tanstack/vue-query';
 import { computed, ref, toRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-const props = defineProps<{ account: AccountModel }>();
+/**
+ * `vehicleId` is required when `account` is a vehicle-category account — the
+ * vehicle's own id (not the account id) is what `POST /vehicles/:id/value`
+ * addresses. Callers on non-vehicle accounts omit it.
+ */
+const props = defineProps<{ account: AccountModel; vehicleId?: string }>();
 const emit = defineEmits<{ close: [] }>();
 
-const { mutateAsync: adjustBalance, isPending } = useAdjustAccountBalance();
+const queryClient = useQueryClient();
+const { mutateAsync: adjustBalance, isPending: isAdjustPending } = useAdjustAccountBalance();
+const { mutateAsync: overrideVehicle, isPending: isOverridePending } = useMutation({
+  mutationFn: overrideVehicleValue,
+});
 const { addSuccessNotification, addErrorNotification } = useNotificationCenter();
 const { hasCreditLimitAdjustment, displayBalance } = useAccountDisplayBalance({
   account: toRef(() => props.account),
@@ -27,6 +39,7 @@ const { hasCreditLimitAdjustment, displayBalance } = useAccountDisplayBalance({
 const { t, te } = useI18n();
 
 const isVehicle = computed(() => props.account.accountCategory === ACCOUNT_CATEGORIES.vehicle);
+const isPending = computed(() => (isVehicle.value ? isOverridePending.value : isAdjustPending.value));
 
 /**
  * Look up a copy key, preferring the vehicle-override namespace when the
@@ -106,12 +119,28 @@ const submit = async () => {
   if (!isFormValid('form') || !isValid.value || computedTarget.value === null) return;
 
   try {
-    await adjustBalance({
-      id: props.account.id,
-      targetBalance: computedTarget.value,
-      note: form.value.note || undefined,
-      time: form.value.time,
-    });
+    if (isVehicle.value && props.vehicleId) {
+      await overrideVehicle({
+        id: props.vehicleId,
+        targetValue: computedTarget.value,
+        note: form.value.note || undefined,
+        time: form.value.time,
+      });
+      // Vehicle cache keys are prefixed with `transactionChange`, so this
+      // predicate invalidation covers vehiclesList / vehicleDetail /
+      // vehicleOverrideHistory too — useAdjustAccountBalance does the same for
+      // the generic path, but that composable isn't invoked here.
+      queryClient.invalidateQueries({
+        predicate: (query) => (query.queryKey as string[]).includes(VUE_QUERY_GLOBAL_PREFIXES.transactionChange),
+      });
+    } else {
+      await adjustBalance({
+        id: props.account.id,
+        targetBalance: computedTarget.value,
+        note: form.value.note || undefined,
+        time: form.value.time,
+      });
+    }
     addSuccessNotification(label('successNotification'));
     isOpen.value = false;
   } catch (error) {

--- a/packages/frontend/src/pages/accounts/vehicle-details.vue
+++ b/packages/frontend/src/pages/accounts/vehicle-details.vue
@@ -224,6 +224,7 @@
       <BalanceAdjustmentDialog
         v-if="isOverrideOpen && vehicle.account"
         :account="vehicle.account"
+        :vehicle-id="vehicle.id"
         @close="onOverrideClosed"
       />
 


### PR DESCRIPTION
Added a dedicated overrideVehicleValue API call for POST /vehicles/:id/value.

Updated the balance adjustment dialog to route vehicle accounts through the dedicated mutation.

Added vehicle-specific query-cache invalidation after successful overrides.

Passed vehicleId from the vehicle details page.

Added regression tests covering success, error handling, notifications, dialog closing, and ensuring the generic mutation is not called.