### PR TITLE
Scale pence/cents-quoted prices to ISO-currency value

### DIFF
--- a/packages/backend/src/services/investments/data-providers/yahoo-provider.ts
+++ b/packages/backend/src/services/investments/data-providers/yahoo-provider.ts
@@ -17,7 +17,7 @@ import {
   toProviderSymbol,
 } from './base-provider';
 import { resolveByIsinFallback } from './yahoo/isin-resolver';
-import { ISIN_PATTERN, mapYahooTypeToAssetClass, remapUcitsType } from './yahoo/utils';
+import { ISIN_PATTERN, mapYahooTypeToAssetClass, remapUcitsType, toIsoCurrency, toMajorUnit } from './yahoo/utils';
 
 const DEFAULT_HISTORY_YEARS = 5;
 const CURRENCY_RESOLVE_CONCURRENCY = 5;
@@ -154,7 +154,7 @@ export class YahooDataProvider extends BaseSecurityDataProvider {
         throw new Error(`No quote data found for symbol: ${providerSymbol}`);
       }
 
-      const priceClose = quote.regularMarketPreviousClose;
+      const priceClose = toMajorUnit({ price: quote.regularMarketPreviousClose, currency: quote.currency });
       if (!quote.regularMarketTime) {
         logger.info(`Missing regularMarketTime for ${providerSymbol}, using current time as fallback`);
       }
@@ -200,13 +200,14 @@ export class YahooDataProvider extends BaseSecurityDataProvider {
       }
 
       const results: PriceData[] = [];
+      const currency = chartResult.meta?.currency;
       for (const q of chartResult.quotes) {
         if (q.close == null) continue;
 
         results.push({
           providerSymbol,
           date: new Date(q.date),
-          priceClose: q.adjclose ?? q.close,
+          priceClose: toMajorUnit({ price: q.adjclose ?? q.close, currency }),
           priceAsOf: new Date(q.date),
           providerName: SECURITY_PROVIDER.yahoo,
         });
@@ -286,7 +287,7 @@ export class YahooDataProvider extends BaseSecurityDataProvider {
       });
 
       for (const entry of cached) {
-        currencyMap.set(entry.symbol, entry.currencyCode);
+        currencyMap.set(entry.symbol, toIsoCurrency(entry.currencyCode));
       }
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
@@ -312,10 +313,11 @@ export class YahooDataProvider extends BaseSecurityDataProvider {
           const symbol = batch[j]!;
 
           if (result.status === 'fulfilled' && result.value?.currency) {
-            currencyMap.set(symbol, result.value.currency);
+            const currencyCode = toIsoCurrency(result.value.currency);
+            currencyMap.set(symbol, currencyCode);
             toCache.push({
               symbol,
-              currencyCode: result.value.currency,
+              currencyCode,
               providerName: SECURITY_PROVIDER.yahoo,
             });
           }

--- a/packages/backend/src/services/investments/data-providers/yahoo/isin-resolver.ts
+++ b/packages/backend/src/services/investments/data-providers/yahoo/isin-resolver.ts
@@ -2,7 +2,13 @@ import { SECURITY_PROVIDER, SecuritySearchResult } from '@bt/shared/types/invest
 import { logger } from '@js/utils';
 import type YahooFinance from 'yahoo-finance2';
 
-import { ISIN_EXCHANGE_SUFFIXES, isExpectedNotFoundError, mapYahooTypeToAssetClass, remapUcitsType } from './utils';
+import {
+  ISIN_EXCHANGE_SUFFIXES,
+  isExpectedNotFoundError,
+  mapYahooTypeToAssetClass,
+  remapUcitsType,
+  toIsoCurrency,
+} from './utils';
 
 // Cap on the number of additional local-ticker candidates we'll quote per ISIN
 // search – guards against a name-match search returning dozens of distantly
@@ -164,7 +170,7 @@ function buildIsinFallbackResult({ quote, isin }: { quote: YahooQuoteResult; isi
     exchangeName: fullExchangeName,
     exchangeAcronym: quote.exchange,
     exchangeMic: undefined,
-    currencyCode: quote.currency,
+    currencyCode: toIsoCurrency(quote.currency),
     cusip: undefined,
     isin,
   };

--- a/packages/backend/src/services/investments/data-providers/yahoo/utils.ts
+++ b/packages/backend/src/services/investments/data-providers/yahoo/utils.ts
@@ -10,6 +10,16 @@ export const ISIN_PATTERN = /^[A-Z]{2}[A-Z0-9]{9}\d$/;
 // the bare ISIN is not searchable.
 export const ISIN_EXCHANGE_SUFFIXES = ['.IR', '.DE', '.PA', '.AS', '.MI', '.L'] as const;
 
+// Yahoo quotes some venues in minor units (LSE pence, JSE cents, TASE agorot)
+// under a non-ISO currency code. Prices are scaled to the major unit at the
+// provider boundary so the rest of the app only ever sees ISO currencies.
+const MINOR_UNIT_CURRENCIES: Record<string, string> = { GBp: 'GBP', GBX: 'GBP', ZAc: 'ZAR', ILA: 'ILS' };
+
+export const toMajorUnit = ({ price, currency }: { price: number; currency?: string }) =>
+  currency && MINOR_UNIT_CURRENCIES[currency] ? price / 100 : price;
+
+export const toIsoCurrency = (currency: string) => MINOR_UNIT_CURRENCIES[currency] ?? currency;
+
 /**
  * Returns true when a quote() rejection is the routine "symbol doesn't exist
  * on this venue" case (404 HTTPError, NotFoundError, "not found" message).

--- a/packages/backend/src/services/investments/holdings/holdings.e2e.ts
+++ b/packages/backend/src/services/investments/holdings/holdings.e2e.ts
@@ -7,6 +7,7 @@ import Holdings from '@models/investments/holdings.model';
 import InvestmentTransaction from '@models/investments/investment-transaction.model';
 import Portfolios from '@models/investments/portfolios.model';
 import Securities from '@models/investments/securities.model';
+import SecurityPricing from '@models/investments/security-pricing.model';
 import { restClient } from '@polygon.io/client-js';
 import { dataProviderFactory } from '@services/investments/data-providers/provider-factory';
 import * as helpers from '@tests/helpers';
@@ -454,6 +455,44 @@ describe('Investment holdings', () => {
     });
 
     it.todo('prevents race condition on duplicate (only one succeeds)');
+
+    it('stores pence-quoted LSE (GBp) prices as pounds', async () => {
+      dataProviderFactory.clearCache();
+      const mockedYahooChart = jest.fn<any>().mockResolvedValue({
+        meta: { currency: 'GBp' },
+        quotes: [{ date: new Date('2024-01-15'), close: 4082, adjclose: 4082 }],
+      });
+      mockedYahooFinance.mockImplementation(
+        () =>
+          ({
+            search: jest.fn<any>().mockRejectedValue(new Error('not configured')),
+            quote: jest.fn<any>().mockRejectedValue(new Error('not configured')),
+            chart: mockedYahooChart,
+          }) as any,
+      );
+
+      const response = await makeRequest({
+        method: 'post',
+        url: '/investments/holding',
+        payload: {
+          portfolioId: investmentPortfolio.id,
+          searchResult: {
+            symbol: 'EMIM.L',
+            providerSymbol: 'EMIM.L',
+            name: 'iShares Core MSCI EM IMI',
+            assetClass: ASSET_CLASS.stocks,
+            providerName: SECURITY_PROVIDER.yahoo,
+            currencyCode: 'GBp',
+          },
+        },
+      });
+      expect(response.statusCode).toBe(201);
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      const stored = await Securities.findOne({ where: { symbol: 'EMIM.L' } });
+      const price = await SecurityPricing.findOne({ where: { securityId: stored!.id } });
+      expect(price?.priceClose.toNumber()).toBeCloseTo(40.82, 5);
+    });
 
     describe('searchResult with priceSourceSymbol (Yahoo ISIN fallback path)', () => {
       it('persists priceSourceSymbol on the new security and routes initial price fetch through it', async () => {

--- a/packages/backend/src/services/investments/securities/search.e2e.ts
+++ b/packages/backend/src/services/investments/securities/search.e2e.ts
@@ -483,6 +483,27 @@ describe('GET /investments/securities/search', () => {
     expect(msftResult?.isInPortfolio).toBe(true);
   });
 
+  it('normalizes minor-unit Yahoo currencies (ZAc) to ISO (ZAR) in search results', async () => {
+    dataProviderFactory.clearCache();
+    mockedFmpSearch.mockResolvedValue([]);
+    const YahooFinance = (await import('yahoo-finance2')).default;
+    jest.mocked(YahooFinance).mockImplementation(
+      () =>
+        ({
+          search: jest.fn<any>().mockResolvedValue({
+            quotes: [{ symbol: 'NPN.JO', longname: 'Naspers', typeDisp: 'Equity', isYahooFinance: true }],
+          }),
+          quote: jest.fn<any>().mockResolvedValue({ symbol: 'NPN.JO', currency: 'ZAc' }),
+          chart: jest.fn<any>(),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+    );
+
+    const results = await helpers.searchSecurities({ payload: { query: 'NPN.JO' }, raw: true });
+
+    expect(results.find((r) => r.symbol === 'NPN.JO')?.currencyCode).toBe('ZAR');
+  });
+
   it('keeps crypto dedup keyed by (providerName, providerSymbol) so the existing CoinGecko BTC matches', async () => {
     // Crypto dedup MUST stay (providerName, providerSymbol) – the ticker "BTC"
     // alone is ambiguous (could be Bitcoin's CoinGecko slug, a different chain's


### PR DESCRIPTION
Yahoo reports GBp/GBX (and ZAc, ILA) as the quote currency, so prices were stored 100x too high under GBP

Closes #556