### PR TITLE
Accept Unicode minus and dash variants as negative sign

### DIFF
--- a/packages/backend/src/services/import-export/core/parse/parse-amount.ts
+++ b/packages/backend/src/services/import-export/core/parse/parse-amount.ts
@@ -8,7 +8,8 @@
 export function parseAmount(amountStr: string): number | null {
   if (!amountStr) return null;
 
-  let cleanStr = amountStr.trim();
+  // Banks export U+2212 minus, en/em dashes, and other hyphen look-alikes as the sign
+  let cleanStr = amountStr.trim().replace(/^[\u2010-\u2015\u2212\uFE63\uFF0D]/, '-');
 
   // Handle parentheses as negative (accounting format)
   const isNegativeParens = cleanStr.startsWith('(') && cleanStr.endsWith(')');

--- a/packages/backend/src/services/import-export/core/parse/parse-amount.unit.ts
+++ b/packages/backend/src/services/import-export/core/parse/parse-amount.unit.ts
@@ -46,6 +46,14 @@ describe('parseAmount (core tabular-import amount parser)', () => {
     expect(parseAmount('+500')).toBe(50000);
   });
 
+  it('treats Unicode minus and dash variants as a negative sign', () => {
+    expect(parseAmount('\u2212361,00')).toBe(-36100);
+    expect(parseAmount('\u2013361,00')).toBe(-36100);
+    expect(parseAmount('\u2014361,00')).toBe(-36100);
+    expect(parseAmount('\u2010361,00')).toBe(-36100);
+    expect(parseAmount('\u2212 1,234.56')).toBe(-123456);
+  });
+
   it('strips currency symbols and whitespace', () => {
     expect(parseAmount('$1,000.00')).toBe(100000);
     expect(parseAmount('€1.000,50')).toBe(100050);


### PR DESCRIPTION
Some banks export negative amounts with U+2212 instead of an ASCII hyphen, which made those rows fail with "Invalid amount"