### PR TITLE
Allow editing credit limit on bank-linked accounts

### DIFF
--- a/packages/backend/src/controllers/accounts.controller.e2e.ts
+++ b/packages/backend/src/controllers/accounts.controller.e2e.ts
@@ -352,7 +352,7 @@ describe('Accounts controller', () => {
       expect(updated.refCreditLimit).toBe(account.refCreditLimit);
     });
 
-    it('updates name but rejects creditLimit and currentBalance changes on non-system account', async () => {
+    it('updates name and creditLimit but rejects currentBalance changes on non-system account', async () => {
       const account = await helpers.createAccount({
         payload: {
           ...helpers.buildAccountPayload(),
@@ -369,12 +369,16 @@ describe('Accounts controller', () => {
 
       expect(updatedAccount.name).toBe('test test');
 
-      const rejectedPayloads = [
-        { creditLimit: 1000 },
-        { creditLimit: 0 },
-        { currentBalance: 0 },
-        { currentBalance: 1000 },
-      ];
+      const withLimit = await helpers.updateAccount({
+        id: account.id,
+        payload: { creditLimit: 1000 },
+        raw: true,
+      });
+      expect(withLimit.creditLimit).toBe(1000);
+      expect(withLimit.currentBalance).toBe(account.currentBalance);
+      expect(withLimit.initialBalance).toBe(account.initialBalance);
+
+      const rejectedPayloads = [{ currentBalance: 0 }, { currentBalance: 1000 }];
 
       for (const payload of rejectedPayloads) {
         const res = await helpers.updateAccount({ id: account.id, payload });
@@ -382,9 +386,9 @@ describe('Accounts controller', () => {
         expect(res.statusCode).toBe(ERROR_CODES.ValidationError);
       }
 
-      const unchanged = await helpers.getAccount({ id: account.id, raw: true });
-      expect(unchanged.creditLimit).toBe(account.creditLimit);
-      expect(unchanged.currentBalance).toBe(account.currentBalance);
+      const reread = await helpers.getAccount({ id: account.id, raw: true });
+      expect(reread.creditLimit).toBe(1000);
+      expect(reread.currentBalance).toBe(account.currentBalance);
     });
 
     it('returns 404 when updating another user account', async () => {

--- a/packages/backend/src/controllers/accounts.controller.ts
+++ b/packages/backend/src/controllers/accounts.controller.ts
@@ -136,12 +136,10 @@ export const updateAccount = createController(
       message: `Account with id "${id}" doesn't exist.`,
     });
 
-    if (account.type !== ACCOUNT_TYPES.system) {
-      if (creditLimit !== undefined || currentBalance !== undefined) {
-        throw new ValidationError({
-          message: `'creditLimit', 'currentBalance' are only allowed to be changed for "${ACCOUNT_TYPES.system}" account type`,
-        });
-      }
+    if (account.type !== ACCOUNT_TYPES.system && currentBalance !== undefined) {
+      throw new ValidationError({
+        message: `'currentBalance' is only allowed to be changed for "${ACCOUNT_TYPES.system}" account type`,
+      });
     }
 
     // Flipping accountCategory into or out of 'vehicle' breaks the 1:1 Vehicles

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking-flow.e2e.ts
@@ -14,11 +14,16 @@ import {
   MOCK_BANK_NAME,
   MOCK_IDENTIFICATION_HASH_1,
   MOCK_IDENTIFICATION_HASH_2,
+  MOCK_IDENTIFICATION_HASH_3,
   getAllMockAccountUIDs,
   getMockedAccountDetails,
 } from '@tests/mocks/enablebanking/data';
 import { AED_PER_USD, EUR_PER_USD } from '@tests/mocks/exchange-rates/data';
+import { format } from 'date-fns';
 import { HttpResponse, http } from 'msw';
+
+// getExchangeRate pivots through USD and truncates the rate to 5 decimals.
+const EUR_TO_AED = Math.trunc((AED_PER_USD / EUR_PER_USD) * 100_000) / 100_000;
 
 /**
  * Create a fully-active EnableBanking connection with one linked account.
@@ -1786,8 +1791,6 @@ describe('Enable Banking Data Provider E2E', () => {
 
       const BOOKING_DATE = utcDaysAgo(20);
 
-      // getExchangeRate pivots through USD and truncates the rate to 5 decimals.
-      const EUR_TO_AED = Math.trunc((AED_PER_USD / EUR_PER_USD) * 100_000) / 100_000;
       const CLOSING_BALANCE_EUR = -50;
 
       // One bank day, settled as four rows the ASPSP displays on four earlier
@@ -2725,5 +2728,92 @@ describe('Enable Banking Data Provider E2E', () => {
         ),
       ).toBe(false);
     });
+  });
+
+  describe('Credit limit lifecycle', () => {
+    it('imports the bank limit, lets the owner edit it, and keeps stats in step', async () => {
+      const connectResult = await helpers.bankDataProviders.connectProvider({
+        providerType: BANK_PROVIDER_TYPE.ENABLE_BANKING,
+        credentials: helpers.enablebanking.mockCredentials(),
+        raw: true,
+      });
+      const state = await helpers.enablebanking.getConnectionState(connectResult.connectionId);
+      await helpers.makeRequest({
+        method: 'post',
+        url: '/bank-data-providers/enablebanking/oauth-callback',
+        payload: { connectionId: connectResult.connectionId, code: helpers.enablebanking.mockAuthCode, state },
+      });
+
+      global.mswMockServer.use(
+        http.get('https://api.enablebanking.com/accounts/:accountId/details', ({ params }) => {
+          const details = getMockedAccountDetails(params.accountId as string);
+          return HttpResponse.json(
+            details.identification_hash === MOCK_IDENTIFICATION_HASH_1
+              ? { ...details, credit_limit: { amount: '5000.00', currency: 'GBP' } }
+              : details,
+          );
+        }),
+      );
+
+      // Mock account 1 (EUR) reports a GBP limit whose currency does not match
+      // the account, account 2 reports 1500 EUR, account 3 an unparsable amount.
+      const { syncedAccounts } = await helpers.bankDataProviders.connectSelectedAccounts({
+        connectionId: connectResult.connectionId,
+        accountExternalIds: [MOCK_IDENTIFICATION_HASH_1, MOCK_IDENTIFICATION_HASH_2, MOCK_IDENTIFICATION_HASH_3],
+        raw: true,
+      });
+      const mismatchId = syncedAccounts.find((a) => a.externalId === MOCK_IDENTIFICATION_HASH_1)!.id;
+      const creditId = syncedAccounts.find((a) => a.externalId === MOCK_IDENTIFICATION_HASH_2)!.id;
+      const unparsableId = syncedAccounts.find((a) => a.externalId === MOCK_IDENTIFICATION_HASH_3)!.id;
+
+      const mismatch = await helpers.getAccount({ id: mismatchId, raw: true });
+      const credit = await helpers.getAccount({ id: creditId, raw: true });
+      const unparsable = await helpers.getAccount({ id: unparsableId, raw: true });
+      expect(mismatch.creditLimit).toBe(0);
+      expect(mismatch.refCreditLimit).toBe(0);
+      expect(credit.creditLimit).toBe(1500);
+      expect(credit.refCreditLimit).toEqualRefValue(1500 * EUR_TO_AED);
+      expect(unparsable.creditLimit).toBe(0);
+      expect(unparsable.refCreditLimit).toBe(0);
+
+      const today = format(new Date(), 'yyyy-MM-dd');
+      const setIncludeLimit = ({ on }: { on: boolean }) =>
+        helpers.patchUserSettings({ patch: { includeCreditLimitInStats: on }, raw: true });
+      const rawTotal = await helpers.getTotalBalance({ date: today, raw: true });
+
+      await setIncludeLimit({ on: true });
+      expect(await helpers.getTotalBalance({ date: today, raw: true })).toEqualRefValue(rawTotal - 1500 * EUR_TO_AED);
+
+      // Owner raises the imported limit; balances stay untouched.
+      const raised = await helpers.updateAccount({ id: creditId, payload: { creditLimit: 2000 }, raw: true });
+      expect(raised.creditLimit).toBe(2000);
+      expect(raised.refCreditLimit).toEqualRefValue(2000 * EUR_TO_AED);
+      expect(raised.currentBalance).toBe(credit.currentBalance);
+      expect(raised.initialBalance).toBe(credit.initialBalance);
+      expect(raised.refCurrentBalance).toBe(credit.refCurrentBalance);
+
+      // Owner adds a limit the bank never reported.
+      const mismatchWithLimit = await helpers.updateAccount({
+        id: mismatchId,
+        payload: { creditLimit: 500 },
+        raw: true,
+      });
+      expect(mismatchWithLimit.creditLimit).toBe(500);
+      expect(await helpers.getTotalBalance({ date: today, raw: true })).toEqualRefValue(rawTotal - 2500 * EUR_TO_AED);
+
+      // Back to zero drops the account out of the adjustment entirely.
+      const zeroed = await helpers.updateAccount({ id: creditId, payload: { creditLimit: 0 }, raw: true });
+      expect(zeroed.creditLimit).toBe(0);
+      expect(zeroed.refCreditLimit).toBe(0);
+      expect(zeroed.currentBalance).toBe(credit.currentBalance);
+      expect(await helpers.getTotalBalance({ date: today, raw: true })).toEqualRefValue(rawTotal - 500 * EUR_TO_AED);
+
+      // Balance itself stays bank-owned.
+      const res = await helpers.updateAccount({ id: creditId, payload: { currentBalance: 1 } });
+      expect(res.statusCode).toBe(ERROR_CODES.ValidationError);
+
+      await setIncludeLimit({ on: false });
+      expect(await helpers.getTotalBalance({ date: today, raw: true })).toBe(rawTotal);
+    }, 60_000);
   });
 });

--- a/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
+++ b/packages/backend/src/services/bank-data-providers/enablebanking/enablebanking.provider.ts
@@ -581,6 +581,28 @@ export class EnableBankingProvider extends BaseBankDataProvider {
           // Convert balance from string to system amount (cents as integer)
           const balanceFloat = primaryBalance?.balance_amount ? parseFloat(primaryBalance.balance_amount.amount) : 0;
           const balanceSystemAmount = Money.fromDecimal(balanceFloat).toCents();
+          const creditLimitCurrencyMatches = Boolean(
+            details.currency &&
+            details.credit_limit?.currency &&
+            details.credit_limit.currency.toUpperCase() === details.currency.toUpperCase(),
+          );
+          const creditLimitFloat = parseFloat(details.credit_limit?.amount ?? '');
+          const creditLimitCents =
+            creditLimitCurrencyMatches && Number.isFinite(creditLimitFloat) && creditLimitFloat > 0
+              ? Money.fromDecimal(creditLimitFloat).toCents()
+              : 0;
+          if (details.credit_limit && (!creditLimitCurrencyMatches || !Number.isFinite(creditLimitFloat))) {
+            logger.info(
+              creditLimitCurrencyMatches
+                ? 'Enable Banking credit limit ignored: unparsable amount'
+                : 'Enable Banking credit limit ignored: currency mismatch',
+              {
+                connectionId,
+                identificationHash: details.identification_hash,
+                creditLimit: details.credit_limit,
+              },
+            );
+          }
 
           return {
             externalId: details.identification_hash,
@@ -595,6 +617,7 @@ export class EnableBankingProvider extends BaseBankDataProvider {
             // requires an explicit user choice instead of failing downstream.
             currency: details.currency?.toUpperCase() || NO_CURRENCY_CODE,
             metadata: {
+              creditLimit: creditLimitCents,
               iban: details.account_id?.iban,
               product: details.product,
               ownerName: details.owner_name,

--- a/packages/backend/src/tests/mocks/enablebanking/data.ts
+++ b/packages/backend/src/tests/mocks/enablebanking/data.ts
@@ -137,6 +137,7 @@ export const getMockedAccountDetails = (accountId: string) => {
       product: 'Savings Account',
       owner_name: 'John Doe',
       details: 'Personal savings',
+      credit_limit: { amount: '1500.00', currency: 'EUR' },
       account_servicer: {
         name: MOCK_BANK_NAME,
         bic_fi: MOCK_BANK_BIC,
@@ -152,6 +153,7 @@ export const getMockedAccountDetails = (accountId: string) => {
       product: 'Business Account',
       owner_name: 'John Doe',
       details: 'Business expenses',
+      credit_limit: { amount: 'N/A', currency: 'USD' },
       account_servicer: {
         name: MOCK_BANK_NAME,
         bic_fi: MOCK_BANK_BIC,

--- a/packages/frontend/src/i18n/locales/chunks/en/pages/account.json
+++ b/packages/frontend/src/i18n/locales/chunks/en/pages/account.json
@@ -152,6 +152,7 @@
       },
       "details": {
         "creditLimit": "Credit Limit:",
+        "creditLimitHint": "Set this only if the bank balance already includes the credit line.",
         "editCreditLimit": "Edit credit limit",
         "creditLimitUpdateSuccess": "Credit limit updated",
         "creditLimitUpdateError": "Failed to update credit limit",

--- a/packages/frontend/src/pages/account/components/account-details-tab.vue
+++ b/packages/frontend/src/pages/account/components/account-details-tab.vue
@@ -7,7 +7,7 @@ import { useAccountAccess } from '@/composable/use-account-access';
 import { useAccountCurrencyCode } from '@/composable/use-account-currency-code';
 import { toLocalCurrencyNumber } from '@/js/helpers';
 import { useCurrenciesStore } from '@/stores';
-import { ACCOUNT_TYPES, AccountModel, isDedicatedFlowAccountCategory } from '@bt/shared/types';
+import { AccountModel, isDedicatedFlowAccountCategory } from '@bt/shared/types';
 import { ChevronDownIcon, ChevronUpIcon } from '@lucide/vue';
 import { storeToRefs } from 'pinia';
 import { computed, defineAsyncComponent, ref, toRef } from 'vue';
@@ -26,7 +26,6 @@ const props = defineProps<{
 const { currenciesMap } = storeToRefs(useCurrenciesStore());
 const isOpen = ref(false);
 
-const isSystemAccount = computed(() => props.account.type === ACCOUNT_TYPES.system);
 const currencyCode = useAccountCurrencyCode({ account: toRef(() => props.account) });
 const { isOwner } = useAccountAccess(toRef(() => props.account));
 // Loan and vehicle categories are locked to their dedicated flows on the backend.
@@ -44,7 +43,7 @@ const isCategoryEditable = computed(
         <div class="flex items-center gap-1.5">
           <span>{{ toLocalCurrencyNumber(account.creditLimit, { currency: currencyCode }) }} {{ currencyCode }}</span>
 
-          <CreditLimitEditPopover v-if="isSystemAccount" :account="account" :currency-code="currencyCode" />
+          <CreditLimitEditPopover v-if="isOwner" :account="account" :currency-code="currencyCode" />
         </div>
       </div>
       <Separator />

--- a/packages/frontend/src/pages/account/components/credit-limit-edit-popover.vue
+++ b/packages/frontend/src/pages/account/components/credit-limit-edit-popover.vue
@@ -93,6 +93,7 @@ watch([isOpen, () => props.account.id], () => {
               <span class="text-muted-foreground text-sm">{{ currencyCode }}</span>
             </template>
           </InputField>
+          <p class="text-muted-foreground text-xs">{{ $t('pages.account.details.creditLimitHint') }}</p>
           <Button
             type="submit"
             :disabled="form.creditLimit === null || form.creditLimit === account.creditLimit || isSaving"


### PR DESCRIPTION
Enable Banking accounts always landed with a 0 limit and the field was locked to manual accounts; the bank-reported credit_limit is now imported on connect and the owner can adjust it afterwards