### PR TITLE
feat(settings): add short currency symbol toggle

### DIFF
--- a/packages/backend/src/models/user-settings.model.ts
+++ b/packages/backend/src/models/user-settings.model.ts
@@ -284,6 +284,7 @@ export const ZodSettingsSchema = z.object({
   // savings rather than spend. Descendants are expanded server-side. Plain z.uuid(), not
   // recordId(): the branded RecordId output breaks the SettingsPatchSchemaIsInSync assertion below.
   savingsCategoryIds: z.array(z.uuid()).optional(),
+  currencyDisplay: z.enum(endpointsTypes.CURRENCY_DISPLAY_PREFERENCES).optional(),
 });
 
 export type SettingsSchema = z.infer<typeof ZodSettingsSchema>;
@@ -375,6 +376,7 @@ export const ZodSettingsPatchSchema = z.object({
   hideZeroBalances: z.boolean().optional(),
   matchTransfersWithManualAccounts: z.boolean().optional(),
   savingsCategoryIds: z.array(z.uuid()).optional(),
+  currencyDisplay: z.enum(endpointsTypes.CURRENCY_DISPLAY_PREFERENCES).optional(),
 });
 
 export type SettingsPatchSchema = z.infer<typeof ZodSettingsPatchSchema>;

--- a/packages/backend/src/services/user-settings/patch-settings.e2e.ts
+++ b/packages/backend/src/services/user-settings/patch-settings.e2e.ts
@@ -65,6 +65,18 @@ describe('Patch user settings', () => {
     });
   });
 
+  it('persists currencyDisplay in both directions and keeps it through a rejected patch', async () => {
+    const patched = await helpers.patchUserSettings({ raw: true, patch: { currencyDisplay: 'narrowSymbol' } });
+    expect(patched.currencyDisplay).toBe('narrowSymbol');
+
+    const invalid = await helpers.patchUserSettings({ patch: { currencyDisplay: 'code' } });
+    expect(invalid.statusCode).toBe(ERROR_CODES.ValidationError);
+    expect((await helpers.getUserSettings({ raw: true })).currencyDisplay).toBe('narrowSymbol');
+
+    await helpers.patchUserSettings({ raw: true, patch: { currencyDisplay: 'symbol' } });
+    expect((await helpers.getUserSettings({ raw: true })).currencyDisplay).toBe('symbol');
+  });
+
   it('replaces arrays wholesale instead of appending', async () => {
     await helpers.patchUserSettings({
       raw: true,
@@ -155,6 +167,7 @@ describe('Patch user settings', () => {
       { import: { recalculateAccountBalance: 'yes' } },
       { accounts: { defaultAccountId: 'not-a-uuid' } },
       { accounts: { showArchivedInDropdowns: 'yes' } },
+      { currencyDisplay: 'code' },
     ];
 
     for (const patch of invalidPatches) {

--- a/packages/frontend/src/api/user-settings.ts
+++ b/packages/frontend/src/api/user-settings.ts
@@ -116,6 +116,7 @@ export interface UserSettingsSchema {
    * expense. Subcategories inherit from their parent. Empty or unset leaves cash flow unchanged.
    */
   savingsCategoryIds?: string[];
+  currencyDisplay?: endpointsTypes.CurrencyDisplayPreference;
 }
 
 export const getUserSettings = async (): Promise<UserSettingsSchema> => {

--- a/packages/frontend/src/app.vue
+++ b/packages/frontend/src/app.vue
@@ -15,8 +15,10 @@ import RestoreInProgressOverlay from '@/components/common/restore-in-progress-ov
 import UpdateAvailableBanner from '@/components/common/update-available-banner.vue';
 import NotificationToaster from '@/components/notification-center/notification-toaster.vue';
 import { useExchangeRates } from '@/composable/data-queries/currencies';
+import { useUserSettings } from '@/composable/data-queries/user-settings';
 import { useAiCategorizationEvents } from '@/composable/use-ai-categorization-events';
 import { useSSE } from '@/composable/use-sse';
+import { currencyDisplayPreference } from '@/js/helpers';
 import { ROUTES_NAMES } from '@/routes';
 import { useAuthStore, useCurrenciesStore, useRootStore } from '@/stores';
 import { storeToRefs } from 'pinia';
@@ -34,6 +36,15 @@ const { isBaseCurrencyExists } = storeToRefs(userCurrenciesStore);
 
 // Prefetch exchange rates for components that need them
 useExchangeRates({ enabled: isLoggedIn });
+
+const { data: userSettings } = useUserSettings({ enabled: isLoggedIn });
+watch(
+  () => userSettings.value?.currencyDisplay,
+  (value) => {
+    currencyDisplayPreference.value = value ?? 'symbol';
+  },
+  { immediate: true },
+);
 
 // SSE for real-time updates
 const { disconnect: disconnectSSE } = useSSE();

--- a/packages/frontend/src/i18n/locales/chunks/en/settings/appearance.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/settings/appearance.json
@@ -16,6 +16,11 @@
         "title": "Header",
         "description": "Choose which header actions are visible.",
         "supportButton": "Support button"
+      },
+      "currency": {
+        "title": "Currency symbols",
+        "description": "How amounts show their currency. Short symbols look like Rp, ₴ or zł instead of IDR, UAH or PLN, but currencies that share a symbol (USD, CAD, AUD, SGD) all become $.",
+        "narrowSymbol": "Use short currency symbols"
       }
     }
   }

--- a/packages/frontend/src/js/helpers/formatters.spec.ts
+++ b/packages/frontend/src/js/helpers/formatters.spec.ts
@@ -1,4 +1,10 @@
-import { formatFiat, formatUIAmount, toLocalCurrencyNumber } from './formatters';
+import {
+  currencyDisplayPreference,
+  formatFiat,
+  formatLargeNumber,
+  formatUIAmount,
+  toLocalCurrencyNumber,
+} from './formatters';
 
 describe('js/helpers/formatters', () => {
   describe('formatUIAmount', () => {
@@ -55,6 +61,30 @@ describe('js/helpers/formatters', () => {
 
     test('malformed currency code degrades to a bare number + code instead of throwing', () => {
       expect(formatUIAmount(1234.5, { currency: 'USDT' })).toBe('1,234.50 USDT');
+    });
+  });
+
+  describe('currencyDisplayPreference', () => {
+    beforeEach(() => {
+      currencyDisplayPreference.value = 'symbol';
+    });
+
+    test('symbol (default) keeps disambiguating codes', () => {
+      expect(currencyDisplayPreference.value).toBe('symbol');
+      expect(formatUIAmount(1234.5, { currency: 'IDR' })).toBe('IDR\u00a01,234.50');
+      expect(formatUIAmount(1234.5, { currency: 'CAD' })).toBe('CA$1,234.50');
+    });
+
+    test('narrowSymbol renders the local short symbol', () => {
+      currencyDisplayPreference.value = 'narrowSymbol';
+      expect(formatUIAmount(1234.5, { currency: 'IDR' })).toBe('Rp\u00a01,234.50');
+      expect(formatUIAmount(1234.5, { currency: 'CAD' })).toBe('$1,234.50');
+    });
+
+    test('applies to compact fiat formatting too', () => {
+      expect(formatLargeNumber(1630, { isFiat: true, currency: 'CAD' })).toBe('CA$1.63k');
+      currencyDisplayPreference.value = 'narrowSymbol';
+      expect(formatLargeNumber(1630, { isFiat: true, currency: 'CAD' })).toBe('$1.63k');
     });
   });
 

--- a/packages/frontend/src/js/helpers/formatters.ts
+++ b/packages/frontend/src/js/helpers/formatters.ts
@@ -1,4 +1,10 @@
+import type { endpointsTypes } from '@bt/shared/types';
+import { ref } from 'vue';
+
 export const formatFiat = (value: unknown): string => Number(value).toFixed(2);
+
+// Module-level so plain helpers, not just composables, follow the user's setting.
+export const currencyDisplayPreference = ref<endpointsTypes.CurrencyDisplayPreference>('symbol');
 
 export function toLocalNumber(
   value: string | number | undefined | null,
@@ -63,7 +69,7 @@ function toLocalFiatCurrency(
       minimumFractionDigits: options.minimumFractionDigits ?? currencyDigits,
       maximumFractionDigits: options.maximumFractionDigits ?? currencyDigits,
       currency,
-      currencyDisplay: options.currencyDisplay ?? 'symbol',
+      currencyDisplay: options.currencyDisplay ?? currencyDisplayPreference.value,
       useGrouping: options.useGrouping ?? true,
       style: 'currency',
     });

--- a/packages/frontend/src/pages/settings/subpages/appearance/index.vue
+++ b/packages/frontend/src/pages/settings/subpages/appearance/index.vue
@@ -70,6 +70,28 @@
 
       <Separator />
 
+      <!-- Currency symbol -->
+      <div>
+        <h3 class="mb-2 text-lg font-medium">{{ $t('settings.appearance.currency.title') }}</h3>
+        <p class="mb-4 text-sm leading-relaxed">
+          {{ $t('settings.appearance.currency.description') }}
+        </p>
+
+        <div class="flex items-center justify-between gap-4">
+          <span class="flex items-center gap-2 text-sm">
+            <CoinsIcon class="text-muted-foreground size-4 shrink-0" />
+            {{ $t('settings.appearance.currency.narrowSymbol') }}
+          </span>
+          <Switch
+            :model-value="userSettings?.currencyDisplay === 'narrowSymbol'"
+            :disabled="isPatching"
+            @update:model-value="(v) => patch({ currencyDisplay: v ? 'narrowSymbol' : 'symbol' })"
+          />
+        </div>
+      </div>
+
+      <Separator />
+
       <!-- Header -->
       <div>
         <h3 class="mb-2 text-lg font-medium">{{ $t('settings.appearance.header.title') }}</h3>
@@ -100,13 +122,15 @@ import Button from '@/components/lib/ui/button/Button.vue';
 import { Card, CardContent, CardHeader } from '@/components/lib/ui/card';
 import { Separator } from '@/components/lib/ui/separator';
 import { Switch } from '@/components/lib/ui/switch';
+import { useUserSettings } from '@/composable/data-queries/user-settings';
 import { TOGGLEABLE_SIDEBAR_SECTIONS, useSidebarSections } from '@/composable/use-sidebar-sections';
 import { useSupportButton } from '@/composable/use-support-button';
-import { HeartIcon, InfoIcon, LayersIcon, MonitorIcon, MoonStarIcon, SunIcon } from '@lucide/vue';
+import { CoinsIcon, HeartIcon, InfoIcon, LayersIcon, MonitorIcon, MoonStarIcon, SunIcon } from '@lucide/vue';
 import { type Component } from 'vue';
 
 const { sidebarSections, toggleSection, isUpdating } = useSidebarSections();
 const { isSupportButtonVisible, setSupportButtonVisible, isUpdating: isSupportButtonUpdating } = useSupportButton();
+const { data: userSettings, patch, isPatching } = useUserSettings();
 
 interface ThemeOption {
   value: ThemePreference;

--- a/packages/shared/src/types/endpoints.ts
+++ b/packages/shared/src/types/endpoints.ts
@@ -381,6 +381,12 @@ export interface SidebarSectionsConfig {
   loans: boolean;
 }
 
+// How fiat amounts render their currency: `symbol` disambiguates (CA$, A$, SGD), `narrowSymbol`
+// is what locals use (Rp, ₴, zł) but collapses every dollar to `$`. Persisted in the
+// user-settings JSONB; the backend Zod enum is built straight off this tuple.
+export const CURRENCY_DISPLAY_PREFERENCES = ['symbol', 'narrowSymbol'] as const;
+export type CurrencyDisplayPreference = (typeof CURRENCY_DISPLAY_PREFERENCES)[number];
+
 // Net Worth Drivers Analytics
 // Splits net-worth growth per period into what the user saved (income - expenses,
 // transfers excluded) versus what the market returned on their holdings, plus the


### PR DESCRIPTION
Opt-in `narrowSymbol` rendering (`Rp`, `₴`, `zł`) instead of blanket use, since it collapses USD/CAD/AUD to `$`. Closes #543