### PR TITLE
Prioritize recently active Monobank accounts in sync queue

### DIFF
--- a/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/monobank.provider.ts
@@ -22,7 +22,7 @@ import { clampSyncStartToLink } from '../utils/clamp-sync-start-to-link';
 import { encryptCredentials } from '../utils/credential-encryption';
 import { writeBankBalanceWithHistory } from '../utils/write-bank-balance-with-history';
 import { MonobankApiClient } from './api-client';
-import { getJobGroupProgress, queueTransactionSync } from './transaction-sync-queue';
+import { getJobGroupProgress, queueTransactionSync, syncPriorityForAccount } from './transaction-sync-queue';
 import { MonobankCredentials, MonobankMetadata } from './types';
 
 /**
@@ -242,6 +242,9 @@ export class MonobankProvider extends BaseBankDataProvider {
           // Only an anchored (incremental) sync may consume plans: the anchorless
           // default window is a backfill, and old charges must not eat fresh plans.
           matchPlanned: Boolean(latestTransaction),
+          priority: syncPriorityForAccount({
+            latestTransactionTime: latestTransaction ? new Date(latestTransaction.time) : null,
+          }),
         });
       },
     });
@@ -276,6 +279,7 @@ export class MonobankProvider extends BaseBankDataProvider {
     from,
     to,
     matchPlanned = false,
+    priority,
   }: {
     connectionId: string;
     systemAccountId: RecordId;
@@ -283,6 +287,7 @@ export class MonobankProvider extends BaseBankDataProvider {
     from: Date;
     to: Date;
     matchPlanned?: boolean;
+    priority?: number;
   }): Promise<{ jobGroupId: string; totalBatches: number; estimatedMinutes: number }> {
     const account = await this.getSystemAccount(systemAccountId);
     const connection = await this.getConnection(connectionId);
@@ -304,6 +309,7 @@ export class MonobankProvider extends BaseBankDataProvider {
       from,
       to,
       matchPlanned,
+      priority,
     });
 
     return result;

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.ts
@@ -704,6 +704,18 @@ function splitDateRangeIntoChunks(from: Date, to: Date): Array<{ from: Date; to:
 }
 
 /**
+ * All accounts on one token share a single rate-limited lane, so a stale
+ * account's multi-chunk backfill must not delay an active account's one chunk.
+ * Priority grows with days since the last known transaction; an account with
+ * no rows yet is the one the user is waiting on and goes first.
+ */
+export function syncPriorityForAccount({ latestTransactionTime }: { latestTransactionTime?: Date | null }): number {
+  if (!latestTransactionTime) return 1;
+  const days = Math.ceil((Date.now() - latestTransactionTime.getTime()) / 86_400_000);
+  return Math.min(Math.max(1, days), 2 ** 21 - 1);
+}
+
+/**
  * Queue transaction sync job for a date range
  * Automatically splits into 31-day chunks
  */
@@ -716,8 +728,20 @@ export async function queueTransactionSync(params: {
   from: Date;
   to: Date;
   matchPlanned?: boolean;
+  /** BullMQ priority (lower runs sooner). Omitted = 0 = ahead of every prioritized job. */
+  priority?: number;
 }): Promise<{ jobGroupId: string; totalBatches: number; estimatedMinutes: number }> {
-  const { userId, accountId, connectionId, externalAccountId, apiToken, from, to, matchPlanned = false } = params;
+  const {
+    userId,
+    accountId,
+    connectionId,
+    externalAccountId,
+    apiToken,
+    from,
+    to,
+    matchPlanned = false,
+    priority,
+  } = params;
 
   const bundle = getOrCreateBundle(apiToken);
 
@@ -759,6 +783,7 @@ export async function queueTransactionSync(params: {
         },
         opts: {
           jobId: `${jobGroupId}-${index}`,
+          priority,
         },
       }));
 

--- a/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.unit.ts
+++ b/packages/backend/src/services/bank-data-providers/monobank/transaction-sync-queue.unit.ts
@@ -9,7 +9,7 @@ import type { Job } from 'bullmq';
 // are the only bullmq surface these tests reach.
 jest.mock('bullmq', () => ({
   __esModule: true,
-  Queue: jest.fn().mockImplementation(() => ({ add: jest.fn(), on: jest.fn(), close: jest.fn() })),
+  Queue: jest.fn().mockImplementation(() => ({ add: jest.fn(), addBulk: jest.fn(), on: jest.fn(), close: jest.fn() })),
   Worker: jest.fn().mockImplementation(() => ({ on: jest.fn(), close: jest.fn() })),
   UnrecoverableError: class UnrecoverableError extends Error {},
 }));
@@ -38,7 +38,7 @@ import { redisClient } from '@root/redis-client';
 import { runPendingLinkAbsorb } from '@services/accounts/absorb-link-residual';
 
 import { SyncStatus, setAccountSyncStatus } from '../sync/sync-status-tracker';
-import { handleCompletedBatch, queueTransactionSync } from './transaction-sync-queue';
+import { handleCompletedBatch, queueTransactionSync, syncPriorityForAccount } from './transaction-sync-queue';
 /* eslint-enable import/first */
 
 const runPendingLinkAbsorbMock = jest.mocked(runPendingLinkAbsorb);
@@ -151,5 +151,39 @@ describe('finalizeSyncGroup via queueTransactionSync empty window (absorb errors
 
     expect(setAccountSyncStatusMock).not.toHaveBeenCalled();
     expect(connectionsUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+const daysAgo = (n: number) => new Date(Date.now() - n * 86_400_000);
+
+describe('syncPriorityForAccount', () => {
+  it('ranks active accounts ahead of stale ones and fresh accounts first', () => {
+    const fresh = syncPriorityForAccount({ latestTransactionTime: null });
+    const active = syncPriorityForAccount({ latestTransactionTime: daysAgo(0.5) });
+    const stale = syncPriorityForAccount({ latestTransactionTime: daysAgo(180) });
+
+    expect(fresh).toBe(1);
+    expect(active).toBe(1);
+    expect(stale).toBe(180);
+    expect(syncPriorityForAccount({ latestTransactionTime: daysAgo(10_000_000) })).toBe(2 ** 21 - 1);
+  });
+
+  it('stamps every queued batch with the given priority', async () => {
+    const { Queue } = jest.requireMock('bullmq') as { Queue: jest.Mock };
+    await queueTransactionSync({
+      userId: USER_ID,
+      accountId: generateRandomRecordId(),
+      connectionId: CONNECTION_ID,
+      externalAccountId: 'external-1',
+      apiToken: 'token-priority',
+      from: new Date('2024-01-01T00:00:00.000Z'),
+      to: new Date('2024-03-15T00:00:00.000Z'),
+      priority: 7,
+    });
+
+    const queue = Queue.mock.results.at(-1)!.value as { addBulk: jest.Mock };
+    const jobs = queue.addBulk.mock.calls[0]![0] as Array<{ opts: { priority?: number } }>;
+    expect(jobs.length).toBeGreaterThan(1);
+    expect(jobs.every((job) => job.opts.priority === 7)).toBe(true);
   });
 });


### PR DESCRIPTION
All accounts on one token share a 1-req/60s lane, so a stale account's multi-chunk backfill no longer delays the active account's sync