### PR TITLE
Opt-in `applyAutomations` flag on POST /transactions

### DIFF
--- a/packages/backend/src/controllers/transactions.controller/create-transaction.ts
+++ b/packages/backend/src/controllers/transactions.controller/create-transaction.ts
@@ -29,6 +29,7 @@ const schema = z.object({
       payeeId: recordId().nullable().optional(),
       payeeLocked: z.boolean().optional(),
       isPlanned: z.boolean().optional().default(false),
+      applyAutomations: z.boolean().optional().default(false),
       originalAmount: nonNegativeAmountSchema().optional(),
       originalCurrencyCode: currencyCode().optional(),
     })

--- a/packages/backend/src/serializers/transactions.serializer.ts
+++ b/packages/backend/src/serializers/transactions.serializer.ts
@@ -119,6 +119,7 @@ interface CreateTransactionRequest {
   payeeId?: RecordId | null;
   payeeLocked?: boolean;
   isPlanned?: boolean;
+  applyAutomations?: boolean;
   originalAmount?: number; // decimal from API
   originalCurrencyCode?: string;
 }
@@ -152,6 +153,7 @@ interface CreateTransactionInternal {
   payeeId?: RecordId | null;
   payeeLocked?: boolean;
   isPlanned?: boolean;
+  applyAutomations?: boolean;
   originalAmount?: Money;
   originalCurrencyCode?: string;
 }
@@ -330,6 +332,7 @@ export function deserializeCreateTransaction(req: CreateTransactionRequest, user
     payeeId: req.payeeId,
     payeeLocked: req.payeeLocked,
     isPlanned: req.isPlanned,
+    applyAutomations: req.applyAutomations,
     originalAmount: req.originalAmount !== undefined ? Money.fromDecimal(req.originalAmount) : undefined,
     originalCurrencyCode: req.originalCurrencyCode,
   };

--- a/packages/backend/src/services/transaction-automations/eligibility.ts
+++ b/packages/backend/src/services/transaction-automations/eligibility.ts
@@ -1,18 +1,32 @@
 import { ACCOUNT_TYPES, TRANSACTION_TRANSFER_NATURE } from '@bt/shared/types';
 import { Op, literal } from 'sequelize';
 
+/**
+ * Rows automations are eligible for:
+ * - non-transfer;
+ * - non-planned
+ * - synced from a bank provider, stamped with `importDetails` by an importer;
+ * - created with `applyAutomations` (API integrations);
+ *
+ * Manually-entered rows on system accounts by default are excluded so a rule never
+ * overrides a field the user chose.
+ */
 export const isAutomationEligible = ({
   accountType,
   externalData,
   transferNature,
   isPlanned,
+  applyAutomations = false,
 }: {
   accountType: ACCOUNT_TYPES;
   externalData: Record<string, unknown> | null | undefined;
   transferNature: TRANSACTION_TRANSFER_NATURE;
   isPlanned: boolean;
+  applyAutomations?: boolean;
 }): boolean =>
-  (accountType !== ACCOUNT_TYPES.system || Boolean(externalData && 'importDetails' in externalData)) &&
+  (applyAutomations ||
+    accountType !== ACCOUNT_TYPES.system ||
+    Boolean(externalData && 'importDetails' in externalData)) &&
   transferNature === TRANSACTION_TRANSFER_NATURE.not_transfer &&
   !isPlanned;
 

--- a/packages/backend/src/services/transaction-automations/eligibility.unit.ts
+++ b/packages/backend/src/services/transaction-automations/eligibility.unit.ts
@@ -42,9 +42,21 @@ describe('isAutomationEligible', () => {
     ).toBe(true);
   });
 
+  it('accepts a manual system row when applyAutomations is set', () => {
+    expect(
+      isAutomationEligible({
+        ...eligible,
+        accountType: ACCOUNT_TYPES.system,
+        externalData: null,
+        applyAutomations: true,
+      }),
+    ).toBe(true);
+  });
+
   it.each([
     ['a manual system row', { accountType: ACCOUNT_TYPES.system, externalData: null }],
     ['a planned row', { isPlanned: true }],
+    ['a planned row even with applyAutomations', { isPlanned: true, applyAutomations: true }],
     ['a transfer leg', { transferNature: TRANSACTION_TRANSFER_NATURE.common_transfer }],
     ['a wallet-out transfer', { transferNature: TRANSACTION_TRANSFER_NATURE.transfer_out_wallet }],
     [

--- a/packages/backend/src/services/transaction-automations/hook.e2e.ts
+++ b/packages/backend/src/services/transaction-automations/hook.e2e.ts
@@ -269,6 +269,28 @@ describe('Transaction automations hook', () => {
     expect((await helpers.getAutomationById({ id: rule.id }))?.matchCount).toBe(0);
   });
 
+  it('applies rules to a system-account row when POST /transactions sends applyAutomations', async () => {
+    const category = await helpers.addCustomCategory({ name: 'Rides', color: '#111111', raw: true });
+    const rule = await noteRule({
+      name: 'Uber is transport',
+      keyword: 'uber',
+      actions: [{ type: 'set_category', categoryId: category.id }],
+    });
+
+    const systemAccount = await helpers.createAccount({ raw: true });
+    const [tx] = await helpers.createTransaction({
+      payload: {
+        ...helpers.buildTransactionPayload({ accountId: systemAccount.id, note: 'UBER TRIP via api' }),
+        applyAutomations: true,
+      },
+      raw: true,
+    });
+
+    expect(tx!.categoryId).toBe(category.id);
+    expect(tx!.categorizationMeta?.source).toBe(CATEGORIZATION_SOURCE.userRule);
+    expect((await helpers.getAutomationById({ id: rule.id }))?.matchCount).toBe(1);
+  });
+
   it("never applies another user's rule to the syncing user's row", async () => {
     const second = await helpers.signUpSecondUser();
     const foreignRule = await helpers.asUser({

--- a/packages/backend/src/services/transactions/create-transaction.ts
+++ b/packages/backend/src/services/transactions/create-transaction.ts
@@ -354,6 +354,7 @@ export const createTransaction = withTransaction(
     payeeLocked: callerPayeeLocked,
     categoryIdIsExplicit = false,
     matchPlanned = false,
+    applyAutomations = false,
     ...payload
   }: CreateTransactionParams): Promise<CreateTxResult> => {
     try {
@@ -657,6 +658,7 @@ export const createTransaction = withTransaction(
           externalData: payload.externalData,
           transferNature,
           isPlanned: Boolean(payload.isPlanned),
+          applyAutomations,
         })
       ) {
         try {

--- a/packages/backend/src/services/transactions/types.ts
+++ b/packages/backend/src/services/transactions/types.ts
@@ -45,6 +45,11 @@ export type CreateTransactionParams = Omit<
    * Set by incremental bank sync and imports; never by manual creation or historical backfill.
    */
   matchPlanned?: boolean;
+  /**
+   * Run the user's automations on a system-account row. Off by default so a hand-typed
+   * entry is never overridden; API integrations posting bank data opt in per request.
+   */
+  applyAutomations?: boolean;
 };
 
 interface UpdateParams {

--- a/packages/shared/src/types/endpoints.ts
+++ b/packages/shared/src/types/endpoints.ts
@@ -118,6 +118,8 @@ export interface CreateTransactionBody {
   /** True when the caller wants future syncs to leave this row's Payee link alone. */
   payeeLocked?: boolean;
   isPlanned?: boolean;
+  /** Run the user's automations on a manual-account row; off by default. For API integrations. */
+  applyAutomations?: boolean;
   originalAmount?: number;
   /** Any ISO 4217 code; it does not have to be connected to the user. */
   originalCurrencyCode?: string;


### PR DESCRIPTION
Lets API integrations run user automations on system-account rows without touching manual entry. Closes #542